### PR TITLE
feat: feat: eval capture workflow — alpha-loop eval capture (closes #93)

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -20,6 +20,10 @@ import type { Config } from '../lib/config.js';
 import {
   loadEvalCases,
   saveEvalCase,
+  saveCapturedCase,
+  loadUnannotatedCases,
+  annotateCapturedCase,
+  detectFailureStep,
   formatEvalCase,
   evalsDir,
 } from '../lib/eval.js';
@@ -171,6 +175,11 @@ export function evalCompareCommand(run1: string, run2: string): void {
 
 /**
  * Capture a failure as an eval case — interactive walkthrough.
+ *
+ * Flow:
+ *   1. Show unannotated (auto-captured) skeleton cases first, prompt to annotate
+ *   2. Show recent session failures grouped by session
+ *   3. For each failure: show step, test/verify status, prompt for diagnosis
  */
 export async function evalCaptureCommand(options: EvalCaptureOptions): Promise<void> {
   const config = loadConfig();
@@ -181,27 +190,139 @@ export async function evalCaptureCommand(options: EvalCaptureOptions): Promise<v
     return;
   }
 
-  // Walk through recent failures from sessions
-  const sessionsDir = join(process.cwd(), '.alpha-loop', 'sessions');
-  if (!existsSync(sessionsDir)) {
-    log.warn('No sessions found. Run `alpha-loop run` first to generate session data.');
-    return;
-  }
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  let capturedCount = 0;
 
-  // Find session directories with results
+  try {
+    // Phase 1: Show unannotated skeleton cases first
+    const unannotated = loadUnannotatedCases();
+    if (unannotated.length > 0) {
+      log.step(`Unannotated eval cases (auto-captured):`);
+      console.log('');
+      for (let i = 0; i < unannotated.length; i++) {
+        const u = unannotated[i];
+        const meta = u.evalCase;
+        console.log(`  ${i + 1}. ${meta.id} (issue #${extractIssueNum(meta.id)}, ${meta.source})`);
+      }
+      console.log('');
+
+      for (const entry of unannotated) {
+        const answer = await ask(rl, `Annotate ${entry.evalCase.id}? (y/n): `);
+        if (answer.toLowerCase() !== 'y') continue;
+
+        const annotation = await promptAnnotation(rl);
+        annotateCapturedCase(entry.path, annotation);
+        capturedCount++;
+        log.success(`Annotated: ${entry.evalCase.id}`);
+      }
+
+      if (capturedCount > 0) console.log('');
+    }
+
+    // Phase 2: Show recent session failures
+    const sessionFailures = collectSessionFailures();
+    if (sessionFailures.length === 0 && unannotated.length === 0) {
+      log.info('No failures found in recent sessions. Nothing to capture.');
+      return;
+    }
+
+    if (sessionFailures.length > 0) {
+      // Group by session
+      const grouped = groupBySession(sessionFailures);
+
+      log.step('Recent sessions with failures:');
+      console.log('');
+
+      let globalIdx = 0;
+      for (const [session, failures] of grouped) {
+        console.log(`  ${session} — ${failures.length} failure(s)`);
+        for (const f of failures) {
+          globalIdx++;
+          const step = detectFailureStepFromResult(f.result);
+          const tests = f.result.testsPassing ? 'PASS' : 'FAIL';
+          const verify = f.result.verifySkipped ? 'SKIP' : (f.result.verifyPassing ? 'PASS' : 'FAIL');
+          console.log(`    #${f.issueNum} — ${f.title}`);
+          console.log(`      Failed at: ${step} | Tests: ${tests} | Verify: ${verify}`);
+        }
+        console.log('');
+      }
+
+      // Prompt to capture each failure
+      for (const [_session, failures] of grouped) {
+        for (const failure of failures) {
+          const answer = await ask(rl, `Capture #${failure.issueNum}? (y/n/skip all): `);
+          if (answer === 'skip all') break;
+          if (answer.toLowerCase() !== 'y') continue;
+
+          const annotation = await promptAnnotation(rl);
+          const step = detectFailureStepFromResult(failure.result);
+
+          const casePath = saveCapturedCase({
+            issueNum: failure.issueNum,
+            title: failure.title,
+            issueBody: typeof failure.result.issueBody === 'string' ? failure.result.issueBody : undefined,
+            step,
+            session: failure.session,
+            tags: annotation.tags,
+          });
+
+          // Immediately annotate since we have the diagnosis
+          annotateCapturedCase(casePath, annotation);
+          capturedCount++;
+          log.success(`Created: ${casePath}`);
+        }
+      }
+    }
+
+    if (capturedCount > 0) {
+      console.log('');
+      log.info(`Done. ${capturedCount} eval case(s) created/annotated. Run 'alpha-loop eval --suite step' to test.`);
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+/** Prompt user for failure annotation. */
+async function promptAnnotation(rl: readline.Interface): Promise<import('../lib/eval.js').CaseAnnotation> {
+  console.log('');
+  const whatWentWrong = await ask(rl, '  What went wrong? (one line): ');
+  const whatShouldHaveHappened = await ask(rl, '  What should have happened? (one line): ');
+  const tagsInput = await ask(rl, '  Tags (comma-separated, optional): ');
+
+  return {
+    whatWentWrong,
+    whatShouldHaveHappened,
+    tags: tagsInput.split(',').map((t) => t.trim()).filter(Boolean),
+  };
+}
+
+/** Extract issue number from a captured case ID like "captured-047-module-format". */
+function extractIssueNum(caseId: string): string {
+  const match = caseId.match(/captured-(\d+)/);
+  return match ? String(parseInt(match[1], 10)) : '?';
+}
+
+type SessionFailure = {
+  session: string;
+  issueNum: number;
+  title: string;
+  file: string;
+  result: Record<string, unknown>;
+};
+
+/** Collect failures from recent sessions. */
+function collectSessionFailures(): SessionFailure[] {
+  const sessionsDir = join(process.cwd(), '.alpha-loop', 'sessions');
+  if (!existsSync(sessionsDir)) return [];
+
   const sessionDirs = readdirSync(sessionsDir, { withFileTypes: true })
     .filter((d) => d.isDirectory())
     .map((d) => d.name)
     .sort()
     .reverse();
 
-  if (sessionDirs.length === 0) {
-    log.warn('No session data found.');
-    return;
-  }
-
-  // Collect failures from recent sessions
-  const failures: Array<{ session: string; issueNum: number; title: string; file: string }> = [];
+  const failures: SessionFailure[] = [];
 
   for (const sessionDir of sessionDirs.slice(0, 5)) {
     const sessionPath = join(sessionsDir, sessionDir);
@@ -217,6 +338,7 @@ export async function evalCaptureCommand(options: EvalCaptureOptions): Promise<v
             issueNum: result.issueNum,
             title: result.title ?? `Issue #${result.issueNum}`,
             file: join(sessionPath, file),
+            result,
           });
         }
       } catch {
@@ -225,46 +347,27 @@ export async function evalCaptureCommand(options: EvalCaptureOptions): Promise<v
     }
   }
 
-  if (failures.length === 0) {
-    log.info('No failures found in recent sessions. Nothing to capture.');
-    return;
+  return failures;
+}
+
+/** Group failures by session name. */
+function groupBySession(failures: SessionFailure[]): Map<string, SessionFailure[]> {
+  const grouped = new Map<string, SessionFailure[]>();
+  for (const f of failures) {
+    const existing = grouped.get(f.session) ?? [];
+    existing.push(f);
+    grouped.set(f.session, existing);
   }
+  return grouped;
+}
 
-  log.step(`Found ${failures.length} failure(s) in recent sessions:`);
-  console.log('');
-
-  for (let i = 0; i < failures.length; i++) {
-    const f = failures[i];
-    console.log(`  ${i + 1}. #${f.issueNum}: ${f.title} (${f.session})`);
+/** Detect failure step from a raw session result object. */
+function detectFailureStepFromResult(result: Record<string, unknown>): string {
+  if (!result.testsPassing) {
+    return (typeof result.filesChanged === 'number' && result.filesChanged > 1) ? 'test-fix' : 'implement';
   }
-
-  console.log('');
-
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-
-  try {
-    const choice = await ask(rl, 'Capture which failure? (number, or "all", or "q" to quit): ');
-
-    if (choice === 'q' || choice === '') {
-      log.info('Cancelled.');
-      return;
-    }
-
-    if (choice === 'all') {
-      for (const failure of failures) {
-        await captureFailure(rl, failure, config);
-      }
-    } else {
-      const idx = parseInt(choice, 10) - 1;
-      if (idx >= 0 && idx < failures.length) {
-        await captureFailure(rl, failures[idx], config);
-      } else {
-        log.warn('Invalid choice.');
-      }
-    }
-  } finally {
-    rl.close();
-  }
+  if (!result.verifyPassing && !result.verifySkipped) return 'verify';
+  return 'review';
 }
 
 /** Capture a specific issue number as an eval case. */
@@ -341,36 +444,31 @@ async function captureFromTrace(
   const plan = readTrace(session, issueNum, 'plan.json');
   const diff = readTrace(session, issueNum, 'diff.patch');
 
+  const step = metadata.testsPassing
+    ? (metadata.verifyPassing ? 'review' : 'verify')
+    : 'implement';
+
   console.log(`\n  Issue: #${issueNum} — ${metadata.title}`);
   console.log(`  Status: ${metadata.status}`);
+  console.log(`  Failed at: ${step}`);
+  console.log(`  Tests: ${metadata.testsPassing ? 'PASS' : 'FAIL'} | Verify: ${metadata.verifySkipped ? 'SKIP' : (metadata.verifyPassing ? 'PASS' : 'FAIL')}`);
   console.log(`  Duration: ${metadata.duration}s, Retries: ${metadata.retries}`);
   if (plan) console.log(`  Plan: available`);
   if (diff) console.log(`  Diff: ${diff.length} chars`);
   console.log('');
 
-  const description = await ask(rl, 'Description (what this eval tests): ');
-  const shouldSucceed = await ask(rl, 'Should the agent succeed? (y/n): ');
-  const tagsInput = await ask(rl, 'Tags (comma-separated, e.g. typescript,refactor): ');
+  const annotation = await promptAnnotation(rl);
 
-  const evalCase: EvalCase = {
-    id: `issue-${issueNum}`,
-    description: description || `Eval case captured from issue #${issueNum}`,
-    type: 'full',
-    fixtureRepo: config.repo,
-    fixtureRef: 'main',
-    issueTitle: metadata.title,
-    issueBody: `Captured from issue #${issueNum} (session: ${session})`,
-    expected: {
-      success: shouldSucceed.toLowerCase() === 'y',
-      testsPassing: shouldSucceed.toLowerCase() === 'y',
-    },
-    tags: tagsInput.split(',').map((t) => t.trim()).filter(Boolean),
-    timeout: 0,
-    source: 'auto-capture',
-  };
+  const casePath = saveCapturedCase({
+    issueNum,
+    title: metadata.title,
+    step,
+    session,
+    tags: annotation.tags,
+  });
 
-  const filePath = saveEvalCase(evalCase);
-  log.success(`Eval case saved: ${filePath}`);
+  annotateCapturedCase(casePath, annotation);
+  log.success(`Eval case saved: ${casePath}`);
 }
 
 /** Capture a failure from session result as an eval case. */
@@ -382,36 +480,26 @@ async function captureFailure(
   log.step(`\nCapturing: #${failure.issueNum} — ${failure.title}`);
 
   const result = JSON.parse(readFileSync(failure.file, 'utf-8'));
+  const step = detectFailureStepFromResult(result);
 
-  console.log(`  Status: ${result.status}`);
-  console.log(`  Tests: ${result.testsPassing ? 'passing' : 'failing'}`);
+  console.log(`  Failed at: ${step}`);
+  console.log(`  Tests: ${result.testsPassing ? 'PASS' : 'FAIL'} | Verify: ${result.verifySkipped ? 'SKIP' : (result.verifyPassing ? 'PASS' : 'FAIL')}`);
   console.log(`  Duration: ${result.duration}s`);
   console.log(`  Files changed: ${result.filesChanged}`);
   console.log('');
 
-  const description = await ask(rl, '  Description (what this eval tests): ');
-  const shouldSucceed = await ask(rl, '  Expected: should succeed? (y/n): ');
-  const tagsInput = await ask(rl, '  Tags (comma-separated): ');
+  const annotation = await promptAnnotation(rl);
 
-  const evalCase: EvalCase = {
-    id: `issue-${failure.issueNum}`,
-    description: description || `Captured from failed issue #${failure.issueNum}`,
-    type: 'full',
-    fixtureRepo: config.repo,
-    fixtureRef: 'main',
-    issueTitle: failure.title,
-    issueBody: `Captured from session ${failure.session}, issue #${failure.issueNum}`,
-    expected: {
-      success: shouldSucceed.toLowerCase() === 'y',
-      testsPassing: shouldSucceed.toLowerCase() === 'y',
-    },
-    tags: tagsInput.split(',').map((t) => t.trim()).filter(Boolean),
-    timeout: 0,
-    source: 'auto-capture',
-  };
+  const casePath = saveCapturedCase({
+    issueNum: failure.issueNum,
+    title: failure.title,
+    step,
+    session: failure.session,
+    tags: annotation.tags,
+  });
 
-  const filePath = saveEvalCase(evalCase);
-  log.success(`Eval case saved: ${filePath}`);
+  annotateCapturedCase(casePath, annotation);
+  log.success(`Eval case saved: ${casePath}`);
 }
 
 /**

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -15,6 +15,7 @@ import { hasVision } from '../lib/vision.js';
 import { contextNeedsRefresh } from '../lib/context.js';
 import { runPreflight } from '../lib/preflight.js';
 import { syncAgentAssets, resolveHarnesses } from './sync.js';
+import { saveCapturedCase, detectFailureStep } from '../lib/eval.js';
 
 export type RunOptions = {
   dryRun?: boolean;
@@ -368,6 +369,28 @@ export async function runCommand(options: RunOptions): Promise<void> {
       }
 
       activeIssueNum = null;
+    }
+  }
+
+  // Auto-capture failures as eval case skeletons
+  if (config.autoCapture && session.results.length > 0) {
+    const failures = session.results.filter((r) => r.status === 'failure');
+    if (failures.length > 0) {
+      log.step(`Auto-capturing ${failures.length} failure(s) as eval cases...`);
+      for (const failure of failures) {
+        try {
+          const step = detectFailureStep(failure);
+          saveCapturedCase({
+            issueNum: failure.issueNum,
+            title: failure.title,
+            step,
+            session: session.name,
+          });
+        } catch (err) {
+          log.warn(`Failed to auto-capture issue #${failure.issueNum}: ${err instanceof Error ? err.message : err}`);
+        }
+      }
+      log.info('Run "alpha-loop eval capture" to add failure descriptions to these cases.');
     }
   }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -59,6 +59,8 @@ export type Config = {
   evalModel: string;
   skipEval: boolean;
   evalTimeout: number;
+  /** Auto-capture failures as eval cases at end of session (default: true). */
+  autoCapture: boolean;
   /** Per-model pricing table (cost per million tokens). */
   pricing: Record<string, ModelPricing>;
 };
@@ -99,6 +101,7 @@ const DEFAULTS: Config = {
   evalModel: '',
   skipEval: false,
   evalTimeout: 300,
+  autoCapture: true,
   pricing: {
     'claude-opus-4-6': { input: 15.0, output: 75.0 },
     'claude-sonnet-4-6': { input: 3.0, output: 15.0 },
@@ -143,6 +146,7 @@ const YAML_KEY_MAP: Record<string, keyof Config> = {
   eval_model: 'evalModel',
   skip_eval: 'skipEval',
   eval_timeout: 'evalTimeout',
+  auto_capture: 'autoCapture',
 };
 
 /** Map from env var name to Config key. */
@@ -180,6 +184,7 @@ const ENV_KEY_MAP: Record<string, keyof Config> = {
   EVAL_MODEL: 'evalModel',
   SKIP_EVAL: 'skipEval',
   EVAL_TIMEOUT: 'evalTimeout',
+  AUTO_CAPTURE: 'autoCapture',
 };
 
 function coerce(value: string, current: unknown): unknown {

--- a/src/lib/eval.ts
+++ b/src/lib/eval.ts
@@ -12,14 +12,18 @@
  *   - 'step' — tests a single pipeline stage (fast, cheap, targeted)
  */
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join, basename, relative } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { log } from './logger.js';
 import type { Config } from './config.js';
+import type { PipelineResult } from './pipeline.js';
 import { computeCompositeScore, appendScore, hashConfig } from './score.js';
 import type { CaseResult, ScoreEntry } from './score.js';
 import { parseChecks } from './eval-checks.js';
 import type { CheckDefinition } from './eval-checks.js';
+
+/** Status of a captured eval case. */
+export type CapturedCaseStatus = 'needs-annotation' | 'ready';
 
 /** The pipeline step that a step-level eval targets. */
 export type PipelineStep = 'plan' | 'implement' | 'test' | 'review' | 'verify';
@@ -70,6 +74,8 @@ export type EvalCase = {
   checks?: CheckDefinition[];
   /** For step cases: raw input text (from input.md). */
   inputText?: string;
+  /** Status of captured cases ('needs-annotation' or 'ready'). */
+  captureStatus?: CapturedCaseStatus;
 };
 
 /** Result of running a single eval case. */
@@ -181,8 +187,10 @@ export function loadEvalCaseDir(dirPath: string): EvalCase | null {
     const evalType = type === 'step' ? 'step' : 'full';
 
     const checks = parseChecks(checksRaw);
-    const pipelineSteps = Array.isArray(metadata.pipeline_steps)
-      ? metadata.pipeline_steps.map(String)
+
+    // Read capture status from checks.yaml (auto-captured cases use 'needs-annotation')
+    const captureStatus = checksRaw.status === 'needs-annotation' ? 'needs-annotation' as CapturedCaseStatus
+      : checksRaw.status === 'ready' ? 'ready' as CapturedCaseStatus
       : undefined;
 
     return {
@@ -203,6 +211,7 @@ export function loadEvalCaseDir(dirPath: string): EvalCase | null {
       source: String(metadata.source ?? 'manual'),
       checks,
       inputText,
+      captureStatus,
     };
   } catch (err) {
     log.warn(`Failed to load eval case dir ${dirPath}: ${err instanceof Error ? err.message : err}`);
@@ -221,6 +230,7 @@ export function loadEvalCases(options?: {
   type?: 'full' | 'step';
   step?: PipelineStep;
   caseId?: string;
+  includeUnannotated?: boolean;
 }): EvalCase[] {
   const dir = evalsDir(options?.projectDir);
   if (!existsSync(dir)) return [];
@@ -274,6 +284,9 @@ export function loadEvalCases(options?: {
 
   // Apply filters
   const filtered = cases.filter((evalCase) => {
+    // Skip unannotated cases unless explicitly including them
+    if (evalCase.captureStatus === 'needs-annotation' && !options?.includeUnannotated) return false;
+
     // Filter by case ID prefix
     if (options?.caseId && !evalCase.id.startsWith(options.caseId)) return false;
 
@@ -457,4 +470,212 @@ export function formatEvalCase(evalCase: EvalCase): string {
   const tags = evalCase.tags.length > 0 ? ` [${evalCase.tags.join(', ')}]` : '';
   const step = evalCase.step ? ` (${evalCase.step})` : '';
   return `${evalCase.id}: ${evalCase.description} — ${evalCase.type}${step}${tags}`;
+}
+
+// ============================================================================
+// Capture Workflow — save, load, and annotate captured eval cases
+// ============================================================================
+
+/** Options for saving a captured eval case. */
+export type SaveCapturedCaseOptions = {
+  issueNum: number;
+  title: string;
+  issueBody?: string;
+  step: string;
+  session: string;
+  tags?: string[];
+  projectDir?: string;
+};
+
+/**
+ * Detect which pipeline step failed from a PipelineResult.
+ */
+export function detectFailureStep(result: PipelineResult): string {
+  if (!result.testsPassing) {
+    // If the issue's filesChanged > 0, the agent at least tried to implement;
+    // multiple retries suggest a test-fix loop failure
+    return result.filesChanged > 1 ? 'test-fix' : 'implement';
+  }
+  if (!result.verifyPassing && !result.verifySkipped) return 'verify';
+  return 'review';
+}
+
+/**
+ * Generate a slug from an issue title for directory naming.
+ */
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+}
+
+/**
+ * Save a captured eval case as a directory-based skeleton.
+ * Creates .alpha-loop/evals/cases/step/{stepName}/captured-{issueNum}-{slug}/
+ * with metadata.yaml, checks.yaml, and issue.md.
+ *
+ * Returns the path to the created case directory.
+ */
+export function saveCapturedCase(opts: SaveCapturedCaseOptions): string {
+  const dir = evalsDir(opts.projectDir);
+  const slug = slugify(opts.title);
+  const caseDirName = `captured-${String(opts.issueNum).padStart(3, '0')}-${slug}`;
+  const casePath = join(dir, 'cases', 'step', opts.step, caseDirName);
+
+  mkdirSync(casePath, { recursive: true });
+
+  // metadata.yaml
+  const metadata = stringifyYaml({
+    id: caseDirName,
+    description: opts.title,
+    tags: opts.tags ?? [],
+    source: 'auto-captured',
+    captured_from: {
+      issue: opts.issueNum,
+      session: opts.session,
+      date: new Date().toISOString().split('T')[0],
+    },
+  });
+  writeFileSync(join(casePath, 'metadata.yaml'), metadata);
+
+  // checks.yaml — skeleton with needs-annotation status
+  const checks = stringifyYaml({
+    type: 'step',
+    step: opts.step,
+    eval_method: 'pending',
+    status: 'needs-annotation',
+    source: 'auto-captured',
+    captured_from: {
+      issue: opts.issueNum,
+      session: opts.session,
+      date: new Date().toISOString().split('T')[0],
+    },
+    checks: [],
+  });
+  writeFileSync(join(casePath, 'checks.yaml'), checks);
+
+  // issue.md
+  const issueContent = `# ${opts.title}\n\n${opts.issueBody ?? `Captured from issue #${opts.issueNum}`}\n`;
+  writeFileSync(join(casePath, 'issue.md'), issueContent);
+
+  return casePath;
+}
+
+/**
+ * Load all unannotated (needs-annotation) captured cases.
+ */
+export function loadUnannotatedCases(projectDir?: string): Array<{ path: string; evalCase: EvalCase }> {
+  const cases = loadEvalCases({ projectDir, includeUnannotated: true });
+  return cases
+    .filter((c) => c.captureStatus === 'needs-annotation')
+    .map((c) => {
+      // Reconstruct the directory path from the case ID
+      const dir = evalsDir(projectDir);
+      // Search for the case directory
+      const casePath = findCaseDir(dir, c.id);
+      return { path: casePath, evalCase: c };
+    })
+    .filter((entry) => entry.path !== '');
+}
+
+/**
+ * Find a case directory by its ID within the evals directory tree.
+ */
+function findCaseDir(baseDir: string, caseId: string): string {
+  const casesDir = join(baseDir, 'cases');
+  if (!existsSync(casesDir)) return '';
+
+  for (const suiteType of ['e2e', 'step']) {
+    const suiteDir = join(casesDir, suiteType);
+    if (!existsSync(suiteDir)) continue;
+
+    if (suiteType === 'step') {
+      const stepDirs = readdirSync(suiteDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory());
+      for (const stepDir of stepDirs) {
+        const candidate = join(suiteDir, stepDir.name, caseId);
+        if (existsSync(candidate) && existsSync(join(candidate, 'checks.yaml'))) {
+          return candidate;
+        }
+        // Also check nested
+        const nested = join(suiteDir, stepDir.name);
+        if (existsSync(nested)) {
+          const subdirs = readdirSync(nested, { withFileTypes: true })
+            .filter((d) => d.isDirectory() && d.name === caseId);
+          if (subdirs.length > 0) return join(nested, subdirs[0].name);
+        }
+      }
+    } else {
+      const candidate = join(suiteDir, caseId);
+      if (existsSync(candidate) && existsSync(join(candidate, 'checks.yaml'))) {
+        return candidate;
+      }
+    }
+  }
+
+  return '';
+}
+
+/** Annotation data for a captured case. */
+export type CaseAnnotation = {
+  whatWentWrong: string;
+  whatShouldHaveHappened: string;
+  tags?: string[];
+};
+
+/**
+ * Annotate a captured case — updates checks.yaml with failure description,
+ * expected behavior, and sets status to 'ready'.
+ */
+export function annotateCapturedCase(casePath: string, annotation: CaseAnnotation): void {
+  const checksPath = join(casePath, 'checks.yaml');
+  if (!existsSync(checksPath)) {
+    throw new Error(`No checks.yaml found at ${casePath}`);
+  }
+
+  const checksRaw = parseYaml(readFileSync(checksPath, 'utf-8')) as Record<string, unknown>;
+
+  checksRaw.status = 'ready';
+  checksRaw.eval_method = 'annotated';
+  checksRaw.failure_description = annotation.whatWentWrong;
+  checksRaw.expected_behavior = annotation.whatShouldHaveHappened;
+
+  // Add keyword checks based on the annotation
+  const checks: Array<Record<string, unknown>> = [];
+  if (annotation.whatShouldHaveHappened) {
+    checks.push({
+      type: 'keyword_present',
+      keywords: extractKeywords(annotation.whatShouldHaveHappened),
+    });
+  }
+  if (checks.length > 0) {
+    checksRaw.checks = checks;
+  }
+
+  writeFileSync(checksPath, stringifyYaml(checksRaw));
+
+  // Update metadata tags if provided
+  if (annotation.tags && annotation.tags.length > 0) {
+    const metadataPath = join(casePath, 'metadata.yaml');
+    if (existsSync(metadataPath)) {
+      const metadata = parseYaml(readFileSync(metadataPath, 'utf-8')) as Record<string, unknown>;
+      const existingTags = Array.isArray(metadata.tags) ? metadata.tags.map(String) : [];
+      metadata.tags = [...new Set([...existingTags, ...annotation.tags])];
+      writeFileSync(metadataPath, stringifyYaml(metadata));
+    }
+  }
+}
+
+/**
+ * Extract meaningful keywords from annotation text for keyword_present checks.
+ */
+function extractKeywords(text: string): string[] {
+  // Split on common delimiters and take meaningful words (>3 chars)
+  return text
+    .split(/[\s,;.!?]+/)
+    .filter((w) => w.length > 3)
+    .map((w) => w.toLowerCase())
+    .slice(0, 5);
 }

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -116,6 +116,7 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
     evalModel: '',
     skipEval: false,
     evalTimeout: 300,
+    autoCapture: true,
     pricing: {},
     ...overrides,
   };

--- a/tests/engine/prerequisites.test.ts
+++ b/tests/engine/prerequisites.test.ts
@@ -51,6 +51,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalModel: '',
     skipEval: false,
     evalTimeout: 300,
+    autoCapture: true,
     pricing: {},
     ...overrides,
   };

--- a/tests/eval-capture.test.ts
+++ b/tests/eval-capture.test.ts
@@ -1,0 +1,379 @@
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parse as parseYaml } from 'yaml';
+import {
+  detectFailureStep,
+  saveCapturedCase,
+  loadUnannotatedCases,
+  annotateCapturedCase,
+  loadEvalCases,
+} from '../src/lib/eval.js';
+import type { PipelineResult } from '../src/lib/pipeline.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-capture-test-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function makePipelineResult(overrides: Partial<PipelineResult> = {}): PipelineResult {
+  return {
+    issueNum: 47,
+    title: 'Add health endpoint',
+    status: 'failure',
+    testsPassing: false,
+    verifyPassing: false,
+    verifySkipped: true,
+    duration: 120,
+    filesChanged: 0,
+    ...overrides,
+  };
+}
+
+describe('detectFailureStep', () => {
+  it('returns "implement" when tests not passing and no files changed', () => {
+    const result = makePipelineResult({ testsPassing: false, filesChanged: 0 });
+    expect(detectFailureStep(result)).toBe('implement');
+  });
+
+  it('returns "implement" when tests not passing and 1 file changed', () => {
+    const result = makePipelineResult({ testsPassing: false, filesChanged: 1 });
+    expect(detectFailureStep(result)).toBe('implement');
+  });
+
+  it('returns "test-fix" when tests not passing and multiple files changed', () => {
+    const result = makePipelineResult({ testsPassing: false, filesChanged: 3 });
+    expect(detectFailureStep(result)).toBe('test-fix');
+  });
+
+  it('returns "verify" when tests pass but verify fails', () => {
+    const result = makePipelineResult({
+      testsPassing: true,
+      verifyPassing: false,
+      verifySkipped: false,
+    });
+    expect(detectFailureStep(result)).toBe('verify');
+  });
+
+  it('returns "review" when tests and verify pass (or verify skipped)', () => {
+    const result = makePipelineResult({
+      testsPassing: true,
+      verifyPassing: false,
+      verifySkipped: true,
+    });
+    expect(detectFailureStep(result)).toBe('review');
+  });
+
+  it('returns "review" when everything passes but status is failure', () => {
+    const result = makePipelineResult({
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+    });
+    expect(detectFailureStep(result)).toBe('review');
+  });
+});
+
+describe('saveCapturedCase', () => {
+  it('creates the correct directory structure', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    expect(existsSync(casePath)).toBe(true);
+    expect(existsSync(join(casePath, 'metadata.yaml'))).toBe(true);
+    expect(existsSync(join(casePath, 'checks.yaml'))).toBe(true);
+    expect(existsSync(join(casePath, 'issue.md'))).toBe(true);
+  });
+
+  it('writes correct metadata.yaml', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      tags: ['typescript', 'api'],
+      projectDir: tempDir,
+    });
+
+    const metadata = parseYaml(readFileSync(join(casePath, 'metadata.yaml'), 'utf-8')) as Record<string, unknown>;
+    expect(metadata.source).toBe('auto-captured');
+    expect(metadata.tags).toEqual(['typescript', 'api']);
+    expect((metadata.captured_from as Record<string, unknown>).issue).toBe(47);
+    expect((metadata.captured_from as Record<string, unknown>).session).toBe('session/20260401-120000');
+  });
+
+  it('writes checks.yaml with needs-annotation status', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    const checks = parseYaml(readFileSync(join(casePath, 'checks.yaml'), 'utf-8')) as Record<string, unknown>;
+    expect(checks.type).toBe('step');
+    expect(checks.step).toBe('implement');
+    expect(checks.status).toBe('needs-annotation');
+    expect(checks.eval_method).toBe('pending');
+    expect(checks.checks).toEqual([]);
+  });
+
+  it('writes issue.md with title and body', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      issueBody: 'We need a GET /health route.',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    const issueContent = readFileSync(join(casePath, 'issue.md'), 'utf-8');
+    expect(issueContent).toContain('# Add health endpoint');
+    expect(issueContent).toContain('We need a GET /health route.');
+  });
+
+  it('creates correct directory path under step/{stepName}/', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 52,
+      title: 'Fix CSV parser',
+      step: 'test-fix',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    expect(casePath).toContain(join('cases', 'step', 'test-fix'));
+    expect(casePath).toContain('captured-052');
+  });
+
+  it('pads issue number to 3 digits', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 5,
+      title: 'Small fix',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    expect(casePath).toContain('captured-005');
+  });
+});
+
+describe('loadUnannotatedCases', () => {
+  it('returns empty when no cases exist', () => {
+    expect(loadUnannotatedCases(tempDir)).toEqual([]);
+  });
+
+  it('finds needs-annotation cases', () => {
+    saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    saveCapturedCase({
+      issueNum: 52,
+      title: 'Fix CSV parser',
+      step: 'test-fix',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    const unannotated = loadUnannotatedCases(tempDir);
+    expect(unannotated).toHaveLength(2);
+    expect(unannotated[0].evalCase.captureStatus).toBe('needs-annotation');
+    expect(unannotated[1].evalCase.captureStatus).toBe('needs-annotation');
+  });
+
+  it('excludes annotated cases', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    // Annotate it
+    annotateCapturedCase(casePath, {
+      whatWentWrong: 'Agent used wrong imports',
+      whatShouldHaveHappened: 'Check package.json type field',
+    });
+
+    const unannotated = loadUnannotatedCases(tempDir);
+    expect(unannotated).toHaveLength(0);
+  });
+});
+
+describe('annotateCapturedCase', () => {
+  it('updates status to ready', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    annotateCapturedCase(casePath, {
+      whatWentWrong: 'Agent wrote ESM imports but project uses CommonJS',
+      whatShouldHaveHappened: 'Check package.json type field and tsconfig before writing imports',
+    });
+
+    const checks = parseYaml(readFileSync(join(casePath, 'checks.yaml'), 'utf-8')) as Record<string, unknown>;
+    expect(checks.status).toBe('ready');
+    expect(checks.eval_method).toBe('annotated');
+    expect(checks.failure_description).toBe('Agent wrote ESM imports but project uses CommonJS');
+    expect(checks.expected_behavior).toBe('Check package.json type field and tsconfig before writing imports');
+  });
+
+  it('adds keyword_present checks from annotation', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    annotateCapturedCase(casePath, {
+      whatWentWrong: 'Wrong format',
+      whatShouldHaveHappened: 'Check package.json type field and tsconfig before writing imports',
+    });
+
+    const checks = parseYaml(readFileSync(join(casePath, 'checks.yaml'), 'utf-8')) as Record<string, unknown>;
+    const checksList = checks.checks as Array<Record<string, unknown>>;
+    expect(checksList.length).toBeGreaterThan(0);
+    expect(checksList[0].type).toBe('keyword_present');
+  });
+
+  it('updates tags in metadata when provided', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      tags: ['existing'],
+      projectDir: tempDir,
+    });
+
+    annotateCapturedCase(casePath, {
+      whatWentWrong: 'Wrong imports',
+      whatShouldHaveHappened: 'Check tsconfig',
+      tags: ['typescript', 'imports'],
+    });
+
+    const metadata = parseYaml(readFileSync(join(casePath, 'metadata.yaml'), 'utf-8')) as Record<string, unknown>;
+    expect(metadata.tags).toEqual(expect.arrayContaining(['existing', 'typescript', 'imports']));
+  });
+
+  it('throws when casePath has no checks.yaml', () => {
+    const fakePath = join(tempDir, 'nonexistent');
+    mkdirSync(fakePath, { recursive: true });
+
+    expect(() =>
+      annotateCapturedCase(fakePath, {
+        whatWentWrong: 'test',
+        whatShouldHaveHappened: 'test',
+      }),
+    ).toThrow('No checks.yaml found');
+  });
+});
+
+describe('loadEvalCases — unannotated filtering', () => {
+  it('excludes needs-annotation cases by default', () => {
+    saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    const cases = loadEvalCases({ projectDir: tempDir });
+    expect(cases).toHaveLength(0);
+  });
+
+  it('includes needs-annotation cases when includeUnannotated is true', () => {
+    saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    const cases = loadEvalCases({ projectDir: tempDir, includeUnannotated: true });
+    expect(cases).toHaveLength(1);
+    expect(cases[0].captureStatus).toBe('needs-annotation');
+  });
+
+  it('includes annotated captured cases in normal eval runs', () => {
+    const casePath = saveCapturedCase({
+      issueNum: 47,
+      title: 'Add health endpoint',
+      step: 'implement',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    annotateCapturedCase(casePath, {
+      whatWentWrong: 'Wrong imports',
+      whatShouldHaveHappened: 'Check tsconfig',
+    });
+
+    const cases = loadEvalCases({ projectDir: tempDir });
+    expect(cases).toHaveLength(1);
+    expect(cases[0].captureStatus).toBe('ready');
+  });
+});
+
+describe('auto-capture integration', () => {
+  it('saveCapturedCase + annotateCapturedCase produces a runnable case', () => {
+    // Simulate auto-capture
+    const casePath = saveCapturedCase({
+      issueNum: 58,
+      title: 'Add dark mode toggle',
+      step: 'verify',
+      session: 'session/20260401-120000',
+      projectDir: tempDir,
+    });
+
+    // Verify skeleton
+    let checks = parseYaml(readFileSync(join(casePath, 'checks.yaml'), 'utf-8')) as Record<string, unknown>;
+    expect(checks.status).toBe('needs-annotation');
+    expect(checks.checks).toEqual([]);
+
+    // Simulate annotation
+    annotateCapturedCase(casePath, {
+      whatWentWrong: 'Dark mode toggle did not persist across page reload',
+      whatShouldHaveHappened: 'Toggle state should be saved to localStorage',
+      tags: ['ui', 'persistence'],
+    });
+
+    // Verify annotated state
+    checks = parseYaml(readFileSync(join(casePath, 'checks.yaml'), 'utf-8')) as Record<string, unknown>;
+    expect(checks.status).toBe('ready');
+    expect(checks.failure_description).toContain('persist');
+    expect(checks.expected_behavior).toContain('localStorage');
+
+    // Should now appear in normal eval case loading
+    const cases = loadEvalCases({ projectDir: tempDir });
+    expect(cases).toHaveLength(1);
+    expect(cases[0].id).toContain('captured-058');
+    expect(cases[0].step).toBe('verify');
+  });
+});

--- a/tests/lib/eval-runner.test.ts
+++ b/tests/lib/eval-runner.test.ts
@@ -34,6 +34,7 @@ const makeConfig = (overrides?: Partial<Config>): Config => ({
   evalModel: '',
   skipEval: false,
   evalTimeout: 300,
+    autoCapture: true,
   pricing: {},
   ...overrides,
 } as Config);

--- a/tests/lib/learning.test.ts
+++ b/tests/lib/learning.test.ts
@@ -76,6 +76,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalModel: '',
     skipEval: false,
     evalTimeout: 300,
+    autoCapture: true,
     pricing: {},
     ...overrides,
   };

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -124,6 +124,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalModel: '',
     skipEval: false,
     evalTimeout: 300,
+    autoCapture: true,
     pricing: {
       'claude-opus-4-6': { input: 15.0, output: 75.0 },
       'claude-sonnet-4-6': { input: 3.0, output: 15.0 },

--- a/tests/lib/session.test.ts
+++ b/tests/lib/session.test.ts
@@ -77,6 +77,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalModel: '',
     skipEval: false,
     evalTimeout: 300,
+    autoCapture: true,
     pricing: {},
     ...overrides,
   };

--- a/tests/lib/testing.test.ts
+++ b/tests/lib/testing.test.ts
@@ -63,6 +63,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalModel: '',
     skipEval: false,
     evalTimeout: 300,
+    autoCapture: true,
     pricing: {},
     ...overrides,
   };

--- a/tests/lib/verify.test.ts
+++ b/tests/lib/verify.test.ts
@@ -51,6 +51,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalModel: '',
     skipEval: false,
     evalTimeout: 300,
+    autoCapture: true,
     pricing: {},
     ...overrides,
   };


### PR DESCRIPTION
Closes #93

## Summary

Automated implementation of **feat: eval capture workflow — alpha-loop eval capture**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

Eval capture workflow fully implements all 7 acceptance criteria with good test coverage (379-line dedicated test file). Build and all 383 tests pass.

- **INFO** [OPEN] `src/commands/eval.ts`: globalIdx variable in evalCaptureCommand (eval.ts:248) is incremented but never read — unused dead code

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*