### PR TITLE
feat: Create agent-agnostic CLI runner (closes #2)

### DIFF
--- a/src/engine/runner.ts
+++ b/src/engine/runner.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createWriteStream, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { dirname } from "node:path";
 
 // --- Types ---
 
@@ -31,8 +31,8 @@ export interface AgentRunner {
 // --- Helpers ---
 
 function ensureDir(filePath: string): void {
-  const dir = filePath.substring(0, filePath.lastIndexOf("/"));
-  if (dir) {
+  const dir = dirname(filePath);
+  if (dir && dir !== ".") {
     mkdirSync(dir, { recursive: true });
   }
 }

--- a/tests/engine/runner.test.ts
+++ b/tests/engine/runner.test.ts
@@ -109,7 +109,8 @@ describe("Runner process handling", () => {
 
     const result = await runner.run({ prompt: "", cwd: "/tmp" });
     expect(result.success).toBe(true);
-    expect(result.output.trim()).toBe("/private/tmp");
+    // /tmp may resolve to /private/tmp on macOS
+    expect(["/tmp", "/private/tmp"]).toContain(result.output.trim());
   });
 
   it("streams output to a log file", async () => {


### PR DESCRIPTION
## Summary

Automated implementation of #2: **Create agent-agnostic CLI runner**

## Code Review Report

<details>
<summary>Click to expand review</summary>

## Review Summary

**Overall: Good implementation.** All acceptance criteria and test requirements are met. The code is clean, functional-style (no classes), and well-structured.

### Fixed (2 issues)

1. **`ensureDir` used manual string splitting** (`runner.ts:34`) — Replaced `filePath.substring(0, filePath.lastIndexOf("/"))` with `dirname(filePath)` from the already-imported `node:path` module. The old approach would break on Windows paths.

2. **cwd test hardcoded `/private/tmp`** (`runner.test.ts:112`) — macOS resolves `/tmp` to `/private/tmp` via symlink, but Linux does not. Changed assertion to accept both paths.

### Noted (not fixed)

- **stderr as fallback only**: `output: stdout || stderr` means stderr is lost if stdout has content. Acceptable design choice since stderr also goes to the log file.
- **Integration test is loose**: The `claude --help` test only checks types, not output content. Fine for CI environments without `claude` installed.

</details>

## Test Results

```
[0;36m[STEP][0m  23:11:52 [1mRunning tests in worktree[0m
[0;34m[INFO][0m  23:11:52 Running unit tests...

> alpha-loop@0.1.0 test:unit /Users/bradtaylor/Github/issue-2
> jest --runInBand

PASS tests/engine/runner.test.ts (10.146 s)
PASS tests/server/status.test.ts

Test Suites: 2 passed, 2 total
Tests:       15 passed, 15 total
Snapshots:   0 total
Time:        10.395 s
Ran all test suites.
[0;32m[OK][0m    23:12:03 Unit tests passed
[0;34m[INFO][0m  23:12:03 Running API tests...

> alpha-loop@0.1.0 test:api /Users/bradtaylor/Github/issue-2
> jest --runInBand

PASS tests/engine/runner.test.ts (8.503 s)
PASS tests/server/status.test.ts

Test Suites: 2 passed, 2 total
Tests:       15 passed, 15 total
Snapshots:   0 total
Time:        8.746 s, estimated 11 s
Ran all test suites.
[0;32m[OK][0m    23:12:13 API tests passed
[0;32m[OK][0m    23:12:13 All tests passed
```

---
Automated by [agent-loop](scripts/loop.sh)