### PR TITLE
feat: 3-digit zero-padded milestone prefixes

### DIFF
--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -16,6 +16,7 @@ import { getRateLimitStatus } from '../lib/rate-limit.js';
 import {
   extractJsonFromResponse,
   formatIssueTable,
+  normalizePlanMilestones,
   readSeedFiles,
   savePlanDraft,
   loadPlanDraft,
@@ -263,6 +264,9 @@ export async function planCommand(options: PlanOptions): Promise<void> {
       log.error(`Agent response (first 500 chars): ${planResult.stdout.slice(0, 500)}`);
       return;
     }
+
+    // Normalize milestone titles to use 3-digit zero-padded prefixes
+    draft = normalizePlanMilestones(draft);
 
     // ── Display plan ─────────────────────────────────────────────────────────
     console.log('');

--- a/src/commands/roadmap.ts
+++ b/src/commands/roadmap.ts
@@ -15,6 +15,7 @@ import { log } from '../lib/logger.js';
 import {
   extractJsonFromResponse,
   formatRoadmapTable,
+  normalizeRoadmapMilestones,
   buildPlanningContext,
   type PlannedMilestone,
   type RoadmapAssignment,
@@ -117,6 +118,11 @@ export async function roadmapCommand(options: RoadmapOptions): Promise<void> {
     log.info('Agent returned no roadmap assignments.');
     return;
   }
+
+  // Normalize milestone titles to use 3-digit zero-padded prefixes
+  const normalizedRoadmap = normalizeRoadmapMilestones(parsed.milestones, parsed.assignments);
+  parsed.milestones = normalizedRoadmap.milestones;
+  parsed.assignments = normalizedRoadmap.assignments;
 
   // ── Display roadmap ────────────────────────────────────────────────────────
   const existingTitles = existingMilestones.map((m) => m.title);

--- a/src/lib/planning.ts
+++ b/src/lib/planning.ts
@@ -91,6 +91,65 @@ const COMPLEXITY_COLORS: Record<Complexity, string> = {
 // ── Functions ────────────────────────────────────────────────────────────────
 
 /**
+ * Ensure milestone titles are prefixed with a zero-padded 3-digit order number.
+ * e.g. "MVP" with order 1 → "001 - MVP", "Core Features" with order 10 → "010 - Core Features".
+ * If the title already has a valid prefix, it is left as-is.
+ */
+export function normalizeMilestoneTitles(milestones: PlannedMilestone[]): PlannedMilestone[] {
+  const prefixPattern = /^\d{3} - /;
+  return milestones.map((ms) => {
+    if (prefixPattern.test(ms.title)) return ms;
+    const prefix = String(ms.order).padStart(3, '0');
+    return { ...ms, title: `${prefix} - ${ms.title}` };
+  });
+}
+
+/**
+ * Normalize a full plan draft: prefix milestone titles and update issue references.
+ */
+export function normalizePlanMilestones(draft: PlanDraft): PlanDraft {
+  const originalTitles = draft.milestones.map((ms) => ms.title);
+  const normalized = normalizeMilestoneTitles(draft.milestones);
+  const titleMap = new Map<string, string>();
+  for (let i = 0; i < originalTitles.length; i++) {
+    if (originalTitles[i] !== normalized[i].title) {
+      titleMap.set(originalTitles[i], normalized[i].title);
+    }
+  }
+  const issues = titleMap.size > 0
+    ? draft.issues.map((issue) => {
+        const mapped = titleMap.get(issue.milestone);
+        return mapped ? { ...issue, milestone: mapped } : issue;
+      })
+    : draft.issues;
+  return { ...draft, milestones: normalized, issues };
+}
+
+/**
+ * Normalize roadmap milestones and update assignment references.
+ */
+export function normalizeRoadmapMilestones(
+  milestones: PlannedMilestone[],
+  assignments: RoadmapAssignment[],
+): { milestones: PlannedMilestone[]; assignments: RoadmapAssignment[] } {
+  const originalTitles = milestones.map((ms) => ms.title);
+  const normalized = normalizeMilestoneTitles(milestones);
+  const titleMap = new Map<string, string>();
+  for (let i = 0; i < originalTitles.length; i++) {
+    if (originalTitles[i] !== normalized[i].title) {
+      titleMap.set(originalTitles[i], normalized[i].title);
+    }
+  }
+  const updatedAssignments = titleMap.size > 0
+    ? assignments.map((a) => {
+        const mapped = titleMap.get(a.milestone);
+        return mapped ? { ...a, milestone: mapped } : a;
+      })
+    : assignments;
+  return { milestones: normalized, assignments: updatedAssignments };
+}
+
+/**
  * Extract JSON from an AI agent response that may include markdown fences,
  * explanatory text, or other noise around the JSON payload.
  */

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -882,7 +882,7 @@ export function buildRoadmapPrompt(options: RoadmapPromptOptions): string {
     '{',
     '  "milestones": [',
     '    {',
-    '      "title": "Milestone Name",',
+    '      "title": "001 - Milestone Name",',
     '      "description": "What this milestone delivers",',
     '      "dueOn": "2026-05-01",',
     '      "order": 1',
@@ -892,7 +892,7 @@ export function buildRoadmapPrompt(options: RoadmapPromptOptions): string {
     '    {',
     '      "issueNum": 3,',
     '      "title": "Issue title",',
-    '      "milestone": "Milestone Name",',
+    '      "milestone": "001 - Milestone Name",',
     '      "currentMilestone": "",',
     '      "selected": true',
     '    }',
@@ -910,6 +910,7 @@ export function buildRoadmapPrompt(options: RoadmapPromptOptions): string {
     '- Set `selected: true` for all assignments (user will deselect if needed)',
     '- Order milestones by suggested execution order (order field)',
     '- Group related issues together (same feature area, same dependency chain)',
+    '- Milestone titles MUST be prefixed with a zero-padded 3-digit number matching their order, e.g. "001 - Foundation", "002 - Core Features", "010 - Polish"',
   );
 
   return sections.join('\n');
@@ -983,7 +984,7 @@ export function buildPlanPrompt(options: PlanPromptOptions): string {
     '  "vision": null,',
     '  "milestones": [',
     '    {',
-    '      "title": "Milestone Name",',
+    '      "title": "001 - Milestone Name",',
     '      "description": "What this milestone delivers",',
     '      "dueOn": "2026-05-01",',
     '      "order": 1',
@@ -995,7 +996,7 @@ export function buildPlanPrompt(options: PlanPromptOptions): string {
     '      "title": "Issue title",',
     '      "body": "## Summary\\n...\\n\\n## Acceptance Criteria\\n- [ ] Criterion 1\\n- [ ] Criterion 2",',
     '      "labels": ["enhancement"],',
-    '      "milestone": "Milestone Name",',
+    '      "milestone": "001 - Milestone Name",',
     '      "priority": "p1",',
     '      "complexity": "medium",',
     '      "dependsOn": [],',
@@ -1017,6 +1018,7 @@ export function buildPlanPrompt(options: PlanPromptOptions): string {
     '- Reuse existing milestones when the work fits; only create new milestones for genuinely new scope',
     '- Consider the codebase structure for realistic issue scoping',
     '- Issue `id` values are temporary local IDs (1, 2, 3...) used only for dependency references',
+    '- Milestone titles MUST be prefixed with a zero-padded 3-digit number matching their order, e.g. "001 - Foundation", "002 - Core Features", "010 - Polish"',
   );
 
   return sections.join('\n');

--- a/tests/commands/plan.test.ts
+++ b/tests/commands/plan.test.ts
@@ -56,6 +56,7 @@ jest.mock('../../src/lib/rate-limit', () => ({
 jest.mock('../../src/lib/planning', () => ({
   extractJsonFromResponse: jest.fn(),
   formatIssueTable: jest.fn(() => 'FORMATTED TABLE'),
+  normalizePlanMilestones: jest.requireActual('../../src/lib/planning').normalizePlanMilestones,
   readSeedFiles: jest.fn(() => []),
   savePlanDraft: jest.fn(),
   loadPlanDraft: jest.fn(() => null),
@@ -104,7 +105,7 @@ const mockCreateLabel = createLabel as jest.MockedFunction<typeof createLabel>;
 const VALID_PLAN_DRAFT = {
   vision: null,
   milestones: [
-    { title: 'MVP', description: 'Core features', dueOn: '2026-06-01', order: 1 },
+    { title: '001 - MVP', description: 'Core features', dueOn: '2026-06-01', order: 1 },
   ],
   issues: [
     {
@@ -112,7 +113,7 @@ const VALID_PLAN_DRAFT = {
       title: 'Add login page',
       body: '## Acceptance Criteria\n- [ ] User can log in',
       labels: ['enhancement'],
-      milestone: 'MVP',
+      milestone: '001 - MVP',
       priority: 'p1' as const,
       complexity: 'medium' as const,
       dependsOn: [],
@@ -123,7 +124,7 @@ const VALID_PLAN_DRAFT = {
       title: 'Add dashboard',
       body: '## Acceptance Criteria\n- [ ] Dashboard renders',
       labels: ['enhancement'],
-      milestone: 'MVP',
+      milestone: '001 - MVP',
       priority: 'p2' as const,
       complexity: 'small' as const,
       dependsOn: [1],
@@ -200,7 +201,7 @@ describe('plan command', () => {
 
     // Verify milestone created
     expect(mockCreateMilestone).toHaveBeenCalledWith(
-      'owner/repo', 'MVP', 'Core features', '2026-06-01',
+      'owner/repo', '001 - MVP', 'Core features', '2026-06-01',
     );
 
     // Verify issues created with ready label and milestone title
@@ -210,7 +211,7 @@ describe('plan command', () => {
       'Add login page',
       expect.any(String),
       expect.arrayContaining(['enhancement', 'ready']),
-      'MVP',
+      '001 - MVP',
     );
 
     expect(log.success).toHaveBeenCalledWith(
@@ -415,7 +416,7 @@ describe('plan command', () => {
     mockListMilestones.mockReturnValue([
       {
         number: 1,
-        title: 'MVP',
+        title: '001 - MVP',
         description: 'Core features',
         openIssues: 0,
         closedIssues: 0,
@@ -453,11 +454,11 @@ describe('plan command', () => {
   });
 
   it('reuses existing milestones instead of creating duplicates', async () => {
-    // Simulate an existing "MVP" milestone on GitHub
+    // Simulate an existing "001 - MVP" milestone on GitHub
     mockListMilestones.mockReturnValue([
       {
         number: 7,
-        title: 'MVP',
+        title: '001 - MVP',
         description: 'Core features',
         openIssues: 3,
         closedIssues: 0,
@@ -490,7 +491,7 @@ describe('plan command', () => {
       'Add login page',
       expect.any(String),
       expect.arrayContaining(['enhancement', 'ready']),
-      'MVP',
+      '001 - MVP',
     );
 
     expect(log.success).toHaveBeenCalledWith(

--- a/tests/commands/roadmap.test.ts
+++ b/tests/commands/roadmap.test.ts
@@ -54,6 +54,7 @@ jest.mock('../../src/lib/rate-limit', () => ({
 jest.mock('../../src/lib/planning', () => ({
   extractJsonFromResponse: jest.fn(),
   formatRoadmapTable: jest.fn(() => 'FORMATTED ROADMAP'),
+  normalizeRoadmapMilestones: jest.requireActual('../../src/lib/planning').normalizeRoadmapMilestones,
   buildPlanningContext: jest.fn(() => ({
     visionContext: null,
     projectContext: null,
@@ -99,13 +100,13 @@ const SAMPLE_ISSUES = [
 
 const SAMPLE_AGENT_RESPONSE = {
   milestones: [
-    { title: 'v1.0 Core', description: 'Core infrastructure', dueOn: '2026-05-01', order: 1 },
-    { title: 'v1.1 Features', description: 'User-facing features', dueOn: '2026-06-15', order: 2 },
+    { title: '001 - v1.0 Core', description: 'Core infrastructure', dueOn: '2026-05-01', order: 1 },
+    { title: '002 - v1.1 Features', description: 'User-facing features', dueOn: '2026-06-15', order: 2 },
   ],
   assignments: [
-    { issueNum: 3, title: 'Set up database schema', milestone: 'v1.0 Core', currentMilestone: '', selected: true },
-    { issueNum: 7, title: 'Create API endpoints', milestone: 'v1.0 Core', currentMilestone: '', selected: true },
-    { issueNum: 15, title: 'User dashboard', milestone: 'v1.1 Features', currentMilestone: '', selected: true },
+    { issueNum: 3, title: 'Set up database schema', milestone: '001 - v1.0 Core', currentMilestone: '', selected: true },
+    { issueNum: 7, title: 'Create API endpoints', milestone: '001 - v1.0 Core', currentMilestone: '', selected: true },
+    { issueNum: 15, title: 'User dashboard', milestone: '002 - v1.1 Features', currentMilestone: '', selected: true },
   ],
 };
 
@@ -147,28 +148,28 @@ describe('roadmap command', () => {
 
     // Should create both milestones
     expect(mockCreateMilestone).toHaveBeenCalledTimes(2);
-    expect(mockCreateMilestone).toHaveBeenCalledWith('owner/repo', 'v1.0 Core', 'Core infrastructure', '2026-05-01');
-    expect(mockCreateMilestone).toHaveBeenCalledWith('owner/repo', 'v1.1 Features', 'User-facing features', '2026-06-15');
+    expect(mockCreateMilestone).toHaveBeenCalledWith('owner/repo', '001 - v1.0 Core', 'Core infrastructure', '2026-05-01');
+    expect(mockCreateMilestone).toHaveBeenCalledWith('owner/repo', '002 - v1.1 Features', 'User-facing features', '2026-06-15');
 
     // Should assign all 3 issues (now passes milestone title, not number)
     expect(mockSetIssueMilestone).toHaveBeenCalledTimes(3);
-    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 3, 'v1.0 Core');
-    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 7, 'v1.0 Core');
-    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 15, 'v1.1 Features');
+    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 3, '001 - v1.0 Core');
+    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 7, '001 - v1.0 Core');
+    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 15, '002 - v1.1 Features');
 
     expect(log.success).toHaveBeenCalledWith(expect.stringContaining('milestone'));
   });
 
   it('does not recreate existing milestones', async () => {
     const existingMilestones = [
-      { number: 5, title: 'v1.0 Core', description: 'Core infra', openIssues: 2, closedIssues: 0, dueOn: '2026-05-01', state: 'open' },
+      { number: 5, title: '001 - v1.0 Core', description: 'Core infra', openIssues: 2, closedIssues: 0, dueOn: '2026-05-01', state: 'open' },
     ];
 
     mockListOpenIssues.mockReturnValue(SAMPLE_ISSUES);
     mockListMilestones.mockReturnValue(existingMilestones);
     mockExec.mockReturnValue({ stdout: '{"json":"here"}', stderr: '', exitCode: 0 });
     mockExtractJson.mockReturnValue(SAMPLE_AGENT_RESPONSE);
-    // Only v1.1 Features is new
+    // Only 002 - v1.1 Features is new
     mockCreateMilestone.mockReturnValueOnce(6);
 
     mockCheckbox.mockResolvedValueOnce([3, 7, 15]);
@@ -176,15 +177,15 @@ describe('roadmap command', () => {
 
     await roadmapCommand({});
 
-    // Should only create v1.1 Features (v1.0 Core already exists)
+    // Should only create 002 - v1.1 Features (001 - v1.0 Core already exists)
     expect(mockCreateMilestone).toHaveBeenCalledTimes(1);
-    expect(mockCreateMilestone).toHaveBeenCalledWith('owner/repo', 'v1.1 Features', 'User-facing features', '2026-06-15');
+    expect(mockCreateMilestone).toHaveBeenCalledWith('owner/repo', '002 - v1.1 Features', 'User-facing features', '2026-06-15');
 
-    // Issues assigned to v1.0 Core should use milestone title (not number)
-    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 3, 'v1.0 Core');
-    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 7, 'v1.0 Core');
-    // Issue assigned to v1.1 Features should use milestone title
-    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 15, 'v1.1 Features');
+    // Issues assigned to 001 - v1.0 Core should use milestone title (not number)
+    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 3, '001 - v1.0 Core');
+    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 7, '001 - v1.0 Core');
+    // Issue assigned to 002 - v1.1 Features should use milestone title
+    expect(mockSetIssueMilestone).toHaveBeenCalledWith('owner/repo', 15, '002 - v1.1 Features');
   });
 
   it('does not make GitHub calls in dry-run mode', async () => {

--- a/tests/lib/planning.test.ts
+++ b/tests/lib/planning.test.ts
@@ -28,6 +28,9 @@ import {
   extractJsonFromResponse,
   formatIssueTable,
   formatTriageFindings,
+  normalizeMilestoneTitles,
+  normalizePlanMilestones,
+  normalizeRoadmapMilestones,
   readSeedFiles,
   buildPlanningContext,
   savePlanDraft,
@@ -371,5 +374,75 @@ describe('savePlanDraft', () => {
         // Best effort cleanup
       }
     }
+  });
+});
+
+// ── normalizeMilestoneTitles ────────────────────────────────────────────────
+
+describe('normalizeMilestoneTitles', () => {
+  it('adds 3-digit prefix based on order', () => {
+    const milestones: PlannedMilestone[] = [
+      { title: 'Foundation', description: '', dueOn: null, order: 1 },
+      { title: 'Features', description: '', dueOn: null, order: 2 },
+      { title: 'Polish', description: '', dueOn: null, order: 10 },
+    ];
+
+    const result = normalizeMilestoneTitles(milestones);
+    expect(result[0].title).toBe('001 - Foundation');
+    expect(result[1].title).toBe('002 - Features');
+    expect(result[2].title).toBe('010 - Polish');
+  });
+
+  it('skips milestones that already have a 3-digit prefix', () => {
+    const milestones: PlannedMilestone[] = [
+      { title: '001 - Foundation', description: '', dueOn: null, order: 1 },
+      { title: 'New Scope', description: '', dueOn: null, order: 2 },
+    ];
+
+    const result = normalizeMilestoneTitles(milestones);
+    expect(result[0].title).toBe('001 - Foundation');
+    expect(result[1].title).toBe('002 - New Scope');
+  });
+});
+
+// ── normalizePlanMilestones ─────────────────────────────────────────────────
+
+describe('normalizePlanMilestones', () => {
+  it('normalizes milestone titles and updates issue references', () => {
+    const draft: PlanDraft = {
+      vision: null,
+      milestones: [
+        { title: 'MVP', description: 'Core', dueOn: null, order: 1 },
+        { title: 'Polish', description: 'Refinement', dueOn: null, order: 2 },
+      ],
+      issues: [
+        { id: 1, title: 'Login', body: '', labels: [], milestone: 'MVP', priority: 'p1', complexity: 'medium', dependsOn: [], selected: true },
+        { id: 2, title: 'Animations', body: '', labels: [], milestone: 'Polish', priority: 'p2', complexity: 'small', dependsOn: [], selected: true },
+      ],
+      projectBoard: null,
+    };
+
+    const result = normalizePlanMilestones(draft);
+    expect(result.milestones[0].title).toBe('001 - MVP');
+    expect(result.milestones[1].title).toBe('002 - Polish');
+    expect(result.issues[0].milestone).toBe('001 - MVP');
+    expect(result.issues[1].milestone).toBe('002 - Polish');
+  });
+});
+
+// ── normalizeRoadmapMilestones ──────────────────────────────────────────────
+
+describe('normalizeRoadmapMilestones', () => {
+  it('normalizes milestone titles and updates assignment references', () => {
+    const milestones: PlannedMilestone[] = [
+      { title: 'Core', description: '', dueOn: null, order: 1 },
+    ];
+    const assignments = [
+      { issueNum: 5, title: 'Issue', milestone: 'Core', currentMilestone: '', selected: true },
+    ];
+
+    const result = normalizeRoadmapMilestones(milestones, assignments);
+    expect(result.milestones[0].title).toBe('001 - Core');
+    expect(result.assignments[0].milestone).toBe('001 - Core');
   });
 });


### PR DESCRIPTION
## Summary
- Milestone titles are now prefixed with a zero-padded 3-digit order number (e.g. `001 - MVP`, `010 - Polish`) for consistent alphabetical sorting
- AI prompts (plan + roadmap) updated with examples and instructions for the new format
- Code-level normalization ensures correct prefixes even if the AI omits them
- Milestones already prefixed are left as-is

## Test plan
- [x] All 706 existing tests pass
- [x] New unit tests for `normalizeMilestoneTitles`, `normalizePlanMilestones`, `normalizeRoadmapMilestones`
- [ ] Run `alpha-loop plan` and verify new milestones get 3-digit prefixed titles
- [ ] Run `alpha-loop roadmap` and verify milestone assignments use prefixed titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)