### PR TITLE
feat: batch learnings + alpha-loop learn command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,6 +114,16 @@ program
   });
 
 program
+  .command('learn')
+  .description('Backfill learnings from existing session traces')
+  .option('--session <name>', 'Only process a specific session (supports partial match)')
+  .option('--dry-run', 'Show what would be extracted without running agents')
+  .action(async (options) => {
+    const { learnCommand } = await import('./commands/learn.js');
+    await learnCommand(options);
+  });
+
+program
   .command('review')
   .description('Analyze accumulated learnings and propose self-improvements to agents, skills, and config')
   .option('--apply', 'Apply proposed changes and open a draft PR')

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -1,0 +1,169 @@
+/**
+ * Learn command — backfill learnings from existing session traces.
+ * Finds issues with trace metadata but no corresponding learning file,
+ * then runs learning extraction for each one.
+ */
+
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { loadConfig } from '../lib/config.js';
+import { extractLearnings } from '../lib/learning.js';
+import { log } from '../lib/logger.js';
+import {
+  listTraceSessions,
+  listTraceIssues,
+  readTraceMetadata,
+  readTrace,
+} from '../lib/traces.js';
+
+export type LearnOptions = {
+  session?: string;
+  dryRun?: boolean;
+};
+
+/**
+ * Check if a learning file already exists for an issue within a given session.
+ * Learning files follow the pattern: issue-{num}-{timestamp}.md
+ * We match on the issue number prefix, not the timestamp, since
+ * multiple runs of the same issue could exist.
+ */
+function hasLearningForIssue(learningsDir: string, issueNum: number, sessionName: string): boolean {
+  if (!existsSync(learningsDir)) return false;
+  const prefix = `issue-${issueNum}-`;
+  return readdirSync(learningsDir)
+    .some((f) => f.startsWith(prefix) && f.endsWith('.md'));
+}
+
+export async function learnCommand(options: LearnOptions): Promise<void> {
+  const projectDir = process.cwd();
+  const config = loadConfig({ dryRun: options.dryRun });
+  const learningsDir = join(projectDir, '.alpha-loop', 'learnings');
+
+  // Discover sessions with traces
+  const allSessions = listTraceSessions(projectDir);
+  if (allSessions.length === 0) {
+    log.warn('No session traces found in .alpha-loop/traces/. Run the loop first.');
+    return;
+  }
+
+  // Filter to requested session or use all
+  let sessions: string[];
+  if (options.session) {
+    // Allow partial match (e.g. "20260414" matches "session/20260414-143022")
+    sessions = allSessions.filter((s) => s.includes(options.session!));
+    if (sessions.length === 0) {
+      log.error(`No sessions matching "${options.session}". Available sessions:`);
+      for (const s of allSessions.slice(0, 10)) {
+        console.log(`  ${s}`);
+      }
+      return;
+    }
+  } else {
+    sessions = allSessions;
+  }
+
+  log.info(`Found ${sessions.length} session(s) to check for missing learnings`);
+
+  // Collect issues that need learning extraction
+  type PendingIssue = {
+    session: string;
+    issueNum: number;
+    title: string;
+    body: string;
+    status: string;
+    retries: number;
+    duration: number;
+    diff: string;
+    testOutput: string;
+    reviewOutput: string;
+    verifyOutput: string;
+  };
+
+  const pending: PendingIssue[] = [];
+  let skipped = 0;
+
+  for (const sessionName of sessions) {
+    const issueNums = listTraceIssues(sessionName, projectDir);
+
+    for (const issueNum of issueNums) {
+      // Skip if learning already exists for this issue
+      if (hasLearningForIssue(learningsDir, issueNum, sessionName)) {
+        skipped++;
+        continue;
+      }
+
+      const metadata = readTraceMetadata(sessionName, issueNum, projectDir);
+      if (!metadata) continue;
+
+      // Read available trace data
+      const diff = readTrace(sessionName, issueNum, 'diff.patch', projectDir) ?? '';
+      const testOutput = readTrace(sessionName, issueNum, 'test-output.txt', projectDir) ?? '';
+      const reviewOutput = readTrace(sessionName, issueNum, 'review-output.json', projectDir) ?? '';
+      const verifyOutput = readTrace(sessionName, issueNum, 'verify-output.json', projectDir) ?? '';
+
+      pending.push({
+        session: sessionName,
+        issueNum,
+        title: metadata.title,
+        body: '', // Issue body isn't stored in traces; agent will work from diff + test output
+        status: metadata.status,
+        retries: metadata.retries,
+        duration: metadata.duration,
+        diff,
+        testOutput,
+        reviewOutput,
+        verifyOutput,
+      });
+    }
+  }
+
+  if (pending.length === 0) {
+    log.success(`All issues already have learnings (${skipped} skipped).`);
+    return;
+  }
+
+  log.info(`${pending.length} issue(s) need learning extraction, ${skipped} already have learnings`);
+  console.log('');
+  for (const p of pending) {
+    console.log(`  #${p.issueNum} — ${p.title} (${p.session})`);
+  }
+  console.log('');
+
+  if (options.dryRun) {
+    log.dry(`Would extract learnings for ${pending.length} issue(s).`);
+    return;
+  }
+
+  // Extract learnings for each pending issue
+  let extracted = 0;
+  let failed = 0;
+
+  for (const p of pending) {
+    log.step(`[${extracted + failed + 1}/${pending.length}] Extracting learnings for #${p.issueNum}: ${p.title}`);
+
+    try {
+      await extractLearnings({
+        issueNum: p.issueNum,
+        title: p.title,
+        status: p.status,
+        retries: p.retries,
+        duration: p.duration,
+        diff: p.diff,
+        testOutput: p.testOutput,
+        reviewOutput: p.reviewOutput,
+        verifyOutput: p.verifyOutput,
+        body: p.body,
+        config,
+        sessionLogsDir: join(projectDir, '.alpha-loop', 'traces', p.session),
+        sessionName: p.session,
+      });
+      extracted++;
+    } catch (err) {
+      log.warn(`Failed to extract learnings for #${p.issueNum}: ${err}`);
+      failed++;
+    }
+  }
+
+  console.log('');
+  log.success(`Learning extraction complete: ${extracted} extracted, ${failed} failed, ${skipped} already existed`);
+}

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -1491,17 +1491,22 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     }
   }
 
-  // --- Step 9: Update each issue individually ---
+  // --- Step 9: Update each issue individually + extract learnings ---
   log.step('Batch Step 8: Updating individual issues');
   const duration = Math.round((Date.now() - startTime) / 1000);
   const perIssueDuration = Math.round(duration / issues.length);
 
-  // Get diff for traces
+  // Get diff for traces and learning analysis
   let runDiff = '';
   if (!config.dryRun) {
     const diffResult = exec(`git diff "origin/${config.baseBranch}...HEAD"`, { cwd: worktreePath });
     runDiff = diffResult.stdout.slice(0, MAX_DIFF_CHARS);
   }
+
+  // Format review gate for learnings (same format as single-issue pipeline)
+  const reviewForLearnings = reviewGate.findings.length > 0
+    ? `Review: ${reviewGate.summary}\n${reviewGate.findings.map((f) => `- [${f.severity}] ${f.description} (${f.fixed ? 'fixed' : 'unfixed'})`).join('\n')}`
+    : `Review: ${reviewGate.summary || 'passed'}`;
 
   const filesChanged = runDiff ? (runDiff.match(/^diff --git/gm) ?? []).length : 0;
   const results: PipelineResult[] = [];
@@ -1530,6 +1535,23 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
     results.push(result);
     saveResult(session, result);
+
+    // Extract learnings per issue
+    await extractLearnings({
+      issueNum: issue.number,
+      title: issue.title,
+      status: testsPassing ? 'success' : 'failure',
+      retries: 0,
+      duration: perIssueDuration,
+      diff: runDiff,
+      testOutput,
+      reviewOutput: reviewForLearnings,
+      verifyOutput: '',
+      body: issue.body,
+      config,
+      sessionLogsDir: session.logsDir,
+      sessionName: session.name,
+    });
 
     // Write per-issue traces
     if (!config.dryRun) {
@@ -1570,6 +1592,8 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
     log.success(`Issue #${issue.number} updated`);
   }
+
+  stepsCompleted.push('learn');
 
   // Write aggregate scores and costs
   if (!config.dryRun) {


### PR DESCRIPTION
## Summary
- **Batch mode learning extraction**: `processBatch` was skipping `extractLearnings` entirely — trace metadata (JSON) was written but no learning `.md` files were generated. Added per-issue learning extraction using the same pattern as the single-issue pipeline.
- **New `alpha-loop learn` command**: Backfills learnings from existing session traces. Scans `.alpha-loop/traces/` for issues with metadata but no corresponding learning file, then runs extraction for each one.

## Usage
```bash
alpha-loop learn                          # Backfill all sessions
alpha-loop learn --session 20260414       # Partial match on session name
alpha-loop learn --dry-run                # Preview what would be extracted
```

## Test plan
- [x] `pnpm build` passes
- [x] All 702 tests pass
- [ ] Run `alpha-loop learn --dry-run` against a repo with existing batch session traces
- [ ] Run `alpha-loop learn` and verify `.md` files appear in `.alpha-loop/learnings/`
- [ ] Run batch mode and verify learnings are now extracted inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)