### PR TITLE
fix: review --apply fails when sync dirs don't exist

### DIFF
--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -415,18 +415,19 @@ async function applyChanges(
   }
 
   // Stage and commit changes (including synced copies)
-  const stageResult = exec(
-    `git add ${appliedPaths.map((p) => JSON.stringify(p)).join(' ')} .alpha-loop/templates/ .claude/ .agents/ .codex/ 2>/dev/null || true`,
-    { cwd: projectDir },
-  );
+  // Build git add paths: applied files + only sync dirs that actually exist
+  const syncDirs = ['.alpha-loop/templates/', '.claude/', '.agents/', '.codex/']
+    .filter((d) => existsSync(join(projectDir, d)));
+  const addPaths = [...appliedPaths.map((p) => JSON.stringify(p)), ...syncDirs.map((d) => JSON.stringify(d))];
+  const stageResult = exec(`git add ${addPaths.join(' ')}`, { cwd: projectDir });
   if (stageResult.exitCode !== 0) {
-    throw new Error(`Failed to stage changes: ${stageResult.stderr}`);
+    throw new Error(`Failed to stage changes: ${stageResult.stderr || stageResult.stdout}`);
   }
 
   const commitMsg = `improve: apply ${appliedPaths.length} learning-driven improvement(s)`;
   const commitResult = exec(`git commit -m ${JSON.stringify(commitMsg)}`, { cwd: projectDir });
   if (commitResult.exitCode !== 0) {
-    throw new Error(`Failed to commit: ${commitResult.stderr}`);
+    throw new Error(`Failed to commit: ${commitResult.stderr || commitResult.stdout}`);
   }
 
   // Build PR body


### PR DESCRIPTION
## Summary
- `review --apply` crashes with empty "Failed to commit:" error when target project lacks `.agents/` or `.codex/` directories
- Root cause: `git add` fails atomically — if any path doesn't exist, *nothing* gets staged. The `2>/dev/null || true` masked the failure, so `git commit` then failed with "nothing to commit" (on stdout, not stderr, making the error message empty)
- Fix: filter sync directories with `existsSync` before passing to `git add`, and fall back to `stdout` in error messages

## Test plan
- [ ] Run `alpha-loop review --apply` in a project that only has `.claude/` (no `.agents/` or `.codex/`)
- [ ] Verify changes are staged and committed successfully
- [ ] Verify PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)