### PR TITLE
feat: Add SSE live streaming of loop output (closes #6)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import { statusRouter } from "./routes/status.js";
+import { streamRouter } from "./routes/stream.js";
 
 const app: ReturnType<typeof express> = express();
 const PORT = process.env.PORT ?? 3000;
@@ -8,6 +9,7 @@ const PORT = process.env.PORT ?? 3000;
 app.use(cors());
 app.use(express.json());
 app.use("/api", statusRouter);
+app.use("/api", streamRouter);
 
 const server = app.listen(PORT, () => {
   console.log(`Alpha Loop server listening on port ${PORT}`);

--- a/src/server/routes/stream.ts
+++ b/src/server/routes/stream.ts
@@ -1,0 +1,35 @@
+import { Router, type Request, type Response, type Router as RouterType } from "express";
+import { loopEmitter, type LoopEvent } from "../sse.js";
+
+const router: RouterType = Router();
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+router.get("/stream", (req: Request, res: Response) => {
+  res.set({
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+  res.flushHeaders();
+
+  const onEvent = (event: LoopEvent) => {
+    res.write(`data: ${JSON.stringify(event)}\n\n`);
+  };
+
+  loopEmitter.on("loopEvent", onEvent);
+
+  const heartbeat = setInterval(() => {
+    res.write(": ping\n\n");
+  }, HEARTBEAT_INTERVAL_MS);
+
+  const cleanup = () => {
+    clearInterval(heartbeat);
+    loopEmitter.off("loopEvent", onEvent);
+  };
+
+  req.on("close", cleanup);
+  res.on("close", cleanup);
+});
+
+export { router as streamRouter };

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -1,0 +1,32 @@
+import { EventEmitter } from "node:events";
+
+export interface StageEvent {
+  type: "stage";
+  data: { issue: number; stage: string; timestamp: string };
+}
+
+export interface OutputEvent {
+  type: "output";
+  data: { line: string; timestamp: string };
+}
+
+export interface TestEvent {
+  type: "test";
+  data: { passed: number; failed: number; timestamp: string };
+}
+
+export interface ErrorEvent {
+  type: "error";
+  data: { message: string; stage: string; timestamp: string };
+}
+
+export interface CompleteEvent {
+  type: "complete";
+  data: { issue: number; prUrl: string; duration: number };
+}
+
+export type LoopEvent = StageEvent | OutputEvent | TestEvent | ErrorEvent | CompleteEvent;
+
+const loopEventEmitter = new EventEmitter();
+
+export const loopEmitter = loopEventEmitter;

--- a/tests/server/stream.test.ts
+++ b/tests/server/stream.test.ts
@@ -1,0 +1,196 @@
+import express from "express";
+import http from "node:http";
+import { EventEmitter } from "node:events";
+import { streamRouter } from "../../src/server/routes/stream";
+import { loopEmitter } from "../../src/server/sse";
+import type { LoopEvent } from "../../src/server/sse";
+
+function createApp(): express.Express {
+  const app = express();
+  app.use("/api", streamRouter);
+  return app;
+}
+
+function getPort(server: http.Server): number {
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("No address");
+  return addr.port;
+}
+
+function startServer(app: express.Express): Promise<http.Server> {
+  return new Promise((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+interface SSEClient {
+  res: http.IncomingMessage;
+  req: http.ClientRequest;
+  messages: string[];
+  destroy: () => void;
+}
+
+function connectSSE(port: number): Promise<SSEClient> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(`http://127.0.0.1:${port}/api/stream`, (res) => {
+      const messages: string[] = [];
+      res.on("data", (chunk: Buffer) => {
+        for (const line of chunk.toString().split("\n")) {
+          if (line.startsWith("data: ")) {
+            messages.push(line.slice(6));
+          } else if (line.startsWith(": ping")) {
+            messages.push("ping");
+          }
+        }
+      });
+      resolve({
+        res,
+        req,
+        messages,
+        destroy: () => { res.destroy(); req.destroy(); },
+      });
+    });
+    req.on("error", reject);
+  });
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("GET /api/stream", () => {
+  let server: http.Server | null = null;
+  const clients: SSEClient[] = [];
+
+  afterEach(async () => {
+    loopEmitter.removeAllListeners();
+    for (const c of clients) c.destroy();
+    clients.length = 0;
+    if (server?.listening) await closeServer(server);
+    server = null;
+  });
+
+  async function connect(): Promise<SSEClient> {
+    const client = await connectSSE(getPort(server!));
+    clients.push(client);
+    return client;
+  }
+
+  it("returns SSE headers", async () => {
+    server = await startServer(createApp());
+    const client = await connect();
+
+    expect(client.res.headers["content-type"]).toContain("text/event-stream");
+    expect(client.res.headers["cache-control"]).toBe("no-cache");
+  });
+
+  it("streams JSON-encoded events with type field", async () => {
+    server = await startServer(createApp());
+    const client = await connect();
+
+    const event: LoopEvent = {
+      type: "stage",
+      data: { issue: 28, stage: "implement", timestamp: "2026-03-29T00:00:00Z" },
+    };
+    loopEmitter.emit("loopEvent", event);
+    await wait(50);
+
+    expect(client.messages.length).toBeGreaterThanOrEqual(1);
+    const parsed = JSON.parse(client.messages[0]);
+    expect(parsed.type).toBe("stage");
+    expect(parsed.data.issue).toBe(28);
+    expect(parsed.data.stage).toBe("implement");
+  });
+
+  it("supports multiple simultaneous clients", async () => {
+    server = await startServer(createApp());
+    const client1 = await connect();
+    const client2 = await connect();
+
+    const event: LoopEvent = {
+      type: "output",
+      data: { line: "Creating health.ts...", timestamp: "2026-03-29T00:00:00Z" },
+    };
+    loopEmitter.emit("loopEvent", event);
+    await wait(50);
+
+    expect(client1.messages.length).toBeGreaterThanOrEqual(1);
+    expect(client2.messages.length).toBeGreaterThanOrEqual(1);
+    expect(JSON.parse(client1.messages[0]).type).toBe("output");
+    expect(JSON.parse(client2.messages[0]).type).toBe("output");
+  });
+
+  it("configures heartbeat at 30s interval", () => {
+    jest.useFakeTimers();
+    try {
+      const mockReq = new EventEmitter();
+      const writtenChunks: string[] = [];
+      const mockRes = {
+        set: jest.fn(),
+        flushHeaders: jest.fn(),
+        write: jest.fn((chunk: string) => writtenChunks.push(chunk)),
+        on: jest.fn(),
+      };
+
+      // Extract the route handler directly from the router
+      const streamLayer = (streamRouter as any).stack.find(
+        (layer: any) => layer.route?.path === "/stream"
+      );
+      expect(streamLayer).toBeDefined();
+      const handler = streamLayer.route.stack[0].handle;
+
+      handler(mockReq, mockRes);
+
+      jest.advanceTimersByTime(30_000);
+      expect(writtenChunks).toContain(": ping\n\n");
+
+      jest.advanceTimersByTime(30_000);
+      const pingCount = writtenChunks.filter((c) => c === ": ping\n\n").length;
+      expect(pingCount).toBe(2);
+
+      // Cleanup
+      mockReq.emit("close");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("cleans up listener on client disconnect", async () => {
+    server = await startServer(createApp());
+
+    const initialCount = loopEmitter.listenerCount("loopEvent");
+    const client = await connect();
+    expect(loopEmitter.listenerCount("loopEvent")).toBe(initialCount + 1);
+
+    client.destroy();
+    await wait(100);
+
+    expect(loopEmitter.listenerCount("loopEvent")).toBe(initialCount);
+  });
+
+  it("streams all event types correctly", async () => {
+    server = await startServer(createApp());
+    const client = await connect();
+
+    const events: LoopEvent[] = [
+      { type: "stage", data: { issue: 1, stage: "test", timestamp: "t" } },
+      { type: "output", data: { line: "hello", timestamp: "t" } },
+      { type: "test", data: { passed: 45, failed: 2, timestamp: "t" } },
+      { type: "error", data: { message: "fail", stage: "test", timestamp: "t" } },
+      { type: "complete", data: { issue: 1, prUrl: "https://github.com/pr/1", duration: 120 } },
+    ];
+
+    for (const event of events) {
+      loopEmitter.emit("loopEvent", event);
+    }
+    await wait(50);
+
+    expect(client.messages.length).toBe(5);
+    const types = client.messages.map((m) => JSON.parse(m).type);
+    expect(types).toEqual(["stage", "output", "test", "error", "complete"]);
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation of #6: **Add SSE live streaming of loop output**

## Code Review Report

<details>
<summary>Click to expand review</summary>

Build passes cleanly. Here's my review:

## Review Summary: SSE Live Streaming (#6)

### Acceptance Criteria - All Met
- `GET /api/stream` returns SSE event stream
- Events include all 5 types: stage, output, test, error, complete
- Multiple simultaneous clients supported
- JSON-encoded with type field
- 30s heartbeat pings
- EventEmitter singleton pattern

### Code Quality: Good
- Clean functional style, no classes
- Proper TypeScript types with discriminated union (`LoopEvent`)
- ESM imports with `.js` extensions
- Proper SSE headers (`text/event-stream`, `no-cache`, `keep-alive`)
- Cleanup on client disconnect removes both the interval and the listener

### Tests: Solid
- 6 tests covering headers, event format, multiple clients, heartbeat (fake timers), cleanup, and all event types
- Proper `afterEach` cleanup of servers and clients
- Heartbeat test correctly uses `jest.useFakeTimers()` per requirements
- Tests exit cleanly with `forceExit`

### No Issues Found
- **No security issues** - the endpoint is read-only SSE, consistent with the existing unauthenticated status routes
- **No missing tests** - all acceptance criteria have corresponding test coverage
- **Cleanup is correct** - both `req.on("close")` and `res.on("close")` trigger cleanup; double-call is harmless since `clearInterval` and `off` are idempotent
- **No protected files modified** - only touched the 4 files specified in the issue

### Minor Observations (not worth fixing)
- The default `EventEmitter` maxListeners is 10. With >10 simultaneous SSE clients, Node will emit a warning. This is fine for a monitoring dashboard but worth noting if usage scales.
- The `"Force exiting Jest"` message is expected given the SSE connection lifecycle and is handled by `forceExit: true` in jest config.

**Verdict: Clean implementation, no fixes needed.** The code is correct, well-tested, and matches all requirements.

</details>

## Test Results

```
[0;36m[STEP][0m  00:31:21 [1mRunning tests in worktree[0m
[0;34m[INFO][0m  00:31:21 Running unit tests...

> alpha-loop@0.1.0 test:unit /Users/bradtaylor/Github/issue-6
> jest --runInBand

PASS tests/engine/runner.test.ts (12.647 s)
Switched to a new branch 'main'
PASS tests/engine/worktree.test.ts
PASS tests/server/stream.test.ts
PASS tests/engine/loop.test.ts
  ● Console

    console.log
      [2026-03-29T07:31:36.398Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.406Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.406Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.406Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.406Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.407Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.409Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.409Z] [test] #42: Test attempt 1/3

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.409Z] [review] #42: Running code review

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.409Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.409Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.410Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.410Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.410Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.410Z] [failed] #42: Implementation failed (exit 1)

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.410Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.411Z] [failed] #42: Worktree creation failed: Error: worktree error

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.411Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.411Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.411Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.411Z] [failed] #42: Failed to push branch: Error: push rejected

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.411Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.411Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.411Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.412Z] [failed] #42: PR creation failed: Error: PR error

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.412Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.412Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.412Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.412Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.412Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.412Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.412Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.412Z] [test] #42: Test attempt 1/3

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.413Z] [fix] #42: Fixing test failures (attempt 1)

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.413Z] [test] #42: Test attempt 2/3

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.413Z] [fix] #42: Fixing test failures (attempt 2)

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.413Z] [test] #42: Test attempt 3/3

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.413Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.413Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.413Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.413Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.413Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [test] #42: Test attempt 1/2

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [fix] #42: Fixing test failures (attempt 1)

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [test] #42: Test attempt 2/2

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [test] #42: Tests still failing after all retries

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [setup] #42: Processing: Add widget feature

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.414Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.415Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.415Z] [done] #42: Completed in 1ms

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.415Z] [setup] #0: Cycle complete. Sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.448Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.459Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.470Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.481Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.493Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.504Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      
      Shutting down gracefully...

      at process.shutdown (src/engine/loop.ts:306:13)

    console.log
      [2026-03-29T07:31:36.516Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.528Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.539Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.551Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.563Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      
      Shutting down gracefully...

      at process.shutdown (src/engine/loop.ts:306:13)

    console.log
      [2026-03-29T07:31:36.575Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.575Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.575Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.575Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:36.575Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

PASS tests/engine/github.test.ts
PASS tests/server/status.test.ts

Test Suites: 6 passed, 6 total
Tests:       62 passed, 62 total
Snapshots:   0 total
Time:        14.148 s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
[0;32m[OK][0m    00:31:36 Unit tests passed
[0;34m[INFO][0m  00:31:36 Running API tests...

> alpha-loop@0.1.0 test:api /Users/bradtaylor/Github/issue-6
> jest --runInBand

PASS tests/engine/runner.test.ts (13.286 s)
Switched to a new branch 'main'
PASS tests/engine/worktree.test.ts
PASS tests/server/stream.test.ts
PASS tests/engine/loop.test.ts
  ● Console

    console.log
      [2026-03-29T07:31:51.725Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.734Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.734Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.734Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.734Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.735Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.736Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.736Z] [test] #42: Test attempt 1/3

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.736Z] [review] #42: Running code review

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.736Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.736Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.736Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.737Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.737Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.737Z] [failed] #42: Implementation failed (exit 1)

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.737Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.737Z] [failed] #42: Worktree creation failed: Error: worktree error

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.738Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.738Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.738Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.738Z] [failed] #42: Failed to push branch: Error: push rejected

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.738Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.738Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.738Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.738Z] [failed] #42: PR creation failed: Error: PR error

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.739Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.739Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.739Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.739Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.739Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.739Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.739Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.739Z] [test] #42: Test attempt 1/3

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.739Z] [fix] #42: Fixing test failures (attempt 1)

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.739Z] [test] #42: Test attempt 2/3

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.740Z] [fix] #42: Fixing test failures (attempt 2)

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.740Z] [test] #42: Test attempt 3/3

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.740Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.740Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.740Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.740Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.740Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.741Z] [test] #42: Test attempt 1/2

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.741Z] [fix] #42: Fixing test failures (attempt 1)

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.741Z] [test] #42: Test attempt 2/2

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.741Z] [test] #42: Tests still failing after all retries

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.741Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.741Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.741Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.741Z] [setup] #42: Processing: Add widget feature

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.741Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.742Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.742Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.742Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.742Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.742Z] [done] #42: Completed in 1ms

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.742Z] [setup] #0: Cycle complete. Sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.773Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.784Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.797Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.809Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.821Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.833Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      
      Shutting down gracefully...

      at process.shutdown (src/engine/loop.ts:306:13)

    console.log
      [2026-03-29T07:31:51.844Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.855Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.867Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.879Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.891Z] [setup] #0: No issues labeled 'ready', sleeping 0.01s

      at log (src/engine/loop.ts:79:11)

    console.log
      
      Shutting down gracefully...

      at process.shutdown (src/engine/loop.ts:306:13)

    console.log
      [2026-03-29T07:31:51.905Z] [setup] #42: Creating worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.905Z] [implement] #42: Running agent for implementation

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.905Z] [pr] #42: Pushing branch and creating PR

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.905Z] [cleanup] #42: Removing worktree

      at log (src/engine/loop.ts:79:11)

    console.log
      [2026-03-29T07:31:51.905Z] [done] #42: Pipeline complete

      at log (src/engine/loop.ts:79:11)

PASS tests/engine/github.test.ts
PASS tests/server/status.test.ts

Test Suites: 6 passed, 6 total
Tests:       62 passed, 62 total
Snapshots:   0 total
Time:        14.711 s
Ran all test suites.
Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?
[0;32m[OK][0m    00:31:52 API tests passed
[0;32m[OK][0m    00:31:52 All tests passed
```

---
Automated by [agent-loop](scripts/loop.sh)