### PR TITLE
feat: Deprecate  in favor of  (closes #118)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,10 @@ alpha-loop run           # Run the loop continuously
 alpha-loop run --once    # Process one issue and exit
 alpha-loop run --dry-run # Dry run (preview, no changes)
 alpha-loop scan          # Generate/refresh project context
-alpha-loop vision        # Interactive project vision setup
+alpha-loop plan          # Generate project scope (milestones + issues) from seed inputs
+alpha-loop triage        # Analyze and improve existing issues
+alpha-loop roadmap       # Organize open issues into milestones
+alpha-loop vision        # (deprecated) Use "alpha-loop plan" instead
 alpha-loop auth          # Save authenticated browser state
 alpha-loop resume        # Resume stranded work from crashed sessions
 alpha-loop resume --issue 34     # Resume a specific issue

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop run` | Fetch matching issues, process them all, then exit |
 | `alpha-loop run --dry-run` | Preview without making changes |
 | `alpha-loop scan` | Generate/refresh project context and instructions file |
-| `alpha-loop vision` | Interactive project vision setup (`.alpha-loop/vision.md`) |
+| `alpha-loop vision` | **(deprecated)** Use `alpha-loop plan` instead |
 | `alpha-loop auth` | Save authenticated browser state for verification |
 | `alpha-loop history` | View session history |
 | `alpha-loop history <name>` | View a specific session |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ program
 
 program
   .command('vision')
-  .description('Interactive project vision setup')
+  .description('(deprecated) Interactive project vision setup — use "plan" instead')
   .action(visionCommand);
 
 program

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -399,18 +399,15 @@ export async function initCommand(): Promise<void> {
   log.step('Step 5: Playwright CLI');
   installPlaywrightSkills(projectDir, projectTemplatesDir);
 
-  // --- Step 6: Vision (interactive) ---
-  if (process.stdin.isTTY) {
+  // --- Step 6: Vision ---
+  {
     const { hasVision } = await import('../lib/vision.js');
     if (!hasVision()) {
       log.step('Step 6: Project vision');
-      const { visionCommand } = await import('./vision.js');
-      await visionCommand();
+      log.info('Run "alpha-loop plan" to set up your project vision and scope');
     } else {
       log.step('Step 6: Project vision (already exists)');
     }
-  } else {
-    log.step('Step 6: Project vision (skipped — non-interactive)');
   }
 
   // --- Step 7: Scan (context + instructions) ---

--- a/src/commands/vision.ts
+++ b/src/commands/vision.ts
@@ -34,6 +34,8 @@ const PRIORITIES: Record<string, string> = {
 };
 
 export async function visionCommand(): Promise<void> {
+  log.warn('vision is deprecated — use "alpha-loop plan" instead');
+
   if (!process.stdin.isTTY) {
     log.info('Not running in an interactive terminal. Skipping vision setup.');
     return;

--- a/tests/commands/vision.test.ts
+++ b/tests/commands/vision.test.ts
@@ -14,7 +14,7 @@ describe('vision', () => {
     errorSpy.mockRestore();
   });
 
-  it('skips when not running in an interactive terminal', async () => {
+  it('shows deprecation warning', async () => {
     const origIsTTY = process.stdin.isTTY;
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
 
@@ -22,6 +22,21 @@ describe('vision', () => {
 
     // Logger outputs to console.error
     const output = errorSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+    expect(output).toContain('vision is deprecated');
+    expect(output).toContain('alpha-loop plan');
+
+    Object.defineProperty(process.stdin, 'isTTY', { value: origIsTTY, configurable: true });
+  });
+
+  it('still works after deprecation warning (not removed)', async () => {
+    const origIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+
+    await visionCommand();
+
+    const output = errorSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+    // Deprecation warning shown first, then skips due to non-TTY
+    expect(output).toContain('vision is deprecated');
     expect(output).toContain('Not running in an interactive terminal');
 
     Object.defineProperty(process.stdin, 'isTTY', { value: origIsTTY, configurable: true });


### PR DESCRIPTION
Closes #118

## Summary

Automated implementation of **Deprecate `alpha-loop vision` in favor of `alpha-loop plan`**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | SKIPPED |

## Code Review

All acceptance criteria met: vision deprecated with warning, still works, docs updated, init suggests plan, plan reads existing vision.md

- **INFO** [FIXED] `src/cli.ts`: The commit also includes plan, triage, and roadmap commands (from issues #115-#117) — this is expected as those were prerequisite PRs merged into the branch
- **INFO** [OPEN] `src/commands/init.ts`: init.ts Step 12 log says 'Step 11' (pre-existing typo, not introduced by this PR)

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*