### PR TITLE
feat: epic: self-improving eval system (Meta-Harness + autoresearch patterns) (closes #90)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,4 +86,83 @@ program
     await reviewCommand(options);
   });
 
+// Eval subcommands
+const evalCmd = program
+  .command('eval')
+  .description('Run eval suite, capture failures, list cases, view scores');
+
+evalCmd
+  .command('run', { isDefault: true })
+  .description('Run the eval suite and compute composite score')
+  .option('--tags <tags>', 'Filter by tags (comma-separated)')
+  .option('--type <type>', 'Filter by type: full or step')
+  .option('--step <step>', 'Filter by pipeline step (plan, implement, test, review, verify)')
+  .option('--verbose', 'Show detailed output')
+  .action(async (options) => {
+    const { evalRunCommand } = await import('./commands/eval.js');
+    await evalRunCommand(options);
+  });
+
+evalCmd
+  .command('capture [issue]')
+  .description('Capture failures as eval cases (interactive)')
+  .action(async (issue) => {
+    const { evalCaptureCommand } = await import('./commands/eval.js');
+    await evalCaptureCommand({ issue });
+  });
+
+evalCmd
+  .command('list')
+  .description('Show eval cases and recent scores')
+  .action(async () => {
+    const { evalListCommand } = await import('./commands/eval.js');
+    evalListCommand();
+  });
+
+evalCmd
+  .command('scores')
+  .description('Show score history over time')
+  .action(async () => {
+    const { evalScoresCommand } = await import('./commands/eval.js');
+    evalScoresCommand();
+  });
+
+evalCmd
+  .command('search')
+  .description('Greedy search over model/agent configurations')
+  .option('--models <models>', 'Models to test (comma-separated)')
+  .option('--agents <agents>', 'Agents to test (comma-separated)')
+  .option('--max-runs <n>', 'Maximum number of eval runs')
+  .action(async (options) => {
+    const { evalSearchCommand } = await import('./commands/eval.js');
+    await evalSearchCommand(options);
+  });
+
+evalCmd
+  .command('pareto')
+  .description('Show score/cost Pareto frontier')
+  .action(async () => {
+    const { evalParetoCommand } = await import('./commands/eval.js');
+    evalParetoCommand();
+  });
+
+evalCmd
+  .command('import-swebench')
+  .description('Import eval cases from SWE-bench dataset')
+  .action(async () => {
+    const { evalImportSwebenchCommand } = await import('./commands/eval.js');
+    await evalImportSwebenchCommand();
+  });
+
+program
+  .command('evolve')
+  .description('Meta-Harness-style automated optimization loop')
+  .option('--max-iterations <n>', 'Maximum optimization iterations (default: 5)')
+  .option('--dry-run', 'Preview without making changes')
+  .option('--verbose', 'Show detailed agent output')
+  .action(async (options) => {
+    const { evolveCommand } = await import('./commands/evolve.js');
+    await evolveCommand(options);
+  });
+
 program.parse();

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -1,0 +1,519 @@
+/**
+ * Eval Command — run eval suite, capture failures, list cases, view scores.
+ *
+ * Subcommands:
+ *   alpha-loop eval              — Run the eval suite, compute composite score
+ *   alpha-loop eval capture      — Interactive: walk through recent failures
+ *   alpha-loop eval capture <N>  — Capture a specific issue as an eval case
+ *   alpha-loop eval list         — Show eval cases and recent scores
+ *   alpha-loop eval scores       — Score history over time
+ *   alpha-loop eval search       — Greedy config search (model/agent variants)
+ *   alpha-loop eval pareto       — Show score/cost Pareto frontier
+ *   alpha-loop eval import-swebench — Import from SWE-bench
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as readline from 'node:readline';
+import { log } from '../lib/logger.js';
+import { loadConfig } from '../lib/config.js';
+import type { Config } from '../lib/config.js';
+import {
+  loadEvalCases,
+  saveEvalCase,
+  formatEvalCase,
+  evalsDir,
+} from '../lib/eval.js';
+import type { EvalCase, ExpectedOutcome } from '../lib/eval.js';
+import {
+  readScores,
+  latestScore,
+  scoresByConfig,
+  paretoFrontier,
+  formatScoreEntry,
+} from '../lib/score.js';
+import {
+  listTraceSessions,
+  listTraceIssues,
+  readTraceMetadata,
+  readTrace,
+} from '../lib/traces.js';
+
+export type EvalOptions = {
+  tags?: string;
+  type?: 'full' | 'step';
+  step?: string;
+  verbose?: boolean;
+};
+
+export type EvalCaptureOptions = {
+  issue?: string;
+};
+
+export type EvalSearchOptions = {
+  models?: string;
+  agents?: string;
+  maxRuns?: string;
+};
+
+/** Helper to ask a question via readline. */
+function ask(rl: readline.Interface, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => resolve(answer.trim()));
+  });
+}
+
+/**
+ * Run the eval suite.
+ */
+export async function evalRunCommand(options: EvalOptions): Promise<void> {
+  const config = loadConfig();
+  const cases = loadEvalCases({
+    tags: options.tags?.split(','),
+    type: options.type,
+    step: options.step as any,
+  });
+
+  if (cases.length === 0) {
+    log.warn('No eval cases found. Use `alpha-loop eval capture` to create some.');
+    log.info(`Eval cases directory: ${evalsDir()}`);
+    return;
+  }
+
+  log.step(`Running ${cases.length} eval case(s)...`);
+  console.log('');
+
+  for (const evalCase of cases) {
+    console.log(`  ${formatEvalCase(evalCase)}`);
+  }
+
+  console.log('');
+  log.info('Eval execution requires fixture repos and agent invocation.');
+  log.info('Use `alpha-loop eval search` for automated config comparison.');
+  log.info('');
+
+  // Show current scores
+  const latest = latestScore(evalsDir());
+  if (latest) {
+    log.info(`Latest score: ${formatScoreEntry(latest)}`);
+  } else {
+    log.info('No scores recorded yet. Run evals to generate scores.');
+  }
+}
+
+/**
+ * Capture a failure as an eval case — interactive walkthrough.
+ */
+export async function evalCaptureCommand(options: EvalCaptureOptions): Promise<void> {
+  const config = loadConfig();
+
+  if (options.issue) {
+    // Capture a specific issue
+    await captureSpecificIssue(parseInt(options.issue, 10), config);
+    return;
+  }
+
+  // Walk through recent failures from sessions
+  const sessionsDir = join(process.cwd(), '.alpha-loop', 'sessions');
+  if (!existsSync(sessionsDir)) {
+    log.warn('No sessions found. Run `alpha-loop run` first to generate session data.');
+    return;
+  }
+
+  // Find session directories with results
+  const sessionDirs = readdirSync(sessionsDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort()
+    .reverse();
+
+  if (sessionDirs.length === 0) {
+    log.warn('No session data found.');
+    return;
+  }
+
+  // Collect failures from recent sessions
+  const failures: Array<{ session: string; issueNum: number; title: string; file: string }> = [];
+
+  for (const sessionDir of sessionDirs.slice(0, 5)) {
+    const sessionPath = join(sessionsDir, sessionDir);
+    const resultFiles = readdirSync(sessionPath)
+      .filter((f) => f.startsWith('result-') && f.endsWith('.json'));
+
+    for (const file of resultFiles) {
+      try {
+        const result = JSON.parse(readFileSync(join(sessionPath, file), 'utf-8'));
+        if (result.status === 'failure') {
+          failures.push({
+            session: sessionDir,
+            issueNum: result.issueNum,
+            title: result.title ?? `Issue #${result.issueNum}`,
+            file: join(sessionPath, file),
+          });
+        }
+      } catch {
+        // Skip malformed result files
+      }
+    }
+  }
+
+  if (failures.length === 0) {
+    log.info('No failures found in recent sessions. Nothing to capture.');
+    return;
+  }
+
+  log.step(`Found ${failures.length} failure(s) in recent sessions:`);
+  console.log('');
+
+  for (let i = 0; i < failures.length; i++) {
+    const f = failures[i];
+    console.log(`  ${i + 1}. #${f.issueNum}: ${f.title} (${f.session})`);
+  }
+
+  console.log('');
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+  try {
+    const choice = await ask(rl, 'Capture which failure? (number, or "all", or "q" to quit): ');
+
+    if (choice === 'q' || choice === '') {
+      log.info('Cancelled.');
+      return;
+    }
+
+    if (choice === 'all') {
+      for (const failure of failures) {
+        await captureFailure(rl, failure, config);
+      }
+    } else {
+      const idx = parseInt(choice, 10) - 1;
+      if (idx >= 0 && idx < failures.length) {
+        await captureFailure(rl, failures[idx], config);
+      } else {
+        log.warn('Invalid choice.');
+      }
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+/** Capture a specific issue number as an eval case. */
+async function captureSpecificIssue(issueNum: number, config: Config): Promise<void> {
+  // Look for this issue in traces
+  const sessions = listTraceSessions();
+  let found = false;
+
+  for (const session of sessions.reverse()) {
+    const issues = listTraceIssues(session);
+    if (issues.includes(issueNum)) {
+      const metadata = readTraceMetadata(session, issueNum);
+      if (metadata) {
+        found = true;
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        try {
+          await captureFromTrace(rl, session, issueNum, metadata, config);
+        } finally {
+          rl.close();
+        }
+        break;
+      }
+    }
+  }
+
+  // Fallback: check session result files
+  if (!found) {
+    const sessionsDir = join(process.cwd(), '.alpha-loop', 'sessions');
+    if (existsSync(sessionsDir)) {
+      const sessionDirs = readdirSync(sessionsDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name)
+        .sort()
+        .reverse();
+
+      for (const sessionDir of sessionDirs) {
+        const resultFile = join(sessionsDir, sessionDir, `result-${issueNum}.json`);
+        if (existsSync(resultFile)) {
+          found = true;
+          const result = JSON.parse(readFileSync(resultFile, 'utf-8'));
+          const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+          try {
+            await captureFailure(rl, {
+              session: sessionDir,
+              issueNum,
+              title: result.title ?? `Issue #${issueNum}`,
+              file: resultFile,
+            }, config);
+          } finally {
+            rl.close();
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  if (!found) {
+    log.warn(`No data found for issue #${issueNum}. Run the pipeline first, or create an eval case manually.`);
+  }
+}
+
+/** Capture an eval case from trace data. */
+async function captureFromTrace(
+  rl: readline.Interface,
+  session: string,
+  issueNum: number,
+  metadata: import('../lib/traces.js').TraceMetadata,
+  config: Config,
+): Promise<void> {
+  log.step(`Capturing eval case from trace: session=${session}, issue=#${issueNum}`);
+
+  // Read available trace data
+  const plan = readTrace(session, issueNum, 'plan.json');
+  const diff = readTrace(session, issueNum, 'diff.patch');
+
+  console.log(`\n  Issue: #${issueNum} — ${metadata.title}`);
+  console.log(`  Status: ${metadata.status}`);
+  console.log(`  Duration: ${metadata.duration}s, Retries: ${metadata.retries}`);
+  if (plan) console.log(`  Plan: available`);
+  if (diff) console.log(`  Diff: ${diff.length} chars`);
+  console.log('');
+
+  const description = await ask(rl, 'Description (what this eval tests): ');
+  const shouldSucceed = await ask(rl, 'Should the agent succeed? (y/n): ');
+  const tagsInput = await ask(rl, 'Tags (comma-separated, e.g. typescript,refactor): ');
+
+  const evalCase: EvalCase = {
+    id: `issue-${issueNum}`,
+    description: description || `Eval case captured from issue #${issueNum}`,
+    type: 'full',
+    fixtureRepo: config.repo,
+    fixtureRef: 'main',
+    issueTitle: metadata.title,
+    issueBody: `Captured from issue #${issueNum} (session: ${session})`,
+    expected: {
+      success: shouldSucceed.toLowerCase() === 'y',
+      testsPassing: shouldSucceed.toLowerCase() === 'y',
+    },
+    tags: tagsInput.split(',').map((t) => t.trim()).filter(Boolean),
+    timeout: 0,
+    source: 'auto-capture',
+  };
+
+  const filePath = saveEvalCase(evalCase);
+  log.success(`Eval case saved: ${filePath}`);
+}
+
+/** Capture a failure from session result as an eval case. */
+async function captureFailure(
+  rl: readline.Interface,
+  failure: { session: string; issueNum: number; title: string; file: string },
+  config: Config,
+): Promise<void> {
+  log.step(`\nCapturing: #${failure.issueNum} — ${failure.title}`);
+
+  const result = JSON.parse(readFileSync(failure.file, 'utf-8'));
+
+  console.log(`  Status: ${result.status}`);
+  console.log(`  Tests: ${result.testsPassing ? 'passing' : 'failing'}`);
+  console.log(`  Duration: ${result.duration}s`);
+  console.log(`  Files changed: ${result.filesChanged}`);
+  console.log('');
+
+  const description = await ask(rl, '  Description (what this eval tests): ');
+  const shouldSucceed = await ask(rl, '  Expected: should succeed? (y/n): ');
+  const tagsInput = await ask(rl, '  Tags (comma-separated): ');
+
+  const evalCase: EvalCase = {
+    id: `issue-${failure.issueNum}`,
+    description: description || `Captured from failed issue #${failure.issueNum}`,
+    type: 'full',
+    fixtureRepo: config.repo,
+    fixtureRef: 'main',
+    issueTitle: failure.title,
+    issueBody: `Captured from session ${failure.session}, issue #${failure.issueNum}`,
+    expected: {
+      success: shouldSucceed.toLowerCase() === 'y',
+      testsPassing: shouldSucceed.toLowerCase() === 'y',
+    },
+    tags: tagsInput.split(',').map((t) => t.trim()).filter(Boolean),
+    timeout: 0,
+    source: 'auto-capture',
+  };
+
+  const filePath = saveEvalCase(evalCase);
+  log.success(`Eval case saved: ${filePath}`);
+}
+
+/**
+ * List eval cases and recent scores.
+ */
+export function evalListCommand(): void {
+  const cases = loadEvalCases();
+  const dir = evalsDir();
+
+  if (cases.length === 0) {
+    log.info('No eval cases found.');
+    log.info(`Create eval cases in: ${dir}`);
+    log.info('Or use `alpha-loop eval capture` to capture from failures.');
+    return;
+  }
+
+  log.step(`Eval Cases (${cases.length}):`);
+  console.log('');
+
+  const fullCases = cases.filter((c) => c.type === 'full');
+  const stepCases = cases.filter((c) => c.type === 'step');
+
+  if (fullCases.length > 0) {
+    console.log('  Full Pipeline:');
+    for (const c of fullCases) {
+      console.log(`    ${formatEvalCase(c)}`);
+    }
+  }
+
+  if (stepCases.length > 0) {
+    console.log('  Step-Level:');
+    for (const c of stepCases) {
+      console.log(`    ${formatEvalCase(c)}`);
+    }
+  }
+
+  console.log('');
+
+  // Show latest score
+  const latest = latestScore(dir);
+  if (latest) {
+    console.log(`  Latest score: ${formatScoreEntry(latest)}`);
+  }
+}
+
+/**
+ * Show score history.
+ */
+export function evalScoresCommand(): void {
+  const scores = readScores(evalsDir());
+
+  if (scores.length === 0) {
+    log.info('No scores recorded yet. Run `alpha-loop eval` to generate scores.');
+    return;
+  }
+
+  log.step(`Score History (${scores.length} entries):`);
+  console.log('');
+
+  // Show last 20 entries
+  const recent = scores.slice(-20);
+  for (const entry of recent) {
+    console.log(`  ${formatScoreEntry(entry)}`);
+  }
+
+  console.log('');
+
+  // Show trend
+  if (scores.length >= 2) {
+    const first = scores[0].composite;
+    const last = scores[scores.length - 1].composite;
+    const delta = last - first;
+    const arrow = delta > 0 ? '+' : '';
+    console.log(`  Trend: ${first} -> ${last} (${arrow}${delta.toFixed(2)})`);
+  }
+}
+
+/**
+ * Show score/cost Pareto frontier.
+ */
+export function evalParetoCommand(): void {
+  const frontier = paretoFrontier(evalsDir());
+
+  if (frontier.length === 0) {
+    log.info('No scores recorded yet.');
+    return;
+  }
+
+  log.step(`Pareto Frontier (${frontier.length} entries):`);
+  console.log('');
+  console.log('  Score    Cost      Config');
+  console.log('  -----    ----      ------');
+
+  for (const entry of frontier) {
+    const score = entry.composite.toFixed(2).padStart(6);
+    const cost = `$${entry.totalCost.toFixed(2)}`.padStart(8);
+    console.log(`  ${score}    ${cost}    ${entry.configHash}`);
+  }
+}
+
+/**
+ * Greedy search over model/agent configs.
+ */
+export async function evalSearchCommand(options: EvalSearchOptions): Promise<void> {
+  const config = loadConfig();
+  const cases = loadEvalCases();
+
+  if (cases.length === 0) {
+    log.warn('No eval cases found. Create some first with `alpha-loop eval capture`.');
+    return;
+  }
+
+  const models = options.models?.split(',') ?? [config.model || 'default'];
+  const agents = options.agents?.split(',') ?? [config.agent];
+  const maxRuns = parseInt(options.maxRuns ?? '10', 10);
+
+  log.step('Config Search');
+  console.log(`  Models: ${models.join(', ')}`);
+  console.log(`  Agents: ${agents.join(', ')}`);
+  console.log(`  Eval cases: ${cases.length}`);
+  console.log(`  Max runs: ${maxRuns}`);
+  console.log('');
+
+  // Generate config variants
+  const variants: Array<{ agent: string; model: string }> = [];
+  for (const agent of agents) {
+    for (const model of models) {
+      variants.push({ agent, model });
+    }
+  }
+
+  log.info(`Generated ${variants.length} config variant(s).`);
+  log.info('To execute: run `alpha-loop eval` with each config variant.');
+  log.info('Results will be tracked in scores.jsonl for comparison.');
+  console.log('');
+
+  for (let i = 0; i < Math.min(variants.length, maxRuns); i++) {
+    const v = variants[i];
+    console.log(`  ${i + 1}. agent=${v.agent} model=${v.model}`);
+  }
+
+  // Show current best
+  const configs = scoresByConfig(evalsDir());
+  if (configs.length > 0) {
+    console.log('');
+    log.step('Current Rankings:');
+    for (const c of configs.slice(0, 5)) {
+      const best = Math.max(...c.scores.map((s) => s.composite));
+      console.log(`  ${c.configHash}: best=${best.toFixed(2)} (${c.scores.length} runs)`);
+    }
+  }
+}
+
+/**
+ * Import SWE-bench cases (placeholder — requires HuggingFace download).
+ */
+export async function evalImportSwebenchCommand(): Promise<void> {
+  log.step('SWE-bench Import');
+  log.info('');
+  log.info('SWE-bench integration imports real GitHub issues with validated patches.');
+  log.info('');
+  log.info('Setup:');
+  log.info('  1. Clone the alpha-loop-evals fixture monorepo');
+  log.info('  2. Download SWE-bench dataset from HuggingFace:');
+  log.info('     princeton-nlp/SWE-bench');
+  log.info('  3. Run: alpha-loop eval import-swebench --dataset <path>');
+  log.info('');
+  log.info('Each SWE-bench instance becomes an eval case with:');
+  log.info('  - fixture_repo: the target repo at the specific commit');
+  log.info('  - issue_body: the original GitHub issue description');
+  log.info('  - expected: validated patch as ground truth');
+  log.info('');
+  log.info('This is planned for M2 (Eval Content). See issue #95.');
+}

--- a/src/commands/evolve.ts
+++ b/src/commands/evolve.ts
@@ -1,0 +1,317 @@
+/**
+ * Evolve Command — Meta-Harness-style automated optimization loop.
+ *
+ * Pattern: Give a proposer agent full filesystem access to:
+ *   - .alpha-loop/traces/ (full execution traces, not summaries)
+ *   - .alpha-loop/evals/scores.jsonl (score history)
+ *   - Source code (prompts, skills, config)
+ *
+ * The agent proposes changes to prompts/skills/config, the eval suite runs,
+ * and we keep improvements or revert (autoresearch keep/discard pattern).
+ *
+ * Key insight from Meta-Harness: full trace access (not summaries) is critical.
+ * Key insight from autoresearch: fixed eval metric + autonomous iteration.
+ */
+import { existsSync, readFileSync, readdirSync, writeFileSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { log } from '../lib/logger.js';
+import { loadConfig } from '../lib/config.js';
+import { spawnAgent } from '../lib/agent.js';
+import { loadEvalCases, evalsDir } from '../lib/eval.js';
+import { readScores, latestScore, formatScoreEntry } from '../lib/score.js';
+import { listTraces, tracesDir, readTrace } from '../lib/traces.js';
+import { exec } from '../lib/shell.js';
+
+export type EvolveOptions = {
+  maxIterations?: string;
+  dryRun?: boolean;
+  verbose?: boolean;
+};
+
+/** Files that the proposer is allowed to modify. */
+const ALLOWED_TARGETS = [
+  '.alpha-loop/templates/skills/',
+  '.alpha-loop/templates/agents/',
+  '.alpha-loop.yaml',
+];
+
+/**
+ * Run the evolve loop: propose → eval → keep/discard.
+ */
+export async function evolveCommand(options: EvolveOptions): Promise<void> {
+  const config = loadConfig({ dryRun: options.dryRun });
+  const maxIterations = parseInt(options.maxIterations ?? '5', 10);
+
+  // Validate prerequisites
+  const cases = loadEvalCases();
+  if (cases.length === 0) {
+    log.warn('No eval cases found. Create eval cases first with `alpha-loop eval capture`.');
+    return;
+  }
+
+  const scores = readScores(evalsDir());
+  const baseline = latestScore(evalsDir());
+
+  log.step('Alpha Loop Evolve — Meta-Harness Optimization');
+  console.log('');
+  console.log(`  Eval cases: ${cases.length}`);
+  console.log(`  Score history: ${scores.length} entries`);
+  console.log(`  Baseline score: ${baseline ? baseline.composite.toFixed(2) : 'none'}`);
+  console.log(`  Max iterations: ${maxIterations}`);
+  console.log(`  Agent: ${config.agent}`);
+  console.log(`  Model: ${config.model || 'default'}`);
+  console.log('');
+
+  // Gather context for the proposer
+  const traces = listTraces();
+  const recentTraces = traces.slice(0, 10);
+
+  log.info(`Recent traces: ${recentTraces.length} (from ${traces.length} total)`);
+
+  for (let iteration = 1; iteration <= maxIterations; iteration++) {
+    log.step(`Iteration ${iteration}/${maxIterations}`);
+
+    if (config.dryRun) {
+      log.dry('Would invoke proposer agent with full trace access');
+      log.dry('Would run eval suite on proposed changes');
+      log.dry('Would keep if score improves, revert if not');
+      continue;
+    }
+
+    // Build the proposer prompt with full filesystem context
+    const prompt = buildProposerPrompt(config, recentTraces, scores, cases.length);
+
+    // Invoke proposer agent
+    log.info('Invoking proposer agent...');
+    const result = await spawnAgent({
+      agent: config.agent,
+      model: config.model,
+      prompt,
+      cwd: process.cwd(),
+      logFile: undefined,
+    });
+
+    if (result.exitCode !== 0 || !result.output.trim()) {
+      log.warn(`Proposer failed (exit ${result.exitCode}). Stopping.`);
+      break;
+    }
+
+    // Parse proposed changes from agent output
+    const changes = parseProposedChanges(result.output);
+
+    if (changes.length === 0) {
+      log.info('Proposer returned no changes. Optimization complete.');
+      break;
+    }
+
+    log.info(`Proposer suggested ${changes.length} change(s):`);
+    for (const change of changes) {
+      console.log(`  - ${change.path}: ${change.reason}`);
+    }
+
+    // Validate all paths are safe
+    const unsafeChanges = changes.filter((c) => !isSafePath(c.path));
+    if (unsafeChanges.length > 0) {
+      log.warn('Proposer suggested changes to unsafe paths — skipping:');
+      for (const c of unsafeChanges) {
+        console.log(`  - ${c.path}`);
+      }
+      continue;
+    }
+
+    // Backup current files
+    const backups = new Map<string, string>();
+    for (const change of changes) {
+      if (existsSync(change.path)) {
+        backups.set(change.path, readFileSync(change.path, 'utf-8'));
+      }
+    }
+
+    // Apply changes
+    for (const change of changes) {
+      writeFileSync(change.path, change.content);
+      log.info(`Applied: ${change.path}`);
+    }
+
+    // TODO: Run eval suite and compare scores
+    // For now, log what would happen
+    log.info('Changes applied. Run `alpha-loop eval` to measure impact.');
+    log.info('If score improves: keep changes. If not: revert with git.');
+    console.log('');
+
+    // In a full implementation, we would:
+    // 1. Run the eval suite
+    // 2. Compare composite score to baseline
+    // 3. If improved: commit and update baseline
+    // 4. If not: revert all changes from backups
+    // 5. Continue to next iteration
+
+    // For now, stop after first proposal (eval execution requires fixture repos)
+    log.info('Stopping after first proposal. Full automated loop requires eval fixtures.');
+    break;
+  }
+
+  // Summary
+  console.log('');
+  log.step('Evolve Summary');
+  if (baseline) {
+    console.log(`  Baseline score: ${baseline.composite.toFixed(2)}`);
+  }
+  log.info('Run `alpha-loop eval` to measure current score after changes.');
+  log.info('Run `alpha-loop eval scores` to view score history.');
+}
+
+/**
+ * Build the proposer prompt with full trace context (Meta-Harness style).
+ */
+function buildProposerPrompt(
+  config: import('../lib/config.js').Config,
+  traces: import('../lib/traces.js').Trace[],
+  scores: import('../lib/score.js').ScoreEntry[],
+  evalCaseCount: number,
+): string {
+  const sections: string[] = [];
+
+  sections.push(`# Alpha Loop Optimization Proposer
+
+You are an optimization agent. Your goal is to improve AlphaLoop's pipeline performance
+by analyzing execution traces, scores, and source code, then proposing targeted changes.
+
+## Current State
+- Eval cases: ${evalCaseCount}
+- Score history: ${scores.length} entries
+- Recent traces: ${traces.length}
+- Agent: ${config.agent}
+- Model: ${config.model || 'default'}
+`);
+
+  // Add score history
+  if (scores.length > 0) {
+    sections.push('## Score History (most recent first)');
+    const recent = scores.slice(-10).reverse();
+    for (const s of recent) {
+      sections.push(`  ${formatScoreEntry(s)}`);
+    }
+    sections.push('');
+  }
+
+  // Add trace summaries with key data
+  if (traces.length > 0) {
+    sections.push('## Recent Execution Traces');
+    sections.push('Full traces are available in .alpha-loop/traces/. Key metadata:');
+    sections.push('');
+
+    for (const trace of traces.slice(0, 5)) {
+      const m = trace.metadata;
+      sections.push(`### Issue #${m.issueNum}: ${m.title}`);
+      sections.push(`- Status: ${m.status}, Duration: ${m.duration}s, Retries: ${m.retries}`);
+      sections.push(`- Tests: ${m.testsPassing ? 'passing' : 'failing'}, Files: ${m.filesChanged}`);
+
+      // Include test output snippet if available
+      const testOutput = readTrace(trace.session, trace.issueNum, 'test-output.txt');
+      if (testOutput) {
+        const snippet = testOutput.slice(-500);
+        sections.push(`- Test output (last 500 chars):\n\`\`\`\n${snippet}\n\`\`\``);
+      }
+      sections.push('');
+    }
+  }
+
+  // Read current agent/skill definitions
+  const templatesDir = join(process.cwd(), '.alpha-loop', 'templates');
+  if (existsSync(templatesDir)) {
+    sections.push('## Current Agent & Skill Definitions');
+    sections.push('These are the files you can propose changes to:');
+    sections.push('');
+
+    const readDir = (dir: string, prefix: string) => {
+      if (!existsSync(dir)) return;
+      for (const file of readdirSync(dir)) {
+        const filePath = join(dir, file);
+        try {
+          const content = readFileSync(filePath, 'utf-8');
+          sections.push(`### ${prefix}${file}`);
+          sections.push('```');
+          sections.push(content.slice(0, 2000));
+          if (content.length > 2000) sections.push('... (truncated)');
+          sections.push('```');
+          sections.push('');
+        } catch {
+          // Skip unreadable files
+        }
+      }
+    };
+
+    readDir(join(templatesDir, 'agents'), '.alpha-loop/templates/agents/');
+    readDir(join(templatesDir, 'skills'), '.alpha-loop/templates/skills/');
+  }
+
+  sections.push(`## Your Task
+
+Analyze the traces and scores above. Identify patterns in failures and propose specific
+changes to agent prompts, skills, or config that would improve the composite score.
+
+Output your proposed changes as a JSON array:
+
+\`\`\`json
+[
+  {
+    "path": ".alpha-loop/templates/agents/implementer.md",
+    "content": "full new file content here",
+    "reason": "Why this change should improve the score"
+  }
+]
+\`\`\`
+
+Rules:
+- Only modify files under: ${ALLOWED_TARGETS.join(', ')}
+- Each change must include a clear reason
+- Focus on the highest-impact changes first
+- If no changes would help, output an empty array: []
+`);
+
+  return sections.join('\n');
+}
+
+/** Parsed proposed change from agent output. */
+type ProposedChange = {
+  path: string;
+  content: string;
+  reason: string;
+};
+
+/**
+ * Parse proposed changes from agent output.
+ * Expects a JSON array in the output.
+ */
+function parseProposedChanges(output: string): ProposedChange[] {
+  // Find JSON array in output
+  const jsonMatch = output.match(/\[[\s\S]*?\]/);
+  if (!jsonMatch) return [];
+
+  try {
+    const parsed = JSON.parse(jsonMatch[0]) as Array<Record<string, unknown>>;
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .filter((p) => p.path && p.content)
+      .map((p) => ({
+        path: String(p.path),
+        content: String(p.content),
+        reason: String(p.reason ?? 'No reason given'),
+      }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Check if a proposed path is safe to modify.
+ */
+function isSafePath(filePath: string): boolean {
+  // Reject absolute paths and path traversal
+  if (filePath.startsWith('/') || filePath.includes('..')) return false;
+
+  // Must be in allowed prefixes
+  return ALLOWED_TARGETS.some((prefix) => filePath.startsWith(prefix));
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -34,6 +34,10 @@ export type Config = {
   verbose: boolean;
   harnesses: string[];
   setupCommand: string;
+  evalDir: string;
+  evalModel: string;
+  skipEval: boolean;
+  evalTimeout: number;
 };
 
 const DEFAULTS: Config = {
@@ -68,6 +72,10 @@ const DEFAULTS: Config = {
   verbose: false,
   harnesses: [],
   setupCommand: '',
+  evalDir: '.alpha-loop/evals',
+  evalModel: '',
+  skipEval: false,
+  evalTimeout: 300,
 };
 
 /** Map from YAML key (snake_case) to Config key (camelCase). */
@@ -102,6 +110,10 @@ const YAML_KEY_MAP: Record<string, keyof Config> = {
   run_full: 'runFull',
   verbose: 'verbose',
   setup_command: 'setupCommand',
+  eval_dir: 'evalDir',
+  eval_model: 'evalModel',
+  skip_eval: 'skipEval',
+  eval_timeout: 'evalTimeout',
 };
 
 /** Map from env var name to Config key. */
@@ -135,6 +147,10 @@ const ENV_KEY_MAP: Record<string, keyof Config> = {
   RUN_FULL: 'runFull',
   VERBOSE: 'verbose',
   SETUP_COMMAND: 'setupCommand',
+  EVAL_DIR: 'evalDir',
+  EVAL_MODEL: 'evalModel',
+  SKIP_EVAL: 'skipEval',
+  EVAL_TIMEOUT: 'evalTimeout',
 };
 
 function coerce(value: string, current: unknown): unknown {

--- a/src/lib/eval.ts
+++ b/src/lib/eval.ts
@@ -1,0 +1,340 @@
+/**
+ * Eval Framework Core — define, load, run, and score eval cases.
+ *
+ * Eval cases live in .alpha-loop/evals/*.yaml and define:
+ *   - A fixture repo + ref (the codebase state to test against)
+ *   - An issue description (what the agent should implement)
+ *   - Expected outcome (what success looks like)
+ *   - Tags for filtering and categorization
+ *
+ * Two eval types:
+ *   - 'full' — runs the complete pipeline (slow, expensive, comprehensive)
+ *   - 'step' — tests a single pipeline stage (fast, cheap, targeted)
+ */
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { log } from './logger.js';
+import type { Config } from './config.js';
+import { computeCompositeScore, appendScore, hashConfig } from './score.js';
+import type { CaseResult, ScoreEntry } from './score.js';
+
+/** The pipeline step that a step-level eval targets. */
+export type PipelineStep = 'plan' | 'implement' | 'test' | 'review' | 'verify';
+
+/** Expected outcome for an eval case. */
+export type ExpectedOutcome = {
+  /** Should the pipeline succeed? */
+  success: boolean;
+  /** Files that should be modified (glob patterns). */
+  filesChanged?: string[];
+  /** Tests that should pass after implementation. */
+  testsPassing?: boolean;
+  /** Key strings that should appear in the diff. */
+  diffContains?: string[];
+  /** Key strings that should NOT appear in the diff. */
+  diffNotContains?: string[];
+  /** For step evals: expected output patterns. */
+  outputContains?: string[];
+};
+
+/** An eval case definition loaded from YAML. */
+export type EvalCase = {
+  /** Unique identifier (derived from filename if not set). */
+  id: string;
+  /** Human-readable description. */
+  description: string;
+  /** Type: full pipeline run or single step. */
+  type: 'full' | 'step';
+  /** For step evals: which pipeline step to test. */
+  step?: PipelineStep;
+  /** Fixture repository (owner/repo or local path). */
+  fixtureRepo: string;
+  /** Git ref to checkout for the fixture. */
+  fixtureRef: string;
+  /** Issue title for the agent. */
+  issueTitle: string;
+  /** Issue body (markdown) for the agent. */
+  issueBody: string;
+  /** What we expect the agent to produce. */
+  expected: ExpectedOutcome;
+  /** Tags for filtering (e.g., 'typescript', 'refactor', 'bug-fix'). */
+  tags: string[];
+  /** Maximum time in seconds for this case (0 = use default). */
+  timeout: number;
+  /** Source: how this case was captured ('manual', 'auto-capture', 'swe-bench'). */
+  source: string;
+};
+
+/** Result of running a single eval case. */
+export type EvalResult = {
+  caseId: string;
+  passed: boolean;
+  partialCredit: number;
+  retries: number;
+  duration: number;
+  error?: string;
+  details: {
+    successMatch: boolean;
+    filesMatch: boolean;
+    testsMatch: boolean;
+    diffMatch: boolean;
+  };
+};
+
+/** Summary of an eval suite run. */
+export type EvalSuiteResult = {
+  cases: EvalResult[];
+  composite: number;
+  totalDuration: number;
+  passCount: number;
+  failCount: number;
+};
+
+const EVALS_DIR = '.alpha-loop/evals';
+
+/** Get the evals directory path. */
+export function evalsDir(projectDir?: string): string {
+  return join(projectDir ?? process.cwd(), EVALS_DIR);
+}
+
+/**
+ * Load a single eval case from a YAML file.
+ */
+export function loadEvalCase(filePath: string): EvalCase | null {
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const parsed = parseYaml(raw) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object') return null;
+
+    const id = String(parsed.id ?? basename(filePath, '.yaml'));
+    const expected = (parsed.expected ?? {}) as Record<string, unknown>;
+
+    return {
+      id,
+      description: String(parsed.description ?? ''),
+      type: parsed.type === 'step' ? 'step' : 'full',
+      step: parsed.step ? String(parsed.step) as PipelineStep : undefined,
+      fixtureRepo: String(parsed.fixture_repo ?? parsed.fixtureRepo ?? ''),
+      fixtureRef: String(parsed.fixture_ref ?? parsed.fixtureRef ?? 'main'),
+      issueTitle: String(parsed.issue_title ?? parsed.issueTitle ?? ''),
+      issueBody: String(parsed.issue_body ?? parsed.issueBody ?? ''),
+      expected: {
+        success: expected.success !== false,
+        filesChanged: Array.isArray(expected.files_changed) ? expected.files_changed.map(String) : undefined,
+        testsPassing: typeof expected.tests_passing === 'boolean' ? expected.tests_passing : undefined,
+        diffContains: Array.isArray(expected.diff_contains) ? expected.diff_contains.map(String) : undefined,
+        diffNotContains: Array.isArray(expected.diff_not_contains) ? expected.diff_not_contains.map(String) : undefined,
+        outputContains: Array.isArray(expected.output_contains) ? expected.output_contains.map(String) : undefined,
+      },
+      tags: Array.isArray(parsed.tags) ? parsed.tags.map(String) : [],
+      timeout: typeof parsed.timeout === 'number' ? parsed.timeout : 0,
+      source: String(parsed.source ?? 'manual'),
+    };
+  } catch (err) {
+    log.warn(`Failed to load eval case from ${filePath}: ${err instanceof Error ? err.message : err}`);
+    return null;
+  }
+}
+
+/**
+ * Load all eval cases from the evals directory.
+ * Optionally filter by tags or type.
+ */
+export function loadEvalCases(options?: {
+  projectDir?: string;
+  tags?: string[];
+  type?: 'full' | 'step';
+  step?: PipelineStep;
+}): EvalCase[] {
+  const dir = evalsDir(options?.projectDir);
+  if (!existsSync(dir)) return [];
+
+  const files = readdirSync(dir).filter((f) => f.endsWith('.yaml') && f.startsWith('case-'));
+  const cases: EvalCase[] = [];
+
+  for (const file of files) {
+    const evalCase = loadEvalCase(join(dir, file));
+    if (!evalCase) continue;
+
+    // Filter by type
+    if (options?.type && evalCase.type !== options.type) continue;
+
+    // Filter by step
+    if (options?.step && evalCase.step !== options.step) continue;
+
+    // Filter by tags (any match)
+    if (options?.tags && options.tags.length > 0) {
+      const hasTag = options.tags.some((t) => evalCase.tags.includes(t));
+      if (!hasTag) continue;
+    }
+
+    cases.push(evalCase);
+  }
+
+  return cases.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Save an eval case to a YAML file.
+ */
+export function saveEvalCase(evalCase: EvalCase, projectDir?: string): string {
+  const dir = evalsDir(projectDir);
+  mkdirSync(dir, { recursive: true });
+
+  const filePath = join(dir, `case-${evalCase.id}.yaml`);
+
+  const yamlData: Record<string, unknown> = {
+    id: evalCase.id,
+    description: evalCase.description,
+    type: evalCase.type,
+    ...(evalCase.step && { step: evalCase.step }),
+    fixture_repo: evalCase.fixtureRepo,
+    fixture_ref: evalCase.fixtureRef,
+    issue_title: evalCase.issueTitle,
+    issue_body: evalCase.issueBody,
+    expected: {
+      success: evalCase.expected.success,
+      ...(evalCase.expected.filesChanged && { files_changed: evalCase.expected.filesChanged }),
+      ...(evalCase.expected.testsPassing !== undefined && { tests_passing: evalCase.expected.testsPassing }),
+      ...(evalCase.expected.diffContains && { diff_contains: evalCase.expected.diffContains }),
+      ...(evalCase.expected.diffNotContains && { diff_not_contains: evalCase.expected.diffNotContains }),
+      ...(evalCase.expected.outputContains && { output_contains: evalCase.expected.outputContains }),
+    },
+    tags: evalCase.tags,
+    timeout: evalCase.timeout,
+    source: evalCase.source,
+  };
+
+  writeFileSync(filePath, stringifyYaml(yamlData));
+  return filePath;
+}
+
+/**
+ * Evaluate a completed pipeline result against expected outcomes.
+ * Returns partial credit based on how many criteria match.
+ */
+export function evaluateResult(
+  evalCase: EvalCase,
+  actual: {
+    success: boolean;
+    testsPassing: boolean;
+    diff: string;
+    filesChanged: string[];
+    output: string;
+    retries: number;
+    duration: number;
+  },
+): EvalResult {
+  const checks = {
+    successMatch: actual.success === evalCase.expected.success,
+    filesMatch: true,
+    testsMatch: true,
+    diffMatch: true,
+  };
+
+  // Check files changed
+  if (evalCase.expected.filesChanged && evalCase.expected.filesChanged.length > 0) {
+    checks.filesMatch = evalCase.expected.filesChanged.every((pattern) =>
+      actual.filesChanged.some((f) => f.includes(pattern) || minimatch(f, pattern)),
+    );
+  }
+
+  // Check tests passing
+  if (evalCase.expected.testsPassing !== undefined) {
+    checks.testsMatch = actual.testsPassing === evalCase.expected.testsPassing;
+  }
+
+  // Check diff contains
+  if (evalCase.expected.diffContains) {
+    checks.diffMatch = evalCase.expected.diffContains.every((s) => actual.diff.includes(s));
+  }
+  if (evalCase.expected.diffNotContains) {
+    checks.diffMatch = checks.diffMatch &&
+      evalCase.expected.diffNotContains.every((s) => !actual.diff.includes(s));
+  }
+
+  // Check output contains (for step evals)
+  if (evalCase.expected.outputContains) {
+    checks.diffMatch = checks.diffMatch &&
+      evalCase.expected.outputContains.every((s) => actual.output.includes(s));
+  }
+
+  // Compute partial credit (0-1)
+  const checkValues = Object.values(checks);
+  const partialCredit = checkValues.filter(Boolean).length / checkValues.length;
+  const passed = checkValues.every(Boolean);
+
+  return {
+    caseId: evalCase.id,
+    passed,
+    partialCredit,
+    retries: actual.retries,
+    duration: actual.duration,
+    details: checks,
+  };
+}
+
+/**
+ * Simple glob-like pattern matching (supports * wildcards).
+ * Not a full glob implementation — just enough for eval file matching.
+ */
+function minimatch(str: string, pattern: string): boolean {
+  const regex = new RegExp('^' + pattern.replace(/\*/g, '.*').replace(/\?/g, '.') + '$');
+  return regex.test(str);
+}
+
+/**
+ * Record eval suite results: compute composite score and append to score history.
+ */
+export function recordEvalResults(
+  results: EvalResult[],
+  config: Config,
+  cost: number,
+  projectDir?: string,
+): EvalSuiteResult {
+  const caseResults: CaseResult[] = results.map((r) => ({
+    caseId: r.caseId,
+    passed: r.passed,
+    partialCredit: r.partialCredit,
+    retries: r.retries,
+    duration: r.duration,
+    error: r.error,
+  }));
+
+  const composite = computeCompositeScore(caseResults);
+
+  const configObj: Record<string, unknown> = {
+    agent: config.agent,
+    model: config.model,
+    reviewModel: config.reviewModel,
+    maxTestRetries: config.maxTestRetries,
+    testCommand: config.testCommand,
+  };
+
+  const entry: ScoreEntry = {
+    timestamp: new Date().toISOString(),
+    configHash: hashConfig(configObj),
+    config: configObj,
+    cases: caseResults,
+    composite,
+    totalCost: cost,
+  };
+
+  appendScore(evalsDir(projectDir), entry);
+
+  const passCount = results.filter((r) => r.passed).length;
+  const failCount = results.length - passCount;
+  const totalDuration = results.reduce((sum, r) => sum + r.duration, 0);
+
+  return { cases: results, composite, totalDuration, passCount, failCount };
+}
+
+/**
+ * Format eval case for display.
+ */
+export function formatEvalCase(evalCase: EvalCase): string {
+  const tags = evalCase.tags.length > 0 ? ` [${evalCase.tags.join(', ')}]` : '';
+  const step = evalCase.step ? ` (${evalCase.step})` : '';
+  return `${evalCase.id}: ${evalCase.description} — ${evalCase.type}${step}${tags}`;
+}

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -20,6 +20,7 @@ import { runTests } from './testing.js';
 import { runVerify } from './verify.js';
 import { extractLearnings, getLearningContext } from './learning.js';
 import { saveResult, getPreviousResult } from './session.js';
+import { writeTrace, writeTraceMetadata } from './traces.js';
 import type { Config } from './config.js';
 import type { SessionContext } from './session.js';
 
@@ -192,6 +193,7 @@ export type PipelineResult = {
   verifySkipped: boolean;
   duration: number;
   filesChanged: number;
+  evalScore?: number;
 };
 
 /**
@@ -677,6 +679,34 @@ Rules:
     body,
     config,
   });
+
+  // --- Step 9b: Write full traces (Meta-Harness style) ---
+  if (!config.dryRun) {
+    try {
+      writeTraceMetadata(session.name, issueNum, {
+        issueNum,
+        title,
+        status: testsPassing ? 'success' : 'failure',
+        duration,
+        retries: testRetries,
+        testsPassing,
+        verifyPassing,
+        verifySkipped,
+        filesChanged: runDiff ? (runDiff.match(/^diff --git/gm) ?? []).length : 0,
+        prUrl,
+        timestamp: new Date().toISOString(),
+        agent: config.agent,
+        model: config.model,
+      });
+      if (runDiff) writeTrace(session.name, issueNum, 'diff.patch', runDiff);
+      if (testOutput) writeTrace(session.name, issueNum, 'test-output.txt', testOutput);
+      if (reviewForLearnings) writeTrace(session.name, issueNum, 'review-output.json', reviewForLearnings);
+      if (verifyOutput) writeTrace(session.name, issueNum, 'verify-output.json', verifyOutput);
+      if (plan.summary) writeTrace(session.name, issueNum, 'plan.json', JSON.stringify(plan, null, 2));
+    } catch (err) {
+      log.warn(`Failed to write traces for #${issueNum}: ${err}`);
+    }
+  }
 
   // --- Step 10: Update issue status ---
   log.step('Step 10: Updating issue status');

--- a/src/lib/score.ts
+++ b/src/lib/score.ts
@@ -1,0 +1,162 @@
+/**
+ * Score Tracking — append-only JSONL score history.
+ *
+ * Scores are appended to .alpha-loop/evals/scores.jsonl with:
+ *   timestamp, config hash, per-case results, composite score, cost.
+ *
+ * Composite score formula (from autoresearch pattern):
+ *   score = (passing/total)*100 - 0.1*avg_retries - 0.01*avg_duration
+ */
+import { existsSync, mkdirSync, readFileSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+/** Result for a single eval case within a score run. */
+export type CaseResult = {
+  caseId: string;
+  passed: boolean;
+  partialCredit: number;
+  retries: number;
+  duration: number;
+  error?: string;
+};
+
+/** A single score entry in the JSONL history. */
+export type ScoreEntry = {
+  timestamp: string;
+  configHash: string;
+  config: Record<string, unknown>;
+  cases: CaseResult[];
+  composite: number;
+  totalCost: number;
+};
+
+const SCORES_FILE = 'scores.jsonl';
+
+/** Get the path to the scores JSONL file. */
+export function scoresPath(evalsDir: string): string {
+  return join(evalsDir, SCORES_FILE);
+}
+
+/**
+ * Compute the composite score from case results.
+ *
+ * score = (passing/total)*100 - 0.1*avg_retries - 0.01*avg_duration
+ */
+export function computeCompositeScore(cases: CaseResult[]): number {
+  if (cases.length === 0) return 0;
+
+  const passing = cases.filter((c) => c.passed).length;
+  const totalRetries = cases.reduce((sum, c) => sum + c.retries, 0);
+  const totalDuration = cases.reduce((sum, c) => sum + c.duration, 0);
+
+  const avgRetries = totalRetries / cases.length;
+  const avgDuration = totalDuration / cases.length;
+
+  const score = (passing / cases.length) * 100 - 0.1 * avgRetries - 0.01 * avgDuration;
+  return Math.round(score * 100) / 100;
+}
+
+/**
+ * Hash a config object to create a stable identifier for comparison.
+ */
+export function hashConfig(config: Record<string, unknown>): string {
+  const sorted = JSON.stringify(config, Object.keys(config).sort());
+  return createHash('sha256').update(sorted).digest('hex').slice(0, 12);
+}
+
+/**
+ * Append a score entry to the JSONL file.
+ */
+export function appendScore(evalsDir: string, entry: ScoreEntry): void {
+  mkdirSync(evalsDir, { recursive: true });
+  const filePath = scoresPath(evalsDir);
+  appendFileSync(filePath, JSON.stringify(entry) + '\n');
+}
+
+/**
+ * Read all score entries from the JSONL file.
+ */
+export function readScores(evalsDir: string): ScoreEntry[] {
+  const filePath = scoresPath(evalsDir);
+  if (!existsSync(filePath)) return [];
+
+  const lines = readFileSync(filePath, 'utf-8').trim().split('\n').filter(Boolean);
+  const entries: ScoreEntry[] = [];
+
+  for (const line of lines) {
+    try {
+      entries.push(JSON.parse(line) as ScoreEntry);
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Get the most recent score entry.
+ */
+export function latestScore(evalsDir: string): ScoreEntry | null {
+  const scores = readScores(evalsDir);
+  return scores.length > 0 ? scores[scores.length - 1] : null;
+}
+
+/**
+ * Get score history grouped by config hash.
+ * Returns configs sorted by best composite score (descending).
+ */
+export function scoresByConfig(evalsDir: string): Array<{ configHash: string; config: Record<string, unknown>; scores: ScoreEntry[] }> {
+  const all = readScores(evalsDir);
+  const grouped = new Map<string, { config: Record<string, unknown>; scores: ScoreEntry[] }>();
+
+  for (const entry of all) {
+    if (!grouped.has(entry.configHash)) {
+      grouped.set(entry.configHash, { config: entry.config, scores: [] });
+    }
+    grouped.get(entry.configHash)!.scores.push(entry);
+  }
+
+  return Array.from(grouped.entries())
+    .map(([configHash, data]) => ({ configHash, ...data }))
+    .sort((a, b) => {
+      const bestA = Math.max(...a.scores.map((s) => s.composite));
+      const bestB = Math.max(...b.scores.map((s) => s.composite));
+      return bestB - bestA;
+    });
+}
+
+/**
+ * Compute the Pareto frontier of score vs cost.
+ * Returns entries where no other entry has both higher score AND lower cost.
+ */
+export function paretoFrontier(evalsDir: string): ScoreEntry[] {
+  const all = readScores(evalsDir);
+  if (all.length === 0) return [];
+
+  // Sort by composite score descending
+  const sorted = [...all].sort((a, b) => b.composite - a.composite);
+
+  const frontier: ScoreEntry[] = [];
+  let minCost = Infinity;
+
+  for (const entry of sorted) {
+    if (entry.totalCost <= minCost) {
+      frontier.push(entry);
+      minCost = entry.totalCost;
+    }
+  }
+
+  return frontier;
+}
+
+/**
+ * Format a score entry for display.
+ */
+export function formatScoreEntry(entry: ScoreEntry): string {
+  const passing = entry.cases.filter((c) => c.passed).length;
+  const total = entry.cases.length;
+  const date = entry.timestamp.split('T')[0];
+  return `${date}  score=${entry.composite}  pass=${passing}/${total}  cost=$${entry.totalCost.toFixed(2)}  config=${entry.configHash}`;
+}

--- a/src/lib/traces.ts
+++ b/src/lib/traces.ts
@@ -1,0 +1,190 @@
+/**
+ * Trace Storage — full execution traces per issue (Meta-Harness style).
+ *
+ * Stores raw agent output, diffs, test output, review output, verify output,
+ * and pipeline metadata as separate files under:
+ *   .alpha-loop/traces/{session}/{issue-num}/
+ *
+ * Key insight from Meta-Harness (Lee et al., 2026): full trace access
+ * outperforms summaries by 15+ points. We store everything raw.
+ */
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { log } from './logger.js';
+
+/** Known trace file names within an issue trace directory. */
+export type TraceFile =
+  | 'agent-output.txt'
+  | 'diff.patch'
+  | 'test-output.txt'
+  | 'review-output.json'
+  | 'verify-output.json'
+  | 'plan.json'
+  | 'metadata.json';
+
+/** Pipeline metadata stored alongside traces. */
+export type TraceMetadata = {
+  issueNum: number;
+  title: string;
+  status: 'success' | 'failure';
+  failureReason?: 'transient' | 'permanent';
+  duration: number;
+  retries: number;
+  testsPassing: boolean;
+  verifyPassing: boolean;
+  verifySkipped: boolean;
+  filesChanged: number;
+  prUrl?: string;
+  timestamp: string;
+  agent: string;
+  model: string;
+};
+
+/** A complete trace for one issue run. */
+export type Trace = {
+  session: string;
+  issueNum: number;
+  dir: string;
+  metadata: TraceMetadata;
+};
+
+const TRACES_ROOT = '.alpha-loop/traces';
+
+/** Get the base traces directory. */
+export function tracesDir(projectDir?: string): string {
+  return join(projectDir ?? process.cwd(), TRACES_ROOT);
+}
+
+/** Get the directory for a specific issue trace within a session. */
+export function traceDir(session: string, issueNum: number, projectDir?: string): string {
+  return join(tracesDir(projectDir), session.replace(/\//g, '-'), String(issueNum));
+}
+
+/**
+ * Write a trace file for an issue.
+ * Creates the directory structure if it doesn't exist.
+ */
+export function writeTrace(
+  session: string,
+  issueNum: number,
+  file: TraceFile,
+  content: string,
+  projectDir?: string,
+): void {
+  const dir = traceDir(session, issueNum, projectDir);
+  mkdirSync(dir, { recursive: true });
+  const filePath = join(dir, file);
+  writeFileSync(filePath, content);
+  log.info(`Trace written: ${filePath}`);
+}
+
+/**
+ * Write trace metadata for an issue.
+ */
+export function writeTraceMetadata(
+  session: string,
+  issueNum: number,
+  metadata: TraceMetadata,
+  projectDir?: string,
+): void {
+  writeTrace(session, issueNum, 'metadata.json', JSON.stringify(metadata, null, 2) + '\n', projectDir);
+}
+
+/**
+ * Read a trace file. Returns null if it doesn't exist.
+ */
+export function readTrace(
+  session: string,
+  issueNum: number,
+  file: TraceFile,
+  projectDir?: string,
+): string | null {
+  const filePath = join(traceDir(session, issueNum, projectDir), file);
+  if (!existsSync(filePath)) return null;
+  return readFileSync(filePath, 'utf-8');
+}
+
+/**
+ * Read trace metadata for an issue. Returns null if it doesn't exist.
+ */
+export function readTraceMetadata(
+  session: string,
+  issueNum: number,
+  projectDir?: string,
+): TraceMetadata | null {
+  const raw = readTrace(session, issueNum, 'metadata.json', projectDir);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as TraceMetadata;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List all sessions that have traces.
+ */
+export function listTraceSessions(projectDir?: string): string[] {
+  const root = tracesDir(projectDir);
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+}
+
+/**
+ * List all issue numbers with traces in a session.
+ */
+export function listTraceIssues(session: string, projectDir?: string): number[] {
+  const sessionDir = join(tracesDir(projectDir), session.replace(/\//g, '-'));
+  if (!existsSync(sessionDir)) return [];
+  return readdirSync(sessionDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => parseInt(d.name, 10))
+    .filter((n) => !isNaN(n))
+    .sort((a, b) => a - b);
+}
+
+/**
+ * List all traces across all sessions.
+ * Returns them newest-first by session name (which is timestamp-based).
+ */
+export function listTraces(projectDir?: string): Trace[] {
+  const traces: Trace[] = [];
+  const sessions = listTraceSessions(projectDir);
+
+  for (const session of sessions.reverse()) {
+    const issues = listTraceIssues(session, projectDir);
+    for (const issueNum of issues) {
+      const metadata = readTraceMetadata(session, issueNum, projectDir);
+      if (metadata) {
+        traces.push({
+          session,
+          issueNum,
+          dir: traceDir(session, issueNum, projectDir),
+          metadata,
+        });
+      }
+    }
+  }
+
+  return traces;
+}
+
+/**
+ * Get the full filesystem path context for a trace.
+ * Returns all trace files and their sizes for Meta-Harness-style filesystem access.
+ */
+export function getTraceFiles(session: string, issueNum: number, projectDir?: string): Array<{ file: string; size: number }> {
+  const dir = traceDir(session, issueNum, projectDir);
+  if (!existsSync(dir)) return [];
+
+  return readdirSync(dir)
+    .map((file) => {
+      const filePath = join(dir, file);
+      const content = readFileSync(filePath, 'utf-8');
+      return { file, size: content.length };
+    })
+    .sort((a, b) => a.file.localeCompare(b.file));
+}

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -112,6 +112,10 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
     milestone: '',
     harnesses: [],
     setupCommand: '',
+    evalDir: '.alpha-loop/evals',
+    evalModel: '',
+    skipEval: false,
+    evalTimeout: 300,
     ...overrides,
   };
 }

--- a/tests/engine/prerequisites.test.ts
+++ b/tests/engine/prerequisites.test.ts
@@ -47,6 +47,10 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     verbose: false,
     harnesses: [],
     setupCommand: '',
+    evalDir: '.alpha-loop/evals',
+    evalModel: '',
+    skipEval: false,
+    evalTimeout: 300,
     ...overrides,
   };
 }

--- a/tests/lib/eval.test.ts
+++ b/tests/lib/eval.test.ts
@@ -1,0 +1,214 @@
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  loadEvalCase,
+  loadEvalCases,
+  saveEvalCase,
+  evaluateResult,
+  formatEvalCase,
+  evalsDir,
+} from '../../src/lib/eval.js';
+import type { EvalCase } from '../../src/lib/eval.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-eval-test-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+const sampleCase: EvalCase = {
+  id: 'test-case-1',
+  description: 'Test adding a new feature',
+  type: 'full',
+  fixtureRepo: 'owner/repo',
+  fixtureRef: 'abc123',
+  issueTitle: 'Add widget support',
+  issueBody: 'We need widget support in the app.',
+  expected: {
+    success: true,
+    filesChanged: ['src/widget.ts'],
+    testsPassing: true,
+    diffContains: ['export function createWidget'],
+  },
+  tags: ['typescript', 'feature'],
+  timeout: 300,
+  source: 'manual',
+};
+
+describe('saveEvalCase / loadEvalCase', () => {
+  it('saves and loads an eval case', () => {
+    const filePath = saveEvalCase(sampleCase, tempDir);
+    expect(existsSync(filePath)).toBe(true);
+
+    const loaded = loadEvalCase(filePath);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.id).toBe('test-case-1');
+    expect(loaded!.description).toBe('Test adding a new feature');
+    expect(loaded!.type).toBe('full');
+    expect(loaded!.fixtureRepo).toBe('owner/repo');
+    expect(loaded!.expected.success).toBe(true);
+    expect(loaded!.tags).toEqual(['typescript', 'feature']);
+  });
+
+  it('returns null for invalid file', () => {
+    const filePath = join(tempDir, 'bad.yaml');
+    writeFileSync(filePath, 'not: [valid: yaml: here');
+    const loaded = loadEvalCase(filePath);
+    // May parse partially or fail — should not throw
+    expect(loaded === null || typeof loaded === 'object').toBe(true);
+  });
+});
+
+describe('loadEvalCases', () => {
+  it('returns empty array when no cases exist', () => {
+    expect(loadEvalCases({ projectDir: tempDir })).toEqual([]);
+  });
+
+  it('loads all case files from evals directory', () => {
+    saveEvalCase({ ...sampleCase, id: 'case-a' }, tempDir);
+    saveEvalCase({ ...sampleCase, id: 'case-b' }, tempDir);
+    const cases = loadEvalCases({ projectDir: tempDir });
+    expect(cases).toHaveLength(2);
+  });
+
+  it('filters by type', () => {
+    saveEvalCase({ ...sampleCase, id: 'full-case', type: 'full' }, tempDir);
+    saveEvalCase({ ...sampleCase, id: 'step-case', type: 'step', step: 'plan' }, tempDir);
+
+    const fullCases = loadEvalCases({ projectDir: tempDir, type: 'full' });
+    expect(fullCases).toHaveLength(1);
+    expect(fullCases[0].id).toBe('full-case');
+
+    const stepCases = loadEvalCases({ projectDir: tempDir, type: 'step' });
+    expect(stepCases).toHaveLength(1);
+    expect(stepCases[0].id).toBe('step-case');
+  });
+
+  it('filters by tags', () => {
+    saveEvalCase({ ...sampleCase, id: 'ts-case', tags: ['typescript'] }, tempDir);
+    saveEvalCase({ ...sampleCase, id: 'py-case', tags: ['python'] }, tempDir);
+
+    const tsCases = loadEvalCases({ projectDir: tempDir, tags: ['typescript'] });
+    expect(tsCases).toHaveLength(1);
+    expect(tsCases[0].id).toBe('ts-case');
+  });
+});
+
+describe('evaluateResult', () => {
+  it('returns passed when all checks match', () => {
+    const result = evaluateResult(sampleCase, {
+      success: true,
+      testsPassing: true,
+      diff: 'export function createWidget() { }',
+      filesChanged: ['src/widget.ts'],
+      output: '',
+      retries: 0,
+      duration: 60,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.partialCredit).toBe(1);
+    expect(result.details.successMatch).toBe(true);
+    expect(result.details.filesMatch).toBe(true);
+    expect(result.details.testsMatch).toBe(true);
+    expect(result.details.diffMatch).toBe(true);
+  });
+
+  it('returns failed when success status mismatches', () => {
+    const result = evaluateResult(sampleCase, {
+      success: false,
+      testsPassing: true,
+      diff: 'export function createWidget() { }',
+      filesChanged: ['src/widget.ts'],
+      output: '',
+      retries: 0,
+      duration: 60,
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.details.successMatch).toBe(false);
+  });
+
+  it('gives partial credit', () => {
+    const result = evaluateResult(sampleCase, {
+      success: true,       // match
+      testsPassing: false,  // mismatch
+      diff: 'something else',  // mismatch (diffContains)
+      filesChanged: ['src/widget.ts'], // match
+      output: '',
+      retries: 1,
+      duration: 120,
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.partialCredit).toBe(0.5); // 2 of 4 checks pass
+  });
+
+  it('checks diffNotContains', () => {
+    const caseWithNot: EvalCase = {
+      ...sampleCase,
+      expected: {
+        success: true,
+        diffNotContains: ['console.log', 'debugger'],
+      },
+    };
+
+    const passResult = evaluateResult(caseWithNot, {
+      success: true,
+      testsPassing: true,
+      diff: 'clean code without debug statements',
+      filesChanged: [],
+      output: '',
+      retries: 0,
+      duration: 30,
+    });
+    expect(passResult.details.diffMatch).toBe(true);
+
+    const failResult = evaluateResult(caseWithNot, {
+      success: true,
+      testsPassing: true,
+      diff: 'code with console.log("debug")',
+      filesChanged: [],
+      output: '',
+      retries: 0,
+      duration: 30,
+    });
+    expect(failResult.details.diffMatch).toBe(false);
+  });
+
+  it('tracks retries and duration', () => {
+    const result = evaluateResult(sampleCase, {
+      success: true,
+      testsPassing: true,
+      diff: 'export function createWidget() { }',
+      filesChanged: ['src/widget.ts'],
+      output: '',
+      retries: 3,
+      duration: 180,
+    });
+
+    expect(result.retries).toBe(3);
+    expect(result.duration).toBe(180);
+  });
+});
+
+describe('formatEvalCase', () => {
+  it('formats full case', () => {
+    const formatted = formatEvalCase(sampleCase);
+    expect(formatted).toContain('test-case-1');
+    expect(formatted).toContain('Test adding a new feature');
+    expect(formatted).toContain('full');
+    expect(formatted).toContain('typescript');
+  });
+
+  it('includes step info for step cases', () => {
+    const stepCase = { ...sampleCase, type: 'step' as const, step: 'plan' as const };
+    const formatted = formatEvalCase(stepCase);
+    expect(formatted).toContain('(plan)');
+  });
+});

--- a/tests/lib/learning.test.ts
+++ b/tests/lib/learning.test.ts
@@ -72,6 +72,10 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     milestone: '',
     harnesses: [],
     setupCommand: '',
+    evalDir: '.alpha-loop/evals',
+    evalModel: '',
+    skipEval: false,
+    evalTimeout: 300,
     ...overrides,
   };
 }

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -120,6 +120,10 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     milestone: '',
     harnesses: [],
     setupCommand: '',
+    evalDir: '.alpha-loop/evals',
+    evalModel: '',
+    skipEval: false,
+    evalTimeout: 300,
     ...overrides,
   };
 }

--- a/tests/lib/score.test.ts
+++ b/tests/lib/score.test.ts
@@ -1,0 +1,213 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  computeCompositeScore,
+  hashConfig,
+  appendScore,
+  readScores,
+  latestScore,
+  scoresByConfig,
+  paretoFrontier,
+  formatScoreEntry,
+} from '../../src/lib/score.js';
+import type { CaseResult, ScoreEntry } from '../../src/lib/score.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-score-test-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('computeCompositeScore', () => {
+  it('returns 0 for empty cases', () => {
+    expect(computeCompositeScore([])).toBe(0);
+  });
+
+  it('returns 100 for all passing with no retries and zero duration', () => {
+    const cases: CaseResult[] = [
+      { caseId: 'a', passed: true, partialCredit: 1, retries: 0, duration: 0 },
+      { caseId: 'b', passed: true, partialCredit: 1, retries: 0, duration: 0 },
+    ];
+    expect(computeCompositeScore(cases)).toBe(100);
+  });
+
+  it('penalizes retries and duration', () => {
+    const cases: CaseResult[] = [
+      { caseId: 'a', passed: true, partialCredit: 1, retries: 2, duration: 100 },
+    ];
+    // score = 100 - 0.1*2 - 0.01*100 = 100 - 0.2 - 1 = 98.8
+    expect(computeCompositeScore(cases)).toBe(98.8);
+  });
+
+  it('penalizes failures', () => {
+    const cases: CaseResult[] = [
+      { caseId: 'a', passed: true, partialCredit: 1, retries: 0, duration: 0 },
+      { caseId: 'b', passed: false, partialCredit: 0, retries: 0, duration: 0 },
+    ];
+    // score = (1/2)*100 - 0 - 0 = 50
+    expect(computeCompositeScore(cases)).toBe(50);
+  });
+});
+
+describe('hashConfig', () => {
+  it('produces consistent hashes', () => {
+    const config = { agent: 'claude', model: 'opus' };
+    const hash1 = hashConfig(config);
+    const hash2 = hashConfig(config);
+    expect(hash1).toBe(hash2);
+  });
+
+  it('produces different hashes for different configs', () => {
+    const hash1 = hashConfig({ agent: 'claude' });
+    const hash2 = hashConfig({ agent: 'codex' });
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('produces 12-character hex strings', () => {
+    const hash = hashConfig({ test: 'value' });
+    expect(hash).toMatch(/^[a-f0-9]{12}$/);
+  });
+});
+
+describe('appendScore / readScores', () => {
+  it('appends and reads score entries', () => {
+    const entry: ScoreEntry = {
+      timestamp: '2026-04-01T12:00:00.000Z',
+      configHash: 'abc123def456',
+      config: { agent: 'claude' },
+      cases: [{ caseId: 'a', passed: true, partialCredit: 1, retries: 0, duration: 60 }],
+      composite: 99.4,
+      totalCost: 0.50,
+    };
+
+    appendScore(tempDir, entry);
+    const scores = readScores(tempDir);
+    expect(scores).toHaveLength(1);
+    expect(scores[0].composite).toBe(99.4);
+  });
+
+  it('appends multiple entries', () => {
+    const makeEntry = (score: number): ScoreEntry => ({
+      timestamp: new Date().toISOString(),
+      configHash: 'test',
+      config: {},
+      cases: [],
+      composite: score,
+      totalCost: 0,
+    });
+
+    appendScore(tempDir, makeEntry(80));
+    appendScore(tempDir, makeEntry(90));
+    appendScore(tempDir, makeEntry(85));
+
+    const scores = readScores(tempDir);
+    expect(scores).toHaveLength(3);
+    expect(scores.map((s) => s.composite)).toEqual([80, 90, 85]);
+  });
+
+  it('returns empty array when no scores file exists', () => {
+    expect(readScores(tempDir)).toEqual([]);
+  });
+});
+
+describe('latestScore', () => {
+  it('returns null when no scores exist', () => {
+    expect(latestScore(tempDir)).toBeNull();
+  });
+
+  it('returns the most recent entry', () => {
+    const makeEntry = (score: number): ScoreEntry => ({
+      timestamp: new Date().toISOString(),
+      configHash: 'test',
+      config: {},
+      cases: [],
+      composite: score,
+      totalCost: 0,
+    });
+
+    appendScore(tempDir, makeEntry(80));
+    appendScore(tempDir, makeEntry(95));
+
+    expect(latestScore(tempDir)?.composite).toBe(95);
+  });
+});
+
+describe('scoresByConfig', () => {
+  it('groups scores by config hash and sorts by best score', () => {
+    const entry = (hash: string, score: number): ScoreEntry => ({
+      timestamp: new Date().toISOString(),
+      configHash: hash,
+      config: { hash },
+      cases: [],
+      composite: score,
+      totalCost: 0,
+    });
+
+    appendScore(tempDir, entry('aaa', 70));
+    appendScore(tempDir, entry('bbb', 90));
+    appendScore(tempDir, entry('aaa', 80));
+    appendScore(tempDir, entry('bbb', 85));
+
+    const grouped = scoresByConfig(tempDir);
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0].configHash).toBe('bbb'); // best=90
+    expect(grouped[1].configHash).toBe('aaa'); // best=80
+    expect(grouped[0].scores).toHaveLength(2);
+  });
+});
+
+describe('paretoFrontier', () => {
+  it('returns empty array when no scores exist', () => {
+    expect(paretoFrontier(tempDir)).toEqual([]);
+  });
+
+  it('computes Pareto frontier correctly', () => {
+    const entry = (score: number, cost: number): ScoreEntry => ({
+      timestamp: new Date().toISOString(),
+      configHash: 'test',
+      config: {},
+      cases: [],
+      composite: score,
+      totalCost: cost,
+    });
+
+    // Pareto-optimal: highest score at lowest cost
+    appendScore(tempDir, entry(90, 10));  // Pareto: best score
+    appendScore(tempDir, entry(80, 5));   // Pareto: lower cost
+    appendScore(tempDir, entry(70, 8));   // Dominated by (80, 5)
+    appendScore(tempDir, entry(60, 3));   // Pareto: cheapest
+
+    const frontier = paretoFrontier(tempDir);
+    // Should include: (90,10), (80,5), (60,3) — not (70,8)
+    expect(frontier).toHaveLength(3);
+    expect(frontier.map((e) => e.composite)).toEqual([90, 80, 60]);
+  });
+});
+
+describe('formatScoreEntry', () => {
+  it('formats entry for display', () => {
+    const entry: ScoreEntry = {
+      timestamp: '2026-04-01T12:00:00.000Z',
+      configHash: 'abc123def456',
+      config: {},
+      cases: [
+        { caseId: 'a', passed: true, partialCredit: 1, retries: 0, duration: 60 },
+        { caseId: 'b', passed: false, partialCredit: 0, retries: 2, duration: 120 },
+      ],
+      composite: 49.5,
+      totalCost: 1.25,
+    };
+
+    const formatted = formatScoreEntry(entry);
+    expect(formatted).toContain('2026-04-01');
+    expect(formatted).toContain('score=49.5');
+    expect(formatted).toContain('pass=1/2');
+    expect(formatted).toContain('cost=$1.25');
+    expect(formatted).toContain('config=abc123def456');
+  });
+});

--- a/tests/lib/session.test.ts
+++ b/tests/lib/session.test.ts
@@ -73,6 +73,10 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     milestone: '',
     harnesses: [],
     setupCommand: '',
+    evalDir: '.alpha-loop/evals',
+    evalModel: '',
+    skipEval: false,
+    evalTimeout: 300,
     ...overrides,
   };
 }

--- a/tests/lib/testing.test.ts
+++ b/tests/lib/testing.test.ts
@@ -59,6 +59,10 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     milestone: '',
     harnesses: [],
     setupCommand: '',
+    evalDir: '.alpha-loop/evals',
+    evalModel: '',
+    skipEval: false,
+    evalTimeout: 300,
     ...overrides,
   };
 }

--- a/tests/lib/traces.test.ts
+++ b/tests/lib/traces.test.ts
@@ -1,0 +1,133 @@
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  writeTrace,
+  writeTraceMetadata,
+  readTrace,
+  readTraceMetadata,
+  listTraceSessions,
+  listTraceIssues,
+  listTraces,
+  getTraceFiles,
+  traceDir,
+} from '../../src/lib/traces.js';
+import type { TraceMetadata } from '../../src/lib/traces.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-trace-test-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+const sampleMetadata: TraceMetadata = {
+  issueNum: 42,
+  title: 'Fix the widget',
+  status: 'success',
+  duration: 120,
+  retries: 1,
+  testsPassing: true,
+  verifyPassing: true,
+  verifySkipped: false,
+  filesChanged: 3,
+  prUrl: 'https://github.com/test/repo/pull/10',
+  timestamp: '2026-04-01T12:00:00.000Z',
+  agent: 'claude',
+  model: 'opus',
+};
+
+describe('writeTrace / readTrace', () => {
+  it('writes and reads a trace file', () => {
+    writeTrace('session-20260401-120000', 42, 'test-output.txt', 'All tests passed', tempDir);
+    const content = readTrace('session-20260401-120000', 42, 'test-output.txt', tempDir);
+    expect(content).toBe('All tests passed');
+  });
+
+  it('returns null for non-existent trace', () => {
+    const content = readTrace('nonexistent', 999, 'test-output.txt', tempDir);
+    expect(content).toBeNull();
+  });
+
+  it('creates directory structure automatically', () => {
+    writeTrace('session-20260401-120000', 42, 'diff.patch', 'diff content', tempDir);
+    const dir = traceDir('session-20260401-120000', 42, tempDir);
+    expect(existsSync(dir)).toBe(true);
+  });
+});
+
+describe('writeTraceMetadata / readTraceMetadata', () => {
+  it('writes and reads metadata', () => {
+    writeTraceMetadata('session-20260401-120000', 42, sampleMetadata, tempDir);
+    const metadata = readTraceMetadata('session-20260401-120000', 42, tempDir);
+    expect(metadata).toEqual(sampleMetadata);
+  });
+
+  it('returns null for non-existent metadata', () => {
+    expect(readTraceMetadata('nonexistent', 999, tempDir)).toBeNull();
+  });
+});
+
+describe('listTraceSessions', () => {
+  it('returns empty array when no traces exist', () => {
+    expect(listTraceSessions(tempDir)).toEqual([]);
+  });
+
+  it('lists session directories', () => {
+    writeTrace('session-20260401-120000', 1, 'metadata.json', '{}', tempDir);
+    writeTrace('session-20260402-120000', 2, 'metadata.json', '{}', tempDir);
+    const sessions = listTraceSessions(tempDir);
+    expect(sessions).toEqual(['session-20260401-120000', 'session-20260402-120000']);
+  });
+});
+
+describe('listTraceIssues', () => {
+  it('returns empty array for non-existent session', () => {
+    expect(listTraceIssues('nonexistent', tempDir)).toEqual([]);
+  });
+
+  it('lists issue numbers in a session', () => {
+    writeTrace('session-20260401-120000', 10, 'metadata.json', '{}', tempDir);
+    writeTrace('session-20260401-120000', 20, 'metadata.json', '{}', tempDir);
+    const issues = listTraceIssues('session-20260401-120000', tempDir);
+    expect(issues).toEqual([10, 20]);
+  });
+});
+
+describe('listTraces', () => {
+  it('returns all traces newest-first', () => {
+    writeTraceMetadata('session-20260401-120000', 1, { ...sampleMetadata, issueNum: 1 }, tempDir);
+    writeTraceMetadata('session-20260402-120000', 2, { ...sampleMetadata, issueNum: 2 }, tempDir);
+    const traces = listTraces(tempDir);
+    expect(traces).toHaveLength(2);
+    expect(traces[0].session).toBe('session-20260402-120000');
+    expect(traces[1].session).toBe('session-20260401-120000');
+  });
+});
+
+describe('getTraceFiles', () => {
+  it('returns empty array for non-existent trace', () => {
+    expect(getTraceFiles('nonexistent', 999, tempDir)).toEqual([]);
+  });
+
+  it('lists trace files with sizes', () => {
+    writeTrace('session-20260401-120000', 42, 'test-output.txt', 'test output', tempDir);
+    writeTrace('session-20260401-120000', 42, 'diff.patch', 'diff content', tempDir);
+    const files = getTraceFiles('session-20260401-120000', 42, tempDir);
+    expect(files).toHaveLength(2);
+    expect(files.map((f) => f.file)).toContain('test-output.txt');
+    expect(files.map((f) => f.file)).toContain('diff.patch');
+  });
+});
+
+describe('session name with slashes', () => {
+  it('replaces slashes with dashes in directory names', () => {
+    writeTrace('session/20260401-120000', 42, 'test-output.txt', 'content', tempDir);
+    const dir = traceDir('session/20260401-120000', 42, tempDir);
+    expect(dir).toContain('session-20260401-120000');
+    expect(existsSync(dir)).toBe(true);
+  });
+});

--- a/tests/lib/verify.test.ts
+++ b/tests/lib/verify.test.ts
@@ -47,6 +47,10 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     autoCleanup: true,
     runFull: false,
     verbose: false,
+    evalDir: '.alpha-loop/evals',
+    evalModel: '',
+    skipEval: false,
+    evalTimeout: 300,
     ...overrides,
   };
 }


### PR DESCRIPTION
Closes #90

## Summary

Automated implementation of **epic: self-improving eval system (Meta-Harness + autoresearch patterns)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Solid eval system implementation covering trace storage, eval framework, score tracking, and CLI commands with comprehensive tests. All 301 tests pass, build clean.

- **INFO** [OPEN] `src/commands/eval.ts`: evalRunCommand loads config but never uses it (line 69 of eval.ts). Likely intended for future eval execution.
- **INFO** [OPEN] `src/lib/pipeline.ts`: PipelineResult.evalScore field added but never set anywhere — dead field placeholder for future use.
- **INFO** [OPEN] `src/lib/eval.ts`: minimatch() in eval.ts doesn't escape regex special chars (e.g. dots in 'src/utils.ts' match any char). Fine for current usage but could cause false positives on complex patterns.
- **INFO** [OPEN] `src/commands/evolve.ts`: parseProposedChanges uses non-greedy regex [\s\S]*? which grabs first [...] pair in output — may misparse if agent output contains markdown links before JSON. Try/catch handles gracefully.
- **INFO** [OPEN] `src/commands/eval.ts`: evalImportSwebenchCommand is a placeholder (prints instructions only). Correctly deferred to M2 issue #95.
- **INFO** [OPEN] `src/commands/evolve.ts`: evolveCommand stops after first proposal with TODO comment for full eval-score-revert loop. Correctly deferred to M3 issue #97.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*