### PR TITLE
feat: epic-aware run — discover, select, and close epic-driven sessions

### DIFF
--- a/.alpha-loop/plans/171-epic-aware-run.md
+++ b/.alpha-loop/plans/171-epic-aware-run.md
@@ -1,0 +1,495 @@
+# Implementation Plan: #171 — Epic-aware run
+
+Branch: `feature/171-epic-aware-run`
+
+## Overview
+
+Add first-class epic support to `alpha-loop run`. An "epic" is a GitHub issue with the `epic` label whose body contains a `- [ ] #N` task list of sub-issues. The feature: auto-discovers open epics, presents them above milestones in an interactive picker, processes their sub-issues in checklist order, flips checklist boxes as sub-issues merge, and triggers a verification pass (agent-powered AC verdict) when the last sub-issue ships.
+
+Non-goals (v1): nested epics, cross-repo sub-issues, automatic epic creation, GitHub Projects v2 native sub-issues API.
+
+---
+
+## Architecture: New and Modified Files
+
+### New files
+- `src/lib/epics.ts` — checklist parsing, sub-issue resolution, progress tracking, checklist mutation
+- `src/lib/verify-epic.ts` — verification pass: per-sub-issue AC verdict, epic close/comment logic
+- `tests/lib/epics.test.ts` — unit tests for epics module
+- `tests/lib/verify-epic.test.ts` — unit tests for verify-epic module
+- `docs/epics.md` — feature documentation
+
+### Modified files
+| File | Change |
+|------|--------|
+| `src/lib/github.ts` | Add `listEpics()`, `getEpicSubIssues()`, `updateEpicChecklist()`, `getIssuePR()` |
+| `src/lib/session.ts` | Add `epic?: number` field to `SessionContext`; slug epic into session name |
+| `src/lib/pipeline.ts` | Append `Part of #<epic>` to PR body in `buildPRBody()` when session has epic |
+| `src/lib/config.ts` | Add `preferEpics: boolean` to `Config` type + DEFAULTS + YAML key map |
+| `src/commands/run.ts` | Add `--epic`, `--no-epic`, `--verify-only` CLI options; refactor `pickMilestone()` into unified `pickTarget()`; add epic execution flow |
+| `src/cli.ts` | Wire `--epic <N>`, `--no-epic`, `--verify-only <N>` options on the `run` command |
+| `src/commands/init.ts` | Create `epic` label during `alpha-loop init` if absent |
+| `README.md` | Add section on epic workflow |
+
+---
+
+## Implementation Steps
+
+### Step 1: Add `epic` GitHub label (Complexity: Low)
+
+**What**: Create the `epic` label in the repo during `alpha-loop init`. Document the label convention.
+
+**Files**:
+- `src/commands/init.ts` — after the existing label-creation logic, call `createLabel(repo, 'epic', '8B5CF6')` guarded by a `listLabels` check (same pattern used for the `ready` label)
+
+**Key points**:
+- Use `--force` flag already in `createLabel()` so this is idempotent
+- Color `8B5CF6` (purple) to distinguish epics visually
+
+**Testing**: Manual — run `alpha-loop init --dry-run` and confirm label appears in output
+**Acceptance criteria satisfied**: AC #1 (`epic` label created in repo and documented)
+
+---
+
+### Step 2: `src/lib/epics.ts` — core epic primitives (Complexity: Medium)
+
+**What**: New module with pure functions for checklist parsing and sub-issue management.
+
+**Files**:
+- `src/lib/epics.ts` (new)
+
+**Exported types and functions**:
+
+```typescript
+export type SubIssueRef = {
+  number: number;
+  checked: boolean;    // true if "- [x]"
+  lineIndex: number;   // position in body lines array (for surgical replacement)
+};
+
+export type EpicSummary = {
+  number: number;
+  title: string;
+  subIssues: SubIssueRef[];
+  doneCount: number;
+  totalCount: number;
+};
+
+/** Parse "- [ ] #N" / "- [x] #N" lines from an issue body. Cross-repo refs ignored. */
+export function parseSubIssues(body: string): SubIssueRef[]
+
+/** Flip one checklist line from unchecked to checked (or vice versa). Returns new body string. */
+export function flipChecklistItem(body: string, subIssueNum: number, checked: boolean): string
+
+/** True when body qualifies as an epic by heuristic (≥3 task-list issue refs). */
+export function looksLikeEpic(body: string): boolean
+
+/** Build an EpicSummary from a parsed issue. */
+export function buildEpicSummary(issue: Issue): EpicSummary
+```
+
+**Key points**:
+- Parse regex: `/^- \[([ xX])\] #(\d+)/gm` — match `[ ]` or `[x]`/`[X]` only; ignore `- [ ] text` without `#N`
+- `flipChecklistItem` must be surgical: replace only the matching line, preserve all surrounding markdown. Do NOT re-render the full body.
+- `looksLikeEpic` returns true when ≥3 `#N` task-list lines found — used only as a warning hint, not as the authoritative epic detection
+- Cross-repo refs (containing `/`) are silently skipped
+
+**Testing**: `tests/lib/epics.test.ts` — see Step 7
+
+---
+
+### Step 3: `src/lib/github.ts` — epic-specific GitHub helpers (Complexity: Low)
+
+**What**: Add four new exported functions.
+
+**Files**:
+- `src/lib/github.ts`
+
+**New functions**:
+
+```typescript
+/** List all open issues with the 'epic' label. */
+export function listEpics(repo: string): Issue[]
+
+/** Fetch an epic issue and return parsed sub-issue refs. */
+export function getEpicSubIssues(repo: string, epicNum: number): SubIssueRef[]
+
+/** Flip the checklist box for subIssueNum in the epic body. */
+export function updateEpicChecklist(repo: string, epicNum: number, subIssueNum: number, checked: boolean): void
+
+/** Get the merged PR URL for an issue, or null if none found. */
+export function getMergedPRForIssue(repo: string, issueNum: number): string | null
+```
+
+**Key points**:
+- `listEpics`: use `gh issue list --label "epic" --state open` — reuse the `ghExec` + JSON pattern already established in `pollIssuesByLabel`
+- `updateEpicChecklist`: fetch current body via `getIssueWithComments`, call `flipChecklistItem` from `epics.ts`, then call `updateIssue` with new body. If the expected `- [ ] #N` line is not present in the fetched body, **throw** (`Error: epic #<epicNum> body no longer contains expected checklist line for sub-issue #<subIssueNum>`). Callers let this bubble up — one-agent-per-epic is the contract, so a missing line is a loud failure, not a silent drift.
+- `getMergedPRForIssue`: `gh pr list --repo <repo> --search "closes:#N" --state merged --json url --limit 1` — needed for the verification pass
+
+**Testing**: extend `tests/lib/github.test.ts` with mock-based tests for each new function
+
+---
+
+### Step 4: `src/lib/config.ts` — add `preferEpics` config field (Complexity: Low)
+
+**What**: Add a new boolean config option `prefer_epics` / `preferEpics`.
+
+**Files**:
+- `src/lib/config.ts`
+
+**Changes**:
+1. Add `preferEpics: boolean` to the `Config` type (after `batch` / `batchSize`)
+2. Add default `preferEpics: false` to `DEFAULTS`
+3. Add `prefer_epics: 'preferEpics'` to the YAML key map
+4. Add `PREFER_EPICS: 'preferEpics'` to ENV var map
+
+**Testing**: extend `tests/lib/config.test.ts` with a test that sets `prefer_epics: true` in a YAML fixture and asserts `config.preferEpics === true`
+
+---
+
+### Step 5: `src/lib/session.ts` — add `epic` to `SessionContext` (Complexity: Low)
+
+**What**: Record which epic (if any) a session is scoped to, and use it to name the session.
+
+**Files**:
+- `src/lib/session.ts`
+
+**Changes**:
+1. Add `epic?: number` to the `SessionContext` type
+2. In `createSession`, accept an optional `epicNum?: number` parameter alongside `milestone?`
+3. When `epicNum` is provided, form the session slug as `epic-${epicNum}-${slugifiedTitle}` so the branch is named `session/epic-165-hybrid-routing` (matching the issue design spec)
+4. Return `epic: epicNum` in the returned `SessionContext`
+
+**Key points**:
+- The session PR title (in `finalizeSession`) should say `Epic #<N>: <title>` when `session.epic` is set, matching the design spec
+
+**Testing**: extend `tests/lib/session.test.ts`
+
+---
+
+### Step 6: `src/lib/pipeline.ts` — append `Part of #<epic>` to PR body (Complexity: Low)
+
+**What**: When the session has an epic, append an epic reference to the individual sub-issue PR body.
+
+**Files**:
+- `src/lib/pipeline.ts`
+
+**Changes**:
+- In `buildPRBody(...)`, add an optional `epicNum?: number` parameter
+- If provided, prepend `Closes #${issueNum}\nPart of #${epicNum}` instead of just `Closes #${issueNum}`
+- Pass `session.epic` from `processIssue` calls down to `buildPRBody`
+
+**Key points**:
+- The `processIssue` function already receives `session: SessionContext`, so `session.epic` is available
+- This is a minimal, surgical change to `buildPRBody` — no structural refactor
+
+**Testing**: add a test in `tests/lib/pipeline.test.ts` asserting the PR body contains `Part of #165` when `epicNum` is set
+
+---
+
+### Step 7: `src/lib/verify-epic.ts` — verification pass (Complexity: High)
+
+**What**: When all sub-issues have merged PRs, run an agent-powered AC verification pass and post a structured comment on the epic.
+
+**Files**:
+- `src/lib/verify-epic.ts` (new)
+
+**Exported functions**:
+
+```typescript
+export type VerifyEpicResult = {
+  verdict: 'pass' | 'partial' | 'fail';
+  comment: string;   // full markdown comment body to post on the epic
+};
+
+/** Run the full verification pass on a closed-or-closing epic. */
+export async function verifyEpic(
+  epicIssue: Issue,
+  subIssues: Issue[],
+  mergedPRUrls: string[],   // parallel array with subIssues
+  config: Config,
+  session: SessionContext,
+): Promise<VerifyEpicResult>
+```
+
+**Algorithm**:
+1. Build a verification prompt containing: epic body (acceptance criteria), each sub-issue body, and the merged PR diff (fetched via `gh pr diff <number>`) — truncated to MAX_DIFF_CHARS
+2. Call `spawnAgent` with `config.reviewModel` (falls back to `config.agent`)
+3. Parse agent output for a structured verdict JSON blob (same `GateResult` pattern used by `readGateResult` in `pipeline.ts`)
+4. Return verdict + a formatted markdown summary for the epic comment
+5. The comment follows: per-sub-issue table (PR link | AC verdict | notes) + overall status
+
+**Key points**:
+- Use `config.reviewModel` (not `config.model`) — matches the spec ("respects routing config once #158/#159 land")
+- Verdict parsing: look for a JSON fence in agent output like the existing `GateResult` parsing in `readGateResult`; if absent, treat as `partial`
+- Prompt must be explicit: "For each sub-issue, evaluate each acceptance criterion in the issue body against the merged PR diff. Output a JSON object with: `verdict: 'pass'|'partial'|'fail'`, `findings: [{issueNum, criterion, verdict, notes}]`"
+
+**Testing**: `tests/lib/verify-epic.test.ts` — mock `spawnAgent`, test verdict parsing, test comment formatting
+
+---
+
+### Step 8: Refactor `pickMilestone()` into `pickTarget()` in `src/commands/run.ts` (Complexity: Medium)
+
+**What**: Extend the existing `pickMilestone()` function (lines 149–185) into a unified picker that shows epics first, then milestones, then a flat option.
+
+**Files**:
+- `src/commands/run.ts`
+
+**New function signature**:
+
+```typescript
+type PickResult =
+  | { type: 'epic'; epicNum: number; epicTitle: string }
+  | { type: 'milestone'; title: string }
+  | { type: 'all' };
+
+async function pickTarget(repo: string, preferEpics: boolean): Promise<PickResult>
+```
+
+**Rendered menu** (matches design spec):
+```
+  Open Epics
+  1  Hybrid cloud + local model routing #165 (0/7 done) · Hybrid Model Routing
+  2  [other epic] ...
+
+  Open Milestones
+  3  Hybrid Model Routing (0 open, 0/8 done · due 2026-05-20)
+  4  Core Pipeline Quality ...
+
+  0  All ready (flat, no filter)
+
+  Select [0-N]:
+```
+
+**Key points**:
+- When no epics exist, fall back to showing milestones only (current behavior preserved)
+- When non-TTY (`!process.stdin.isTTY`) skip the picker entirely — return `{ type: 'all' }` or use the `--milestone` flag value
+- The `preferEpics` config: if user selects a milestone and `preferEpics: true` and there is exactly one epic in that milestone → auto-promote to epic selection
+- Index offset: epics take indices 1..E, milestones take indices E+1..E+M, 0 = all. `askChoice` max = E+M
+
+**Acceptance criteria satisfied**: AC #3 (epic picker shown when ≥1 open epic), AC #14 (non-TTY defaults to flat)
+
+---
+
+### Step 9: Epic execution flow in `runCommand` (Complexity: High)
+
+**What**: When an epic is selected, change the issue queue to be the epic's sub-issues in checklist order, and after each successful merge, flip the epic checklist box.
+
+**Files**:
+- `src/commands/run.ts`
+
+**Changes to `runCommand`**:
+
+1. Extend `RunOptions` type:
+```typescript
+epic?: number;        // --epic <N>
+noEpic?: boolean;     // --no-epic
+verifyOnly?: number;  // --verify-only <N>
+```
+
+2. Replace `pickMilestone()` call (line 214–215) with `pickTarget()`:
+```typescript
+let activeEpic: number | undefined;
+let activeMilestone = config.milestone;
+
+if (!config.dryRun && process.stdin.isTTY && !options.noEpic && !options.epic && !activeMilestone) {
+  const target = await pickTarget(config.repo, config.preferEpics);
+  if (target.type === 'epic') { activeEpic = target.epicNum; }
+  else if (target.type === 'milestone') { activeMilestone = target.title; }
+}
+if (options.epic) activeEpic = options.epic;
+if (options.noEpic) activeEpic = undefined;
+```
+
+3. If `activeEpic` is set, build the issue queue from epic sub-issues in checklist order:
+```typescript
+if (activeEpic !== undefined) {
+  const subRefs = getEpicSubIssues(config.repo, activeEpic);
+  const openReadySubIssues = subRefs
+    .filter(ref => !ref.checked)           // not already done
+    .map(ref => getIssueWithComments(config.repo, ref.number))
+    .filter((iss): iss is Issue => iss !== null)
+    .filter(iss => {
+      if (!iss.labels.includes(config.labelReady)) {
+        log.warn(`Sub-issue #${iss.number} skipped: not labeled '${config.labelReady}'`);
+        return false;
+      }
+      return true;
+    });
+  issuesToProcess = openReadySubIssues;   // checklist order preserved
+}
+```
+
+4. After each successful `processIssue`, if `activeEpic` is set, flip the checklist:
+```typescript
+if (result.status === 'success' && activeEpic !== undefined) {
+  updateEpicChecklist(config.repo, activeEpic, issue.number, true);
+}
+```
+
+5. After the issue loop finishes, if `activeEpic` is set and all sub-issues are now done:
+```typescript
+const remaining = getEpicSubIssues(config.repo, activeEpic).filter(r => !r.checked);
+if (remaining.length === 0) {
+  // All done — run verification pass
+  const verifyResult = await verifyEpic(...);
+  commentIssue(config.repo, activeEpic, verifyResult.comment);
+  if (verifyResult.verdict === 'pass') {
+    closeIssue(config.repo, activeEpic, 'completed');
+    log.success(`Epic #${activeEpic} closed: all sub-issues shipped and verified`);
+  } else {
+    labelIssue(config.repo, activeEpic, 'needs-human-input');
+    log.warn(`Epic #${activeEpic} needs human review: verdict=${verifyResult.verdict}`);
+  }
+}
+```
+
+6. Epic exclusion from normal `ready` flow: in `pollIssues` (or immediately after, in `runCommand`), filter out issues that have the `epic` label. Since `pollIssues` already returns labels on each issue, this is a one-liner filter:
+```typescript
+issuesToProcess = issuesToProcess.filter(iss => !iss.labels.includes('epic'));
+```
+Apply this filter in ALL paths (flat, milestone, project-board) — before any other slicing.
+
+7. `--verify-only <N>` path: if `options.verifyOnly` is set, skip the issue loop entirely and jump straight to the verification pass for that epic number.
+
+**Acceptance criteria satisfied**: AC #2, #4, #5, #6, #7, #8, #9, #11, #12, #13
+
+---
+
+### Step 10: Wire CLI flags (Complexity: Low)
+
+**What**: Add `--epic`, `--no-epic`, `--verify-only` options to the `run` command in `src/cli.ts`.
+
+**Files**:
+- `src/cli.ts`
+
+**Changes** (inside the `run` command block):
+```typescript
+.option('--epic <n>', 'Force a specific epic by number, skip the picker', parseInt)
+.option('--no-epic', 'Skip the epic picker, use flat/milestone flow')
+.option('--verify-only <n>', 'Run only the verification pass on an existing epic', parseInt)
+```
+
+**Acceptance criteria satisfied**: AC #4 (`--epic <N>` and `--no-epic` work), AC #12 (`--verify-only <N>`)
+
+---
+
+### Step 11: Unit tests (Complexity: Medium)
+
+**What**: Full test coverage for all new modules and modified helpers.
+
+**Files**:
+- `tests/lib/epics.test.ts` (new)
+- `tests/lib/verify-epic.test.ts` (new)
+- `tests/lib/github.test.ts` (extend)
+- `tests/lib/pipeline.test.ts` (extend)
+- `tests/lib/session.test.ts` (extend)
+
+**Test cases for `epics.test.ts`**:
+- `parseSubIssues`: unchecked `- [ ] #N`, checked `- [x] #N`, uppercase `- [X] #N`, mixed list, cross-repo ref ignored, plain task item without `#N` ignored
+- `flipChecklistItem`: flips unchecked to checked, flips checked to unchecked, leaves other lines untouched
+- `looksLikeEpic`: true when ≥3 items, false when <3, false when no task list
+- `buildEpicSummary`: correct `doneCount` and `totalCount`
+
+**Test cases for `verify-epic.test.ts`**:
+- `verifyEpic` with agent returning `pass` JSON → closes epic
+- `verifyEpic` with agent returning `partial` → leaves open, returns structured comment
+- `verifyEpic` with no parseable JSON → defaults to `partial`
+
+**Test cases for `github.test.ts`**:
+- `listEpics`: returns only issues with `epic` label
+- `updateEpicChecklist`: calls `updateIssue` with correctly flipped body
+- `getMergedPRForIssue`: returns URL from mock gh output
+
+**Integration test** (mocked):
+- Full mock run in `tests/commands/run.test.ts` (or a new `tests/lib/epic-run.test.ts`): synthetic epic with 3 sub-issues (one not-ready), assert order preserved, not-ready one skipped, checklist flipped, verification called after last merge
+
+**Acceptance criteria satisfied**: AC #15, #16
+
+---
+
+### Step 12: Documentation (Complexity: Low)
+
+**What**: New `docs/epics.md` and a README section.
+
+**Files**:
+- `docs/epics.md` (new) — feature overview, label setup (`alpha-loop init` creates it), example workflow, checklist format, CLI flags, config option
+- `README.md` — add a "Epics" section after the existing "Milestones" section, linking to `docs/epics.md`
+
+**Acceptance criteria satisfied**: AC #17
+
+---
+
+## Testing Strategy
+
+**Unit tests** (Jest, mocked gh CLI):
+- All pure functions in `src/lib/epics.ts` — markdown parsing edge cases are the highest-value tests
+- Verification verdict parsing in `src/lib/verify-epic.ts` — mock `spawnAgent`
+- New GitHub helpers in `src/lib/github.ts` — follow exact mock pattern in `tests/lib/github.test.ts`
+
+**Integration / mock-run test**:
+- Create a `tests/commands/epic-run.test.ts` that stubs `pollIssues`, `getEpicSubIssues`, `processIssue`, `updateEpicChecklist`, and `verifyEpic`, then calls `runCommand({ epic: 165 })` and asserts the call sequence is correct
+
+**Manual validation** (epic #165):
+1. Run `alpha-loop run`, confirm epic #165 appears in the picker
+2. Select it — confirm sub-issues are listed in checklist order
+3. Confirm skipped-issue warning fires for any non-ready sub-issue
+4. After a sub-issue merges, confirm epic body checklist is updated
+5. After all merge — confirm verification comment posted, epic closed (or `needs-human-input` added)
+
+---
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **Checklist race / unexpected body shape**: `updateEpicChecklist` reads, mutates, writes. If the fetched body no longer contains the expected `- [ ] #N` line, something is wrong. | Low | One-agent-per-epic is the documented contract. `updateEpicChecklist` throws if the expected line is absent; `runCommand` lets it bubble up and stops processing that epic. Loud failure, not silent drift. |
+| **Checklist formatting preservation**: The flip must not disturb surrounding markdown (description text, non-issue task items, headers, HTML). | High | `flipChecklistItem` uses surgical line-replacement (find line by regex match + `lineIndex`, replace only that line). Unit-test with real-world epic body samples including mixed markdown. Never regenerate the full body from AST. |
+| **Verification pass prompt quality**: The agent must produce parseable JSON with per-criterion verdicts from a potentially large PR diff. | High | (1) Truncate diff per existing `MAX_DIFF_CHARS` constant. (2) Use the existing `GateResult` JSON schema so the agent already has a pattern to follow from the code review prompts. (3) If JSON parse fails → default to `partial`, never crash. (4) Trace the prompt+output to `.alpha-loop/traces/` for debugging. |
+| **`epic` label not existing in target repo** | Medium | `alpha-loop init` creates it. `listEpics` gracefully returns `[]` if the label doesn't exist — no crash. `updateEpicChecklist` warns if label-add fails. |
+| **`--no-epic` vs Commander.js boolean coercion**: Commander parses `--no-epic` as negating a `--epic` default, which may conflict with `--epic <N>`. | Low | Register `--no-epic` as a standalone flag (`noEpic: boolean`) separate from `--epic <N>` (which takes an integer argument). Verify with a test against the Commander config. |
+
+---
+
+## Acceptance Criteria Mapping
+
+| AC | Step(s) |
+|----|---------|
+| 1. `epic` label created in repo and documented | Step 1, Step 12 |
+| 2. Epic-labeled issues never picked up by normal `ready` flow | Step 9 |
+| 3. Epic picker shown when ≥1 open epic exists (TTY only) | Step 8 |
+| 4. `--epic <N>` and `--no-epic` work as specified | Step 10, Step 9 |
+| 5. Sub-issues processed in checklist order | Step 9 |
+| 6. Sub-issue PR bodies include `Part of #<epic>` | Step 6 |
+| 7. Epic checklist boxes auto-flip as sub-issues merge | Step 9 (after each processIssue) |
+| 8. Non-ready sub-issues skipped with warning | Step 9 |
+| 9. Verification pass runs when final sub-issue merges | Step 9 (post-loop check) |
+| 10. Verification pass posts structured per-sub-issue comment | Step 7 |
+| 11. Verification auto-closes on pass; partial/fail → `needs-human-input` | Step 9, Step 7 |
+| 12. `--verify-only <N>` re-runs verification | Step 9, Step 10 |
+| 13. `prefer_epics: true` honored in picker | Step 4, Step 8 |
+| 14. Non-TTY / CI defaults to flat, epics still excluded from ready | Step 9 |
+| 15. Unit tests: parse, order, skip, exclude, verdict | Step 11 |
+| 16. Integration test: mock run against synthetic epic | Step 11 |
+| 17. Docs: README section + `docs/epics.md` | Step 12 |
+| 18. `alpha-loop init` creates `epic` label | Step 1 |
+
+---
+
+## Locked Decisions
+
+### Decision 1: Checklist race — **ERROR on conflict**
+
+One-agent-per-epic is the contract. If `updateEpicChecklist` detects that the expected `- [ ] #N` line is missing from the fetched body (external mutation since last read, or sub-issue not actually referenced in the epic), it **throws**. The run loop bubbles the error up and stops processing that epic. No warn-and-continue.
+
+Rationale: concurrent sessions against the same epic are not a supported workflow. A missing checklist line signals that either (a) something else is touching the epic body, or (b) we have a bug — both cases warrant a loud failure, not a silent drift.
+
+### Decision 2: Verification verdict shape — **separate `EpicVerdict` type**
+
+Keep `GateResult` as-is for code review. Define a new `EpicVerdict` type in `src/lib/verify-epic.ts` with its own JSON schema (`verdict`, `findings[].issueNum`, `findings[].criterion`, `findings[].verdict`, `findings[].notes`) and its own parser. Avoids awkward optionals on `GateResult`.
+
+### Decision 3: `--verify-only` scope — **permissive**
+
+Runs verification on whichever sub-issues have merged PRs at call time. Missing/open sub-issues are listed in the comment as "not yet merged — skipped" but do not block the pass. Useful for iterating on epic #165 during development (can re-run verification as more sub-issues land).
+
+The verdict tally only counts sub-issues that were actually evaluated; if any sub-issue was skipped for missing PR, the overall verdict caps at `partial` (can't declare `pass` without full coverage).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ alpha-loop init          # Full onboarding: config, templates, vision, scan, syn
 alpha-loop run           # Run the loop continuously
 alpha-loop run --once    # Process one issue and exit
 alpha-loop run --dry-run # Dry run (preview, no changes)
+alpha-loop run --epic <N>        # Process an epic (sub-issues in checklist order, auto-verify on completion)
+alpha-loop run --verify-only <N> # Run just the epic verification pass
 alpha-loop scan          # Generate/refresh project context
 alpha-loop plan          # Generate project scope (milestones + issues) from seed inputs
 alpha-loop add           # Create a new issue from a free-form description using AI

--- a/README.md
+++ b/README.md
@@ -480,6 +480,27 @@ Use GitHub milestones to group issues into planned releases or sprints. When you
 
 Create milestones at `github.com/<owner>/<repo>/milestones/new`. Set due dates to keep yourself on track.
 
+### Epics
+
+An epic is a GitHub issue with the `epic` label and a task-list body that references sub-issues by number:
+
+```markdown
+## Sub-issues
+- [ ] #158 Add tenant column to users table
+- [ ] #159 Add tenant middleware
+- [ ] #160 Scope queries by tenant
+```
+
+When you start the loop, open epics appear above milestones in the picker. You can also target one directly:
+
+```bash
+alpha-loop run --epic 165
+```
+
+Sub-issues are processed in checklist order (not issue-number order). Each sub-issue PR gets `Part of #165` appended, and the epic body's checkboxes auto-flip from `- [ ]` to `- [x]` as PRs merge. When every sub-issue has shipped, the loop runs a verification pass against each sub-issue's acceptance criteria — on `pass` the epic is auto-closed, on `partial` or `fail` it stays open with a `needs-human-input` label and a structured comment explaining the gaps.
+
+See [docs/epics.md](docs/epics.md) for the full feature reference, including `--verify-only`, the `prefer_epics` config option, skip rules, and safety rails.
+
 ### GitHub Project Board
 
 Alpha Loop reads issues from a GitHub Project board (v2). Issues are processed in board order, so you control priority by reordering. When combined with milestones, only "Todo" items in the selected milestone are processed.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop init` | Full onboarding: config, templates, vision, scan, sync, commit |
 | `alpha-loop run` | Fetch matching issues, process them all, then exit |
 | `alpha-loop run --dry-run` | Preview without making changes |
+| `alpha-loop run --epic <N>` | Process an epic — its sub-issues in checklist order, auto-verify on completion (see [docs/epics.md](docs/epics.md)) |
+| `alpha-loop run --verify-only <N>` | Run just the epic verification pass — evaluates merged PRs against acceptance criteria |
 | `alpha-loop scan` | Generate/refresh project context and instructions file |
 | `alpha-loop vision` | **(deprecated)** Use `alpha-loop plan` instead |
 | `alpha-loop auth` | Save authenticated browser state for verification |
@@ -283,6 +285,9 @@ Options:
   --merge-to <branch> Use an existing branch instead of creating a new session branch
   --batch             Batch mode: process multiple issues per agent call (faster, fewer tokens)
   --batch-size <n>    Issues per batch (default: 5)
+  --epic <n>          Process a specific epic by issue number (skips the picker)
+  --skip-epic         Skip the epic picker, use flat/milestone flow
+  --verify-only <n>   Run only the verification pass on an existing epic
 ```
 
 ## Configuration

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -68,7 +68,7 @@ Processes epic `#165` directly, skipping the picker.
 ### Excluded
 
 ```bash
-alpha-loop run --no-epic
+alpha-loop run --skip-epic
 ```
 
 Skips the epic picker entirely and goes straight to milestones. Useful when you want to work on standalone issues in a repo that has open epics.

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -1,0 +1,218 @@
+# Epics
+
+Epics let you group related issues into a single, end-to-end deliverable that Alpha Loop ships as one unit. You plan the pieces, mark the parent issue with the `epic` label, and the loop builds the sub-issues in order, auto-links their PRs, verifies completeness when the last one merges, and closes the epic on pass.
+
+## What is an Epic
+
+An epic is a GitHub issue with:
+
+1. The `epic` label applied.
+2. A GitHub task-list in the body that references sub-issues by number.
+
+Example epic body:
+
+```markdown
+## Goal
+Add multi-tenant support to the API layer.
+
+## Sub-issues
+- [ ] #158 Add tenant column to users table
+- [ ] #159 Add tenant middleware to Express router
+- [ ] #160 Scope existing queries by tenant
+- [ ] #161 Add tenant header validation
+- [ ] #162 Update docs for tenant header
+
+## Acceptance Criteria
+- [ ] All endpoints scoped by tenant
+- [ ] Backward-compatible for single-tenant deployments
+```
+
+The task-list lines are the source of truth for both ordering and completion tracking.
+
+## How Epics Are Detected
+
+- The `epic` **label is authoritative**. An issue with no `epic` label is never treated as an epic, regardless of body content.
+- If an issue has a task-list body with three or more `- [ ] #N` items but no `epic` label, it is treated as a **hint** — the picker may flag it as a candidate, but the loop will not process it as an epic until you add the label.
+
+This keeps epic detection explicit. You opt in by labeling.
+
+## Running the Loop Against an Epic
+
+### Interactive
+
+```bash
+alpha-loop run
+```
+
+The picker lists open epics above milestones:
+
+```
+  Open Epics
+  1  #165 Multi-tenant support (0/7 sub-issues done)
+  2  #170 Billing revamp (2/5 sub-issues done)
+
+  Open Milestones
+  3  v1.1 — Polish (10 open)
+
+  Select [1-3]:
+```
+
+### Forced
+
+```bash
+alpha-loop run --epic 165
+```
+
+Processes epic `#165` directly, skipping the picker.
+
+### Excluded
+
+```bash
+alpha-loop run --no-epic
+```
+
+Skips the epic picker entirely and goes straight to milestones. Useful when you want to work on standalone issues in a repo that has open epics.
+
+## Sub-Issue Ordering
+
+Sub-issues are processed in the order they appear in the epic's task-list — **not** by issue number. To reorder, edit the epic body and rearrange the `- [ ] #N` lines.
+
+For the epic above, the loop processes `#158` first, then `#159`, `#160`, `#161`, `#162` — regardless of the order those issues were created.
+
+## Skip Rules
+
+The loop skips a sub-issue (with a warning, not a hard error) when:
+
+| Condition | Reason |
+|-----------|--------|
+| Sub-issue has no `ready` label | The issue is not ready to work on; fix by adding `ready` and re-running |
+| Sub-issue has the `epic` label | Nested epics are unsupported in v1 |
+| Sub-issue reference is cross-repo (e.g. `- [ ] owner/other-repo#42`) | Ignored silently |
+| Sub-issue is already closed | Skipped; checklist is flipped to `- [x]` if not already |
+
+Skipped sub-issues do not block the rest of the epic. The loop continues to the next item and reports skipped items in the epic summary.
+
+## PR Body Additions
+
+Each sub-issue PR gets `Part of #<epic>` appended to its body. For epic `#165` with sub-issue `#158`:
+
+```markdown
+## Summary
+Adds tenant column to users table...
+
+## Test Plan
+...
+
+Part of #165
+```
+
+This gives GitHub the linkage needed to surface the PR on the epic's timeline and makes it trivial to find every PR that contributed to the epic.
+
+## Checklist Auto-Flip
+
+When a sub-issue's PR merges, the loop edits the epic body and flips the corresponding line from `- [ ]` to `- [x]`:
+
+```diff
+ ## Sub-issues
+-- [ ] #158 Add tenant column to users table
++- [x] #158 Add tenant column to users table
+ - [ ] #159 Add tenant middleware to Express router
+```
+
+GitHub's progress indicator on the epic updates automatically from this.
+
+### Safety Rail
+
+The checklist updater throws loudly if it cannot find the expected `- [ ] #N` line in the epic body. This is the **one-agent-per-epic contract**: if two loop sessions are editing the same epic, they will trip each other's safety checks and the second will fail rather than silently double-writing.
+
+**Concurrent sessions against the same epic are not supported.** Running two `alpha-loop run --epic 165` processes in parallel will corrupt the checklist or error out; always run one at a time.
+
+## Verification Pass
+
+When every sub-issue in the task-list is either merged or skipped, the loop runs a **verification pass**:
+
+1. The review model (see `pipeline.review.model` in `.alpha-loop.yaml`) reads each sub-issue's Acceptance Criteria checklist.
+2. For each sub-issue, it inspects the merged PR's diff and judges whether each AC item is satisfied.
+3. It aggregates into an overall verdict: `pass`, `partial`, or `fail`.
+4. It posts a structured comment on the epic with the per-sub-issue breakdown.
+
+Verdict outcomes:
+
+| Verdict | Action |
+|---------|--------|
+| `pass` | Epic is closed with reason `completed` |
+| `partial` | Epic stays open; `needs-human-input` label is added |
+| `fail` | Epic stays open; `needs-human-input` label is added |
+
+### Re-running Verification Only
+
+```bash
+alpha-loop run --verify-only 165
+```
+
+Re-runs just the verification pass on epic `#165`. This is **permissive**: it works even if some sub-issues are not yet merged. When any sub-issue is still open, the overall verdict caps at `partial` — a `pass` is only possible when every sub-issue has shipped.
+
+Use this when you have edited a sub-issue PR, re-tuned the AC, or want to re-judge after a manual fix.
+
+## Config: `prefer_epics`
+
+```yaml
+# .alpha-loop.yaml
+prefer_epics: true
+```
+
+When this is `true` and there is exactly one open epic in the repo, the loop auto-selects it without prompting. If there are zero or multiple open epics, the picker is shown normally.
+
+This is useful for teams that keep one active epic at a time and want `alpha-loop run` to "just start" without interaction.
+
+## Non-Goals (v1)
+
+- **Nested epics.** Sub-issues with the `epic` label are skipped with a warning. Build a flat epic instead.
+- **Cross-repo sub-issue references.** Lines like `- [ ] owner/other-repo#42` are ignored silently. Sub-issues must live in the same repo as the epic.
+- **Automatic epic creation.** You create the epic issue and populate its task-list yourself. The loop does not turn loose issues into an epic.
+- **GitHub Projects v2 native sub-issues API.** The loop reads task-lists from the issue body, not from the Projects v2 sub-issue hierarchy.
+
+## Example Workflow
+
+A walk-through of epic `#165` "Multi-tenant support" with 7 sub-issues.
+
+**1. Create the epic.** You open issue `#165`, add the `epic` label, and populate the body:
+
+```markdown
+## Sub-issues
+- [ ] #158 Add tenant column to users table
+- [ ] #159 Add tenant middleware
+- [ ] #160 Scope existing queries by tenant
+- [ ] #161 Add tenant header validation
+- [ ] #162 Update docs
+- [ ] #163 Add tenant admin dashboard
+- [ ] #164 Backfill migration for existing rows
+```
+
+Each sub-issue has its own AC checklist and the `ready` label. `#163` does not yet have `ready`.
+
+**2. Start the loop.**
+
+```bash
+alpha-loop run --epic 165
+```
+
+**3. Sub-issues run in checklist order.**
+
+The loop processes `#158`, `#159`, `#160`, `#161`, `#162`. Each PR gets `Part of #165` appended. As each merges, the corresponding line in the epic body flips to `- [x]`.
+
+**4. `#163` is skipped.** It has no `ready` label. The loop logs a warning and moves on.
+
+**5. `#164` runs and merges.** Checklist flips.
+
+**6. Verification pass runs.** One sub-issue (`#163`) is still open, so the verdict caps at `partial`. The loop posts a structured comment on `#165` summarizing per-sub-issue AC coverage and adds the `needs-human-input` label. Epic stays open.
+
+**7. You review the comment.** `#163` genuinely was not ready; you add the `ready` label and run:
+
+```bash
+alpha-loop run --epic 165
+```
+
+The loop picks up where it left off — only `#163` is unchecked — processes it, and on merge runs verification again.
+
+**8. Verification passes.** All seven sub-issues' AC items are satisfied. The loop closes epic `#165` with reason `completed`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,9 @@ program
   .option('--validate', 'Run pre-session validation on all queued issues before processing')
   .option('--fix', 'Auto-fix validation issues (reorder deps, comment on incomplete issues)')
   .option('--verbose', 'Stream live agent output to terminal')
+  .option('--epic <n>', 'Process a specific epic by issue number (skips the picker)', parseInt)
+  .option('--no-epic', 'Skip the epic picker, use flat/milestone flow')
+  .option('--verify-only <n>', 'Run only the verification pass on an existing epic', parseInt)
   .action(async (options) => {
     const { runCommand } = await import('./commands/run.js');
     if (options.once) options.maxIssues = 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,7 +37,7 @@ program
   .option('--fix', 'Auto-fix validation issues (reorder deps, comment on incomplete issues)')
   .option('--verbose', 'Stream live agent output to terminal')
   .option('--epic <n>', 'Process a specific epic by issue number (skips the picker)', parseInt)
-  .option('--no-epic', 'Skip the epic picker, use flat/milestone flow')
+  .option('--skip-epic', 'Skip the epic picker, use flat/milestone flow')
   .option('--verify-only <n>', 'Run only the verification pass on an existing epic', parseInt)
   .action(async (options) => {
     const { runCommand } = await import('./commands/run.js');

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -183,6 +183,8 @@ const REQUIRED_LABELS = [
   { name: 'in-progress', color: '1D76DB', description: 'Agent is working on this' },
   { name: 'in-review', color: 'FBCA04', description: 'PR created, awaiting review' },
   { name: 'failed', color: 'D93F0B', description: 'Agent processing failed' },
+  { name: 'epic', color: '8B5CF6', description: 'Tracker issue with sub-issue checklist' },
+  { name: 'needs-human-input', color: 'E99695', description: 'Requires human review or decision' },
 ];
 
 /**

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -6,7 +6,13 @@ import * as readline from 'node:readline';
 import { log } from '../lib/logger.js';
 import { exec } from '../lib/shell.js';
 import { loadConfig, assertSafeShellArg, type Config } from '../lib/config.js';
-import { pollIssues, listMilestones, type Milestone } from '../lib/github.js';
+import {
+  pollIssues, listMilestones, listEpics, getEpicSubIssues, getIssueWithComments,
+  getMergedPRForIssue, updateEpicChecklist, commentIssue, closeIssue, labelIssue,
+  type Milestone, type Issue,
+} from '../lib/github.js';
+import { buildEpicSummary } from '../lib/epics.js';
+import { verifyEpic } from '../lib/verify-epic.js';
 import { processIssue, processBatch } from '../lib/pipeline.js';
 import { createSession, finalizeSession, type SessionContext } from '../lib/session.js';
 import { cleanupWorktree } from '../lib/worktree.js';
@@ -37,6 +43,12 @@ export type RunOptions = {
   verbose?: boolean;
   validate?: boolean;
   fix?: boolean;
+  /** Force a specific epic by number, skip picker. */
+  epic?: number;
+  /** Skip the epic picker entirely, use flat/milestone flow. */
+  noEpic?: boolean;
+  /** Run only the verification pass on an existing epic. */
+  verifyOnly?: number;
 };
 
 /**
@@ -142,16 +154,39 @@ function askChoice(prompt: string, max: number): Promise<number> {
   });
 }
 
+export type PickTargetResult =
+  | { type: 'epic'; epicNum: number; epicTitle: string }
+  | { type: 'milestone'; title: string }
+  | { type: 'all' };
+
 /**
- * Show open milestones and let the user pick one, or choose "all in order".
- * Returns the milestone title to filter by, or empty string for all issues.
+ * Show open epics + milestones and let the user pick one, or choose "all in order".
+ * Epics are listed first (they're typically what the user actually wants).
+ *
+ * When `preferEpics` is true and there's exactly one open epic, the picker
+ * auto-selects it without prompting.
+ *
+ * When `hideEpics` is true, epics are not shown or auto-selected (the `--no-epic`
+ * flag path).
  */
-async function pickMilestone(repo: string): Promise<string> {
+async function pickTarget(
+  repo: string,
+  opts: { preferEpics: boolean; hideEpics: boolean },
+): Promise<PickTargetResult> {
+  const epics = opts.hideEpics ? [] : listEpics(repo);
   const milestones = listMilestones(repo);
 
-  if (milestones.length === 0) {
-    log.info('No open milestones found — processing all ready issues');
-    return '';
+  if (epics.length === 0 && milestones.length === 0) {
+    log.info('No open epics or milestones found — processing all ready issues');
+    return { type: 'all' };
+  }
+
+  // preferEpics: when there's exactly one open epic and the user has opted in,
+  // skip the picker and use it. This is the common case for a single-initiative repo.
+  if (opts.preferEpics && epics.length === 1) {
+    const only = epics[0];
+    log.info(`preferEpics: auto-selecting sole open epic #${only.number}`);
+    return { type: 'epic', epicNum: only.number, epicTitle: only.title };
   }
 
   const BOLD = '\x1b[1m';
@@ -159,29 +194,113 @@ async function pickMilestone(repo: string): Promise<string> {
   const NC = '\x1b[0m';
 
   console.error('');
-  console.error(`${BOLD}  Open Milestones${NC}`);
-  console.error('');
-  console.error(`  ${BOLD}0${NC}  All issues (no milestone filter)`);
-  for (let i = 0; i < milestones.length; i++) {
-    const m = milestones[i];
-    const progress = m.openIssues + m.closedIssues > 0
-      ? `${m.closedIssues}/${m.openIssues + m.closedIssues} done`
-      : 'empty';
-    const due = m.dueOn ? ` · due ${m.dueOn.split('T')[0]}` : '';
-    console.error(`  ${BOLD}${i + 1}${NC}  ${m.title} ${DIM}(${m.openIssues} open, ${progress}${due})${NC}`);
+  if (epics.length > 0) {
+    console.error(`${BOLD}  Open Epics${NC}`);
+    console.error('');
+    for (let i = 0; i < epics.length; i++) {
+      const e = epics[i];
+      const summary = buildEpicSummary(e);
+      const progress = summary.totalCount > 0
+        ? `${summary.doneCount}/${summary.totalCount} done`
+        : 'no sub-issues';
+      console.error(`  ${BOLD}${i + 1}${NC}  ${e.title} #${e.number} ${DIM}(${progress})${NC}`);
+    }
+    console.error('');
   }
+
+  if (milestones.length > 0) {
+    console.error(`${BOLD}  Open Milestones${NC}`);
+    console.error('');
+    for (let i = 0; i < milestones.length; i++) {
+      const m = milestones[i];
+      const progress = m.openIssues + m.closedIssues > 0
+        ? `${m.closedIssues}/${m.openIssues + m.closedIssues} done`
+        : 'empty';
+      const due = m.dueOn ? ` · due ${m.dueOn.split('T')[0]}` : '';
+      console.error(`  ${BOLD}${epics.length + i + 1}${NC}  ${m.title} ${DIM}(${m.openIssues} open, ${progress}${due})${NC}`);
+    }
+    console.error('');
+  }
+
+  const total = epics.length + milestones.length;
+  console.error(`  ${BOLD}0${NC}  All ready issues (no filter)`);
   console.error('');
 
-  const choice = await askChoice(`  Select milestone [0-${milestones.length}]: `, milestones.length);
+  const choice = await askChoice(`  Select [0-${total}]: `, total);
 
   if (choice <= 0) {
-    log.info('Processing all ready issues (no milestone filter)');
-    return '';
+    log.info('Processing all ready issues (no filter)');
+    return { type: 'all' };
   }
 
-  const selected = milestones[choice - 1];
+  if (choice <= epics.length) {
+    const selected = epics[choice - 1];
+    log.success(`Epic selected: ${selected.title} (#${selected.number})`);
+    return { type: 'epic', epicNum: selected.number, epicTitle: selected.title };
+  }
+
+  const milestoneIdx = choice - epics.length - 1;
+  const selected = milestones[milestoneIdx];
   log.success(`Milestone selected: ${selected.title} (${selected.openIssues} open issues)`);
-  return selected.title;
+  return { type: 'milestone', title: selected.title };
+}
+
+/**
+ * Run the verification pass on an epic: fetch sub-issues + merged PRs, evaluate
+ * AC via the review model, post a summary comment, and close the epic on pass
+ * (or add `needs-human-input` on partial/fail).
+ *
+ * Shared between the post-loop trigger and the `--verify-only` entry point.
+ */
+async function runEpicVerificationFlow(
+  epicNum: number,
+  config: Config,
+  session: SessionContext | null,
+): Promise<void> {
+  const epic = getIssueWithComments(config.repo, epicNum);
+  if (!epic) {
+    log.error(`Could not fetch epic #${epicNum}`);
+    return;
+  }
+  const refs = getEpicSubIssues(config.repo, epicNum);
+  if (refs.length === 0) {
+    log.warn(`Epic #${epicNum} has no sub-issues in its checklist — nothing to verify`);
+    return;
+  }
+
+  const subIssues: Issue[] = [];
+  const mergedPRUrls: Array<string | null> = [];
+  for (const ref of refs) {
+    const sub = getIssueWithComments(config.repo, ref.number);
+    if (!sub) continue;
+    subIssues.push(sub);
+    mergedPRUrls.push(getMergedPRForIssue(config.repo, ref.number));
+  }
+
+  const logsDir = session?.logsDir
+    ?? join(process.cwd(), '.alpha-loop', 'sessions', `verify-${epicNum}-${Date.now()}`, 'logs');
+
+  if (!session) {
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(logsDir, { recursive: true });
+  }
+
+  const result = await verifyEpic({ epic, subIssues, mergedPRUrls }, config, logsDir);
+
+  if (config.dryRun) {
+    log.dry(`[verify-only] Would post comment on #${epicNum} (verdict=${result.verdict})`);
+    console.error(result.comment);
+    return;
+  }
+
+  commentIssue(config.repo, epicNum, result.comment);
+  if (result.verdict === 'pass') {
+    closeIssue(config.repo, epicNum, 'completed');
+    log.success(`Epic #${epicNum} verified and closed`);
+  } else {
+    labelIssue(config.repo, epicNum, 'needs-human-input');
+    log.warn(`Epic #${epicNum} needs human review: verdict=${result.verdict}`);
+  }
 }
 
 /**
@@ -209,17 +328,56 @@ export async function runCommand(options: RunOptions): Promise<void> {
     process.exit(1);
   }
 
-  // Milestone selection (interactive or from config/CLI flag) — must happen before session creation
-  let activeMilestone = config.milestone;
-  if (!activeMilestone && !config.dryRun && process.stdin.isTTY) {
-    activeMilestone = await pickMilestone(config.repo);
+  // --- Verify-only path: bypass the normal loop entirely ---
+  if (options.verifyOnly !== undefined) {
+    log.step(`Running verify-only pass for epic #${options.verifyOnly}`);
+    await runEpicVerificationFlow(options.verifyOnly, config, null);
+    return;
   }
-  if (activeMilestone) {
+
+  // --- Target selection (epic or milestone) — must happen before session creation ---
+  let activeEpic: number | undefined;
+  let activeEpicTitle: string | undefined;
+  let activeMilestone = config.milestone;
+
+  // --epic <N> overrides everything except --verify-only
+  if (options.epic !== undefined) {
+    const epic = getIssueWithComments(config.repo, options.epic);
+    if (!epic) {
+      log.error(`Could not fetch epic #${options.epic}`);
+      process.exit(1);
+    }
+    activeEpic = epic.number;
+    activeEpicTitle = epic.title;
+    activeMilestone = '';
+  }
+
+  // Interactive picker when TTY and nothing preset
+  if (activeEpic === undefined && !activeMilestone && !config.dryRun && process.stdin.isTTY) {
+    const target = await pickTarget(config.repo, {
+      preferEpics: config.preferEpics,
+      hideEpics: options.noEpic === true,
+    });
+    if (target.type === 'epic') {
+      activeEpic = target.epicNum;
+      activeEpicTitle = target.epicTitle;
+    } else if (target.type === 'milestone') {
+      activeMilestone = target.title;
+    }
+  }
+
+  if (activeEpic !== undefined) {
+    log.info(`Processing epic #${activeEpic}${activeEpicTitle ? ': ' + activeEpicTitle : ''}`);
+  } else if (activeMilestone) {
     log.info(`Filtering issues by milestone: ${activeMilestone}`);
   }
 
-  // Create session (named after milestone if selected)
-  const session = createSession(config, { milestone: activeMilestone || undefined });
+  // Create session (named after epic or milestone if selected)
+  const session = createSession(config, {
+    milestone: activeMilestone || undefined,
+    epicNum: activeEpic,
+    epicTitle: activeEpicTitle,
+  });
 
   // Print startup banner
   printBanner(config, session);
@@ -325,15 +483,44 @@ export async function runCommand(options: RunOptions): Promise<void> {
     }
   }
 
-  // Fetch all matching issues
-  const milestoneMsg = activeMilestone ? ` in milestone '${activeMilestone}'` : '';
-  log.info(`Fetching issues${milestoneMsg}...`);
+  // --- Fetch issue queue ---
+  // When an epic is selected, the queue is its sub-issues in checklist order.
+  // Otherwise, fetch via the usual project/label/milestone path and exclude
+  // epic-labeled issues (AC #2: epics never picked up by the normal `ready` flow).
+  let issues: Issue[];
+  if (activeEpic !== undefined) {
+    log.info(`Fetching sub-issues of epic #${activeEpic} in checklist order...`);
+    const refs = getEpicSubIssues(config.repo, activeEpic);
+    issues = [];
+    for (const ref of refs) {
+      if (ref.checked) continue; // already done
+      const sub = getIssueWithComments(config.repo, ref.number);
+      if (!sub) {
+        log.warn(`Sub-issue #${ref.number} skipped: could not fetch`);
+        continue;
+      }
+      if (sub.labels.includes('epic')) {
+        log.warn(`Sub-issue #${sub.number} skipped: is itself an epic (nested epics unsupported in v1)`);
+        continue;
+      }
+      if (!sub.labels.includes(config.labelReady)) {
+        log.warn(`Sub-issue #${sub.number} skipped: not labeled '${config.labelReady}'`);
+        continue;
+      }
+      issues.push(sub);
+    }
+  } else {
+    const milestoneMsg = activeMilestone ? ` in milestone '${activeMilestone}'` : '';
+    log.info(`Fetching issues${milestoneMsg}...`);
+    issues = pollIssues(config.repo, config.labelReady, 100, {
+      project: config.project,
+      repoOwner: config.repoOwner,
+      milestone: activeMilestone || undefined,
+    }).filter((iss) => !iss.labels.includes('epic'));
+  }
 
-  const issues = pollIssues(config.repo, config.labelReady, 100, {
-    project: config.project,
-    repoOwner: config.repoOwner,
-    milestone: activeMilestone || undefined,
-  });
+  // When set mid-loop, skip post-loop epic verification (e.g. checklist body inconsistency).
+  let epicAbort = false;
 
   if (issues.length === 0) {
     log.info('No issues found. Nothing to do.');
@@ -415,6 +602,27 @@ export async function runCommand(options: RunOptions): Promise<void> {
           const results = await processBatch(batchIssues, config, session);
           session.results.push(...results);
 
+          // Flip epic checklist for each successful sub-issue
+          if (activeEpic !== undefined) {
+            let checklistError = false;
+            for (const r of results) {
+              if (r.status !== 'success') continue;
+              try {
+                updateEpicChecklist(config.repo, activeEpic, r.issueNum, true);
+              } catch (err) {
+                log.error(`Epic #${activeEpic} checklist update failed for sub-issue #${r.issueNum}: ${err instanceof Error ? err.message : err}`);
+                // One-agent-per-epic contract — halt further processing on body inconsistency
+                epicAbort = true;
+                checklistError = true;
+                break;
+              }
+            }
+            if (checklistError) {
+              activeIssueNum = null;
+              break;
+            }
+          }
+
           // Stop if any issue hit a transient error
           if (results.some((r) => r.failureReason === 'transient')) {
             log.warn('Agent hit a rate/usage limit — stopping session to avoid wasting cycles');
@@ -454,6 +662,19 @@ export async function runCommand(options: RunOptions): Promise<void> {
           );
           session.results.push(result);
 
+          // Flip the epic checklist box when this sub-issue succeeded
+          if (activeEpic !== undefined && result.status === 'success') {
+            try {
+              updateEpicChecklist(config.repo, activeEpic, issue.number, true);
+            } catch (err) {
+              log.error(`Epic #${activeEpic} checklist update failed for sub-issue #${issue.number}: ${err instanceof Error ? err.message : err}`);
+              // One-agent-per-epic contract — halt further processing on body inconsistency
+              epicAbort = true;
+              activeIssueNum = null;
+              break;
+            }
+          }
+
           // Stop processing if agent hit a transient error (usage/rate limit)
           if (result.failureReason === 'transient') {
             log.warn('Agent hit a rate/usage limit — stopping session to avoid wasting cycles');
@@ -465,6 +686,21 @@ export async function runCommand(options: RunOptions): Promise<void> {
 
         activeIssueNum = null;
       }
+    }
+  }
+
+  // --- Epic completion check: verify and close if all sub-issues are now done ---
+  if (activeEpic !== undefined && !epicAbort && !config.dryRun) {
+    try {
+      const remaining = getEpicSubIssues(config.repo, activeEpic).filter((r) => !r.checked);
+      if (remaining.length === 0) {
+        log.step(`All sub-issues of epic #${activeEpic} are complete — running verification pass`);
+        await runEpicVerificationFlow(activeEpic, config, session);
+      } else {
+        log.info(`Epic #${activeEpic}: ${remaining.length} sub-issue(s) still open — verification deferred`);
+      }
+    } catch (err) {
+      log.warn(`Epic completion check failed: ${err instanceof Error ? err.message : err}`);
     }
   }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -46,7 +46,7 @@ export type RunOptions = {
   /** Force a specific epic by number, skip picker. */
   epic?: number;
   /** Skip the epic picker entirely, use flat/milestone flow. */
-  noEpic?: boolean;
+  skipEpic?: boolean;
   /** Run only the verification pass on an existing epic. */
   verifyOnly?: number;
 };
@@ -166,7 +166,7 @@ export type PickTargetResult =
  * When `preferEpics` is true and there's exactly one open epic, the picker
  * auto-selects it without prompting.
  *
- * When `hideEpics` is true, epics are not shown or auto-selected (the `--no-epic`
+ * When `hideEpics` is true, epics are not shown or auto-selected (the `--skip-epic`
  * flag path).
  */
 async function pickTarget(
@@ -330,6 +330,10 @@ export async function runCommand(options: RunOptions): Promise<void> {
 
   // --- Verify-only path: bypass the normal loop entirely ---
   if (options.verifyOnly !== undefined) {
+    if (!Number.isFinite(options.verifyOnly) || options.verifyOnly <= 0) {
+      log.error('--verify-only requires a positive integer issue number (e.g. --verify-only 165)');
+      process.exit(1);
+    }
     log.step(`Running verify-only pass for epic #${options.verifyOnly}`);
     await runEpicVerificationFlow(options.verifyOnly, config, null);
     return;
@@ -342,6 +346,10 @@ export async function runCommand(options: RunOptions): Promise<void> {
 
   // --epic <N> overrides everything except --verify-only
   if (options.epic !== undefined) {
+    if (typeof options.epic !== 'number' || !Number.isFinite(options.epic) || options.epic <= 0) {
+      log.error('--epic requires a positive integer issue number (e.g. --epic 165)');
+      process.exit(1);
+    }
     const epic = getIssueWithComments(config.repo, options.epic);
     if (!epic) {
       log.error(`Could not fetch epic #${options.epic}`);
@@ -356,7 +364,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
   if (activeEpic === undefined && !activeMilestone && !config.dryRun && process.stdin.isTTY) {
     const target = await pickTarget(config.repo, {
       preferEpics: config.preferEpics,
-      hideEpics: options.noEpic === true,
+      hideEpics: options.skipEpic === true,
     });
     if (target.type === 'epic') {
       activeEpic = target.epicNum;
@@ -602,8 +610,10 @@ export async function runCommand(options: RunOptions): Promise<void> {
           const results = await processBatch(batchIssues, config, session);
           session.results.push(...results);
 
-          // Flip epic checklist for each successful sub-issue
-          if (activeEpic !== undefined) {
+          // Flip epic checklist for each successful sub-issue.
+          // Skipped in dry-run: `processIssue` returns status='success' when tests are
+          // stubbed in dry-run, which would otherwise mutate the live epic body.
+          if (activeEpic !== undefined && !config.dryRun) {
             let checklistError = false;
             for (const r of results) {
               if (r.status !== 'success') continue;
@@ -620,6 +630,12 @@ export async function runCommand(options: RunOptions): Promise<void> {
             if (checklistError) {
               activeIssueNum = null;
               break;
+            }
+          } else if (activeEpic !== undefined && config.dryRun) {
+            for (const r of results) {
+              if (r.status === 'success') {
+                log.dry(`Would flip epic #${activeEpic} checklist for sub-issue #${r.issueNum}`);
+              }
             }
           }
 
@@ -662,8 +678,10 @@ export async function runCommand(options: RunOptions): Promise<void> {
           );
           session.results.push(result);
 
-          // Flip the epic checklist box when this sub-issue succeeded
-          if (activeEpic !== undefined && result.status === 'success') {
+          // Flip the epic checklist box when this sub-issue succeeded.
+          // Skipped in dry-run: `processIssue` stubs tests in dry-run and returns success,
+          // which would otherwise mutate the live epic body.
+          if (activeEpic !== undefined && result.status === 'success' && !config.dryRun) {
             try {
               updateEpicChecklist(config.repo, activeEpic, issue.number, true);
             } catch (err) {
@@ -673,6 +691,8 @@ export async function runCommand(options: RunOptions): Promise<void> {
               activeIssueNum = null;
               break;
             }
+          } else if (activeEpic !== undefined && result.status === 'success' && config.dryRun) {
+            log.dry(`Would flip epic #${activeEpic} checklist for sub-issue #${issue.number}`);
           }
 
           // Stop processing if agent hit a transient error (usage/rate limit)

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -219,7 +219,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
   }
 
   // Create session (named after milestone if selected)
-  const session = createSession(config, activeMilestone || undefined);
+  const session = createSession(config, { milestone: activeMilestone || undefined });
 
   // Print startup banner
   printBanner(config, session);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -93,6 +93,11 @@ export type Config = {
   evalIncludeAgentPrompts: boolean;
   /** Include repo-specific skills during eval runs (default: true). */
   evalIncludeSkills: boolean;
+  /**
+   * When the picker shows a milestone that contains exactly one open epic,
+   * auto-promote the selection to that epic. Default: false.
+   */
+  preferEpics: boolean;
 };
 
 const DEFAULTS: Config = {
@@ -151,6 +156,7 @@ const DEFAULTS: Config = {
   pipeline: {},
   evalIncludeAgentPrompts: true,
   evalIncludeSkills: true,
+  preferEpics: false,
 };
 
 /** Map from YAML key (snake_case) to Config key (camelCase). */
@@ -197,6 +203,7 @@ const YAML_KEY_MAP: Record<string, keyof Config> = {
   pipeline: 'pipeline',
   eval_include_agent_prompts: 'evalIncludeAgentPrompts',
   eval_include_skills: 'evalIncludeSkills',
+  prefer_epics: 'preferEpics',
 };
 
 /** Map from env var name to Config key. */
@@ -241,6 +248,7 @@ const ENV_KEY_MAP: Record<string, keyof Config> = {
   BATCH_SIZE: 'batchSize',
   SMOKE_TEST: 'smokeTest',
   AGENT_TIMEOUT: 'agentTimeout',
+  PREFER_EPICS: 'preferEpics',
 };
 
 function coerce(value: string, current: unknown): unknown {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -94,8 +94,8 @@ export type Config = {
   /** Include repo-specific skills during eval runs (default: true). */
   evalIncludeSkills: boolean;
   /**
-   * When the picker shows a milestone that contains exactly one open epic,
-   * auto-promote the selection to that epic. Default: false.
+   * When there is exactly one open epic in the repo, the picker auto-selects
+   * it instead of prompting. Default: false.
    */
   preferEpics: boolean;
 };

--- a/src/lib/epics.ts
+++ b/src/lib/epics.ts
@@ -1,0 +1,103 @@
+/**
+ * Epic primitives — pure functions for parsing and mutating epic issue bodies.
+ *
+ * An "epic" is a GitHub issue whose body contains a task-list of sub-issue
+ * references (`- [ ] #N` lines). This module is the single source of truth
+ * for how that checklist is parsed and modified.
+ *
+ * All functions here are pure — no gh CLI calls, no side effects. Callers in
+ * github.ts wire these into read/modify/write flows.
+ */
+import type { Issue } from './github.js';
+
+const SUB_ISSUE_LINE_RE = /^(\s*)- \[([ xX])\] #(\d+)\b/;
+const EPIC_HEURISTIC_MIN_ITEMS = 3;
+
+export type SubIssueRef = {
+  number: number;
+  checked: boolean;
+  /** Zero-indexed line position in the split body — used for surgical replacement. */
+  lineIndex: number;
+};
+
+export type EpicSummary = {
+  number: number;
+  title: string;
+  subIssues: SubIssueRef[];
+  doneCount: number;
+  totalCount: number;
+};
+
+/**
+ * Parse task-list sub-issue references from an issue body.
+ *
+ * Matches lines like `- [ ] #42` or `- [x] #42` (with optional leading
+ * whitespace to allow nested markdown lists). Cross-repo refs like
+ * `- [ ] owner/repo#42` are silently skipped — see the v1 non-goals.
+ *
+ * Returns refs in document order.
+ */
+export function parseSubIssues(body: string): SubIssueRef[] {
+  const lines = body.split('\n');
+  const refs: SubIssueRef[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const m = SUB_ISSUE_LINE_RE.exec(line);
+    if (!m) continue;
+    refs.push({
+      number: parseInt(m[3], 10),
+      checked: m[2] === 'x' || m[2] === 'X',
+      lineIndex: i,
+    });
+  }
+  return refs;
+}
+
+/**
+ * Flip the checkbox state for a specific sub-issue in a body string.
+ *
+ * Surgical: finds the first line matching `- [?] #N` and rewrites only
+ * that line's checkbox character. All other markdown is preserved byte-for-byte.
+ *
+ * Returns the new body. If the target sub-issue is not found, returns the
+ * original body unchanged — callers in github.ts detect this case by
+ * comparing before/after and throwing, since one-agent-per-epic is the contract.
+ */
+export function flipChecklistItem(body: string, subIssueNum: number, checked: boolean): string {
+  const lines = body.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const m = SUB_ISSUE_LINE_RE.exec(lines[i]);
+    if (!m) continue;
+    if (parseInt(m[3], 10) !== subIssueNum) continue;
+    const newBox = checked ? 'x' : ' ';
+    lines[i] = lines[i].replace(SUB_ISSUE_LINE_RE, `${m[1]}- [${newBox}] #${m[3]}`);
+    return lines.join('\n');
+  }
+  return body;
+}
+
+/**
+ * Heuristic epic detection. Returns true when the body contains at least
+ * {@link EPIC_HEURISTIC_MIN_ITEMS} sub-issue task-list refs.
+ *
+ * This is a warning hint only — the authoritative epic detection is the
+ * `epic` label. An unlabeled tracker issue just looks like a regular issue.
+ */
+export function looksLikeEpic(body: string): boolean {
+  return parseSubIssues(body).length >= EPIC_HEURISTIC_MIN_ITEMS;
+}
+
+/**
+ * Build an EpicSummary from a parsed issue.
+ */
+export function buildEpicSummary(issue: Issue): EpicSummary {
+  const subIssues = parseSubIssues(issue.body);
+  const doneCount = subIssues.filter(r => r.checked).length;
+  return {
+    number: issue.number,
+    title: issue.title,
+    subIssues,
+    doneCount,
+    totalCount: subIssues.length,
+  };
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import { exec } from './shell.js';
 import { ghExec, getProjectCache, setProjectCache } from './rate-limit.js';
 import { log } from './logger.js';
+import { flipChecklistItem, parseSubIssues, type SubIssueRef } from './epics.js';
 
 /** Max PR body length. GitHub supports 65536 but we leave room for metadata. */
 const MAX_PR_BODY_CHARS = 60_000;
@@ -748,4 +749,89 @@ export function addIssueToProject(owner: string, projectNum: number, repo: strin
 function truncateBody(body: string): string {
   if (body.length <= MAX_PR_BODY_CHARS) return body;
   return body.slice(0, MAX_PR_BODY_CHARS) + '\n\n... (body truncated, see full log)';
+}
+
+/**
+ * List open issues labeled `epic`.
+ */
+export function listEpics(repo: string): Issue[] {
+  const result = ghExec(
+    `gh issue list --repo "${repo}" --label "epic" --state open --json number,title,body,labels --limit 100`,
+  );
+  if (result.exitCode !== 0) {
+    log.warn(`Failed to list epics: ${result.stderr}`);
+    return [];
+  }
+  try {
+    const raw = JSON.parse(result.stdout) as Array<{
+      number: number;
+      title: string;
+      body: string;
+      labels: Array<{ name: string }>;
+    }>;
+    return raw.map((issue) => ({
+      number: issue.number,
+      title: issue.title,
+      body: issue.body ?? '',
+      labels: (issue.labels ?? []).map((l) => l.name),
+    }));
+  } catch {
+    log.warn('Failed to parse epics JSON');
+    return [];
+  }
+}
+
+/**
+ * Fetch an epic and return its parsed sub-issue refs in checklist order.
+ * Returns empty array if the epic cannot be fetched.
+ */
+export function getEpicSubIssues(repo: string, epicNum: number): SubIssueRef[] {
+  const epic = getIssueWithComments(repo, epicNum);
+  if (!epic) return [];
+  return parseSubIssues(epic.body);
+}
+
+/**
+ * Flip the checklist box for `subIssueNum` in the epic's body.
+ *
+ * Throws if the expected `- [?] #<subIssueNum>` line is not present in the
+ * fetched body. One-agent-per-epic is the contract; a missing line means
+ * either external mutation since this session started or a bug — either way,
+ * loud failure, not silent drift.
+ */
+export function updateEpicChecklist(repo: string, epicNum: number, subIssueNum: number, checked: boolean): void {
+  const epic = getIssueWithComments(repo, epicNum);
+  if (!epic) {
+    throw new Error(`updateEpicChecklist: could not fetch epic #${epicNum}`);
+  }
+  const refs = parseSubIssues(epic.body);
+  if (!refs.some((r) => r.number === subIssueNum)) {
+    throw new Error(
+      `updateEpicChecklist: epic #${epicNum} body no longer contains a checklist line for sub-issue #${subIssueNum}`,
+    );
+  }
+  const newBody = flipChecklistItem(epic.body, subIssueNum, checked);
+  if (newBody === epic.body) {
+    // Already in the requested state — no-op.
+    return;
+  }
+  updateIssue(repo, epicNum, { body: newBody });
+}
+
+/**
+ * Find the merged PR URL that closed `issueNum`, or null if none.
+ * Uses GitHub's search for `closes:#N` — matches the convention used by
+ * `buildPRBody()` in pipeline.ts.
+ */
+export function getMergedPRForIssue(repo: string, issueNum: number): string | null {
+  const result = ghExec(
+    `gh pr list --repo "${repo}" --search "closes:#${issueNum}" --state merged --json url --limit 1`,
+  );
+  if (result.exitCode !== 0) return null;
+  try {
+    const prs = JSON.parse(result.stdout) as Array<{ url: string }>;
+    return prs[0]?.url ?? null;
+  } catch {
+    return null;
+  }
 }

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -1807,7 +1807,7 @@ function buildBatchPRBody(
   return lines.join('\n');
 }
 
-function buildPRBody(
+export function buildPRBody(
   issueNum: number,
   title: string,
   reviewGate: GateResult,

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -861,7 +861,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
   if (!config.dryRun) {
     const prBase = config.autoMerge ? session.branch : config.baseBranch;
-    const prBody = buildPRBody(issueNum, title, reviewGate, testOutput, testsPassing, verifyPassing, verifySkipped, body);
+    const prBody = buildPRBody(issueNum, title, reviewGate, testOutput, testsPassing, verifyPassing, verifySkipped, body, session.epic);
 
     try {
       prUrl = createPR({
@@ -1816,14 +1816,18 @@ function buildPRBody(
   verifyPassing: boolean,
   verifySkipped: boolean,
   body: string,
+  epicNum?: number,
 ): string {
   const testSummary = extractTestSummary(testOutput);
 
   const verifyStatus = verifySkipped ? 'SKIPPED' : verifyPassing ? 'PASS' : 'FAIL';
   const reviewStatus = reviewGate.passed ? 'PASS' : 'FAIL';
 
+  const refs = [`Closes #${issueNum}`];
+  if (epicNum !== undefined) refs.push(`Part of #${epicNum}`);
+
   const lines: string[] = [
-    `Closes #${issueNum}`,
+    ...refs,
     '',
     `## Summary`,
     '',

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -17,18 +17,42 @@ export type SessionContext = {
   logsDir: string;
   results: PipelineResult[];
   sessionReviewFindings?: GateResult;
+  /** When set, this session processes sub-issues of the given epic. */
+  epic?: number;
 };
+
+export type CreateSessionOptions = {
+  milestone?: string;
+  /** When set, session is scoped to an epic — drives the name slug and PR title. */
+  epicNum?: number;
+  /** Title of the epic, used to form a human-readable session slug. */
+  epicTitle?: string;
+};
+
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
 
 /**
  * Create a new session context with timestamp-based name.
  * Optionally creates a session branch when autoMerge is enabled.
  */
-export function createSession(config: Config, milestone?: string): SessionContext {
+export function createSession(config: Config, options?: CreateSessionOptions): SessionContext {
   const now = new Date();
   const timestamp = formatTimestamp(now);
-  const slug = milestone
-    ? milestone.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-    : timestamp;
+  const milestone = options?.milestone;
+  const epicNum = options?.epicNum;
+  const epicTitle = options?.epicTitle;
+
+  let slug: string;
+  if (epicNum !== undefined) {
+    const titleSlug = epicTitle ? slugify(epicTitle) : '';
+    slug = titleSlug ? `epic-${epicNum}-${titleSlug}` : `epic-${epicNum}`;
+  } else if (milestone) {
+    slug = slugify(milestone);
+  } else {
+    slug = timestamp;
+  }
   const name = `session/${slug}`;
   const branch = config.mergeTo || name;
 
@@ -68,8 +92,14 @@ export function createSession(config: Config, milestone?: string): SessionContex
           repo: config.repo,
           base: config.baseBranch,
           head: branch,
-          title: milestone ? `Milestone: ${milestone}` : `Session: ${name}`,
-          body: `## Session In Progress\n\n${milestone ? `**Milestone:** ${milestone}\n` : ''}**Branch:** ${branch}\n**Started:** ${new Date().toISOString()}\n\nThis PR will be updated as issues are processed.\n\n---\n*Automated by alpha-loop*`,
+          title: epicNum !== undefined
+            ? `Epic #${epicNum}${epicTitle ? `: ${epicTitle}` : ''}`
+            : milestone ? `Milestone: ${milestone}` : `Session: ${name}`,
+          body: `## Session In Progress\n\n${
+            epicNum !== undefined
+              ? `**Epic:** #${epicNum}${epicTitle ? ` — ${epicTitle}` : ''}\n`
+              : milestone ? `**Milestone:** ${milestone}\n` : ''
+          }**Branch:** ${branch}\n**Started:** ${new Date().toISOString()}\n\nThis PR will be updated as issues are processed.\n\n---\n*Automated by alpha-loop*`,
           cwd: projectDir,
         });
         log.success(`Session PR (draft): ${draftPR}`);
@@ -121,7 +151,7 @@ export function createSession(config: Config, milestone?: string): SessionContex
     }
   }
 
-  return { name, branch, resultsDir, logsDir, results: [] };
+  return { name, branch, resultsDir, logsDir, results: [], epic: epicNum };
 }
 
 /**

--- a/src/lib/verify-epic.ts
+++ b/src/lib/verify-epic.ts
@@ -1,0 +1,284 @@
+/**
+ * Epic verification pass — runs after all sub-issues of an epic have shipped.
+ *
+ * The agent is given the epic body (with its acceptance criteria), each
+ * sub-issue body (with its own AC checklist), and the merged PR diffs.
+ * It emits a structured {@link EpicVerdict} JSON block rating each
+ * sub-issue's AC against what actually landed.
+ *
+ * Permissive `--verify-only` mode: sub-issues without a merged PR are reported
+ * as `skipped` in the comment; the overall verdict caps at `partial` in that
+ * case (we can't declare `pass` without full coverage).
+ */
+import { spawnAgent } from './agent.js';
+import { log } from './logger.js';
+import { ghExec } from './rate-limit.js';
+import type { Config } from './config.js';
+import type { Issue } from './github.js';
+
+/** Max chars of a single PR diff to include in the prompt. Mirrors pipeline.ts. */
+const MAX_DIFF_CHARS = 10_000;
+
+export type EpicFindingVerdict = 'met' | 'partial' | 'missing' | 'unclear';
+export type EpicOverallVerdict = 'pass' | 'partial' | 'fail';
+
+export type EpicFinding = {
+  issueNum: number;
+  criterion: string;
+  verdict: EpicFindingVerdict;
+  notes?: string;
+};
+
+export type EpicVerdict = {
+  verdict: EpicOverallVerdict;
+  summary: string;
+  findings: EpicFinding[];
+};
+
+export type VerifyEpicInput = {
+  epic: Issue;
+  subIssues: Issue[];
+  /** Parallel to subIssues — null entries indicate sub-issues without a merged PR. */
+  mergedPRUrls: Array<string | null>;
+};
+
+export type VerifyEpicResult = {
+  verdict: EpicOverallVerdict;
+  comment: string;
+  parsed: EpicVerdict;
+};
+
+const DEFAULT_VERDICT: EpicVerdict = {
+  verdict: 'partial',
+  summary: 'Verification output could not be parsed; defaulting to partial.',
+  findings: [],
+};
+
+/**
+ * Extract a pr number from a github PR URL like
+ * `https://github.com/owner/repo/pull/42`.
+ */
+function prNumberFromUrl(url: string): number | null {
+  const m = url.match(/\/pull\/(\d+)(?:\D|$)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+function fetchPRDiff(repo: string, prUrl: string): string {
+  const prNum = prNumberFromUrl(prUrl);
+  if (prNum === null) return '';
+  const result = ghExec(`gh pr diff ${prNum} --repo "${repo}"`);
+  if (result.exitCode !== 0) return '';
+  const diff = result.stdout;
+  return diff.length > MAX_DIFF_CHARS
+    ? diff.slice(0, MAX_DIFF_CHARS) + '\n\n... (diff truncated)'
+    : diff;
+}
+
+/** Extract the last fenced ```json block from agent output, or a trailing JSON object. */
+function extractJsonBlock(output: string): string | null {
+  const fence = /```json\s*([\s\S]*?)\s*```/gi;
+  let lastMatch: RegExpExecArray | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = fence.exec(output)) !== null) lastMatch = m;
+  if (lastMatch) return lastMatch[1];
+
+  const trailing = output.match(/\{[\s\S]*\}\s*$/);
+  return trailing ? trailing[0] : null;
+}
+
+function parseVerdict(output: string): EpicVerdict {
+  const block = extractJsonBlock(output);
+  if (!block) return DEFAULT_VERDICT;
+  try {
+    const parsed = JSON.parse(block) as Record<string, unknown>;
+    const rawVerdict = String(parsed.verdict ?? '').toLowerCase();
+    const verdict: EpicOverallVerdict = (['pass', 'partial', 'fail'] as const).includes(
+      rawVerdict as EpicOverallVerdict,
+    )
+      ? (rawVerdict as EpicOverallVerdict)
+      : 'partial';
+    const findings = Array.isArray(parsed.findings)
+      ? (parsed.findings as Array<Record<string, unknown>>).flatMap((f): EpicFinding[] => {
+          const issueNum = Number(f.issueNum ?? f.issue ?? 0);
+          if (!Number.isFinite(issueNum) || issueNum <= 0) return [];
+          const rawFindingVerdict = String(f.verdict ?? '').toLowerCase();
+          const findingVerdict: EpicFindingVerdict = (
+            ['met', 'partial', 'missing', 'unclear'] as const
+          ).includes(rawFindingVerdict as EpicFindingVerdict)
+            ? (rawFindingVerdict as EpicFindingVerdict)
+            : 'unclear';
+          return [
+            {
+              issueNum,
+              criterion: String(f.criterion ?? ''),
+              verdict: findingVerdict,
+              notes: f.notes ? String(f.notes) : undefined,
+            },
+          ];
+        })
+      : [];
+    return {
+      verdict,
+      summary: String(parsed.summary ?? ''),
+      findings,
+    };
+  } catch {
+    return DEFAULT_VERDICT;
+  }
+}
+
+function buildPrompt(input: VerifyEpicInput, diffs: Map<number, string>): string {
+  const lines: string[] = [
+    `You are verifying that epic #${input.epic.number} ("${input.epic.title}") has been met by its merged sub-issue PRs.`,
+    '',
+    `For each sub-issue, evaluate each acceptance-criterion checklist item against the merged PR diff.`,
+    `Return ONLY a JSON object (wrapped in a \`\`\`json code fence) matching this shape:`,
+    '',
+    '```json',
+    '{',
+    '  "verdict": "pass" | "partial" | "fail",',
+    '  "summary": "one-paragraph overall assessment",',
+    '  "findings": [',
+    '    { "issueNum": 123, "criterion": "quoted AC text", "verdict": "met" | "partial" | "missing" | "unclear", "notes": "why" }',
+    '  ]',
+    '}',
+    '```',
+    '',
+    'Rules:',
+    '- `pass` only if every criterion on every evaluated sub-issue is `met`.',
+    '- `partial` if some are met and some are `partial`/`missing`/`unclear`.',
+    '- `fail` if a majority are `missing` or `unclear`.',
+    '- Sub-issues marked as "not yet merged" in the input are out of scope — do not include findings for them.',
+    '',
+    '---',
+    '',
+    `## Epic #${input.epic.number}: ${input.epic.title}`,
+    '',
+    input.epic.body.slice(0, 4000),
+    '',
+    '## Sub-issues',
+    '',
+  ];
+
+  for (let i = 0; i < input.subIssues.length; i++) {
+    const sub = input.subIssues[i];
+    const prUrl = input.mergedPRUrls[i];
+    lines.push(`### #${sub.number}: ${sub.title}`);
+    if (!prUrl) {
+      lines.push('*Not yet merged — skipped in this pass.*', '');
+      continue;
+    }
+    lines.push(`Merged PR: ${prUrl}`, '');
+    lines.push('#### Issue body');
+    lines.push(sub.body.slice(0, 3000), '');
+    const diff = diffs.get(sub.number) ?? '';
+    if (diff) {
+      lines.push('#### Merged diff');
+      lines.push('```diff');
+      lines.push(diff);
+      lines.push('```', '');
+    } else {
+      lines.push('*(diff unavailable)*', '');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function formatComment(input: VerifyEpicInput, parsed: EpicVerdict, capped: boolean): string {
+  const lines: string[] = [
+    '## Epic Verification',
+    '',
+    `**Overall:** ${parsed.verdict.toUpperCase()}${capped ? ' (capped — some sub-issues not yet merged)' : ''}`,
+    '',
+  ];
+  if (parsed.summary) {
+    lines.push(parsed.summary, '');
+  }
+
+  lines.push('| Sub-issue | PR | Status |', '|---|---|---|');
+  for (let i = 0; i < input.subIssues.length; i++) {
+    const sub = input.subIssues[i];
+    const prUrl = input.mergedPRUrls[i];
+    if (!prUrl) {
+      lines.push(`| #${sub.number} ${sub.title} | — | not yet merged |`);
+      continue;
+    }
+    const subFindings = parsed.findings.filter((f) => f.issueNum === sub.number);
+    const met = subFindings.filter((f) => f.verdict === 'met').length;
+    const total = subFindings.length;
+    const status = total === 0
+      ? 'evaluated'
+      : met === total
+        ? `pass (${met}/${total})`
+        : `partial (${met}/${total})`;
+    lines.push(`| #${sub.number} ${sub.title} | [PR](${prUrl}) | ${status} |`);
+  }
+  lines.push('');
+
+  if (parsed.findings.length > 0) {
+    lines.push('<details>', `<summary>Per-criterion findings (${parsed.findings.length})</summary>`, '');
+    for (const f of parsed.findings) {
+      const notes = f.notes ? ` — ${f.notes}` : '';
+      lines.push(`- #${f.issueNum} • **${f.verdict}** — ${f.criterion}${notes}`);
+    }
+    lines.push('', '</details>', '');
+  }
+
+  lines.push('---', '*Verified by alpha-loop*');
+  return lines.join('\n');
+}
+
+/**
+ * Run the verification pass. If any sub-issue has no merged PR, the overall
+ * verdict is capped at `partial`.
+ */
+export async function verifyEpic(
+  input: VerifyEpicInput,
+  config: Config,
+  logsDir: string,
+): Promise<VerifyEpicResult> {
+  // Fetch diffs for every sub-issue that has a merged PR.
+  const diffs = new Map<number, string>();
+  for (let i = 0; i < input.subIssues.length; i++) {
+    const sub = input.subIssues[i];
+    const url = input.mergedPRUrls[i];
+    if (!url) continue;
+    try {
+      diffs.set(sub.number, fetchPRDiff(config.repo, url));
+    } catch (err) {
+      log.warn(`Could not fetch diff for sub-issue #${sub.number}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  const prompt = buildPrompt(input, diffs);
+  const model = config.reviewModel || config.model;
+
+  log.step(`Verifying epic #${input.epic.number} (${input.subIssues.filter((_, i) => input.mergedPRUrls[i]).length}/${input.subIssues.length} sub-issues merged)`);
+
+  let parsed: EpicVerdict;
+  try {
+    const result = await spawnAgent({
+      agent: config.agent,
+      model,
+      prompt,
+      cwd: process.cwd(),
+      logFile: `${logsDir}/epic-${input.epic.number}-verify.log`,
+      verbose: config.verbose,
+      timeout: config.agentTimeout * 1000,
+    });
+    parsed = parseVerdict(result.output);
+  } catch (err) {
+    log.warn(`Epic verification agent call failed: ${err instanceof Error ? err.message : err}`);
+    parsed = DEFAULT_VERDICT;
+  }
+
+  const hasUnmerged = input.mergedPRUrls.some((u) => !u);
+  let verdict = parsed.verdict;
+  if (hasUnmerged && verdict === 'pass') {
+    verdict = 'partial';
+  }
+
+  const comment = formatComment(input, { ...parsed, verdict }, hasUnmerged && parsed.verdict === 'pass');
+  return { verdict, comment, parsed: { ...parsed, verdict } };
+}

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -105,6 +105,8 @@ describe('ensureLabels', () => {
             { name: 'in-progress' },
             { name: 'in-review' },
             { name: 'failed' },
+            { name: 'epic' },
+            { name: 'needs-human-input' },
           ]),
           stderr: '',
         };

--- a/tests/engine/prerequisites.test.ts
+++ b/tests/engine/prerequisites.test.ts
@@ -53,6 +53,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalTimeout: 300,
     evalIncludeAgentPrompts: true,
     evalIncludeSkills: true,
+    preferEpics: false,
     autoCapture: true,
     skipPostSessionReview: false,
     skipPostSessionSecurity: false,

--- a/tests/lib/epics.test.ts
+++ b/tests/lib/epics.test.ts
@@ -1,0 +1,229 @@
+import { parseSubIssues, flipChecklistItem, looksLikeEpic, buildEpicSummary } from '../../src/lib/epics.js';
+import type { Issue } from '../../src/lib/github.js';
+
+// epics.ts contains only pure functions — no mocks needed.
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    number: 1,
+    title: 'Test epic',
+    body: '',
+    labels: [],
+    ...overrides,
+  };
+}
+
+describe('parseSubIssues', () => {
+  test('parses unchecked item - [ ] #42', () => {
+    const refs = parseSubIssues('- [ ] #42');
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ number: 42, checked: false, lineIndex: 0 });
+  });
+
+  test('parses checked item - [x] #42', () => {
+    const refs = parseSubIssues('- [x] #42');
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ number: 42, checked: true, lineIndex: 0 });
+  });
+
+  test('parses uppercase checked item - [X] #42', () => {
+    const refs = parseSubIssues('- [X] #42');
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ number: 42, checked: true, lineIndex: 0 });
+  });
+
+  test('parses indented item   - [ ] #42', () => {
+    const refs = parseSubIssues('  - [ ] #42');
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ number: 42, checked: false, lineIndex: 0 });
+  });
+
+  test('parses mixed checked and unchecked items and preserves document order', () => {
+    const body = [
+      '- [x] #10',
+      '- [ ] #20',
+      '- [X] #30',
+      '- [ ] #40',
+    ].join('\n');
+    const refs = parseSubIssues(body);
+    expect(refs).toHaveLength(4);
+    expect(refs[0]).toMatchObject({ number: 10, checked: true, lineIndex: 0 });
+    expect(refs[1]).toMatchObject({ number: 20, checked: false, lineIndex: 1 });
+    expect(refs[2]).toMatchObject({ number: 30, checked: true, lineIndex: 2 });
+    expect(refs[3]).toMatchObject({ number: 40, checked: false, lineIndex: 3 });
+  });
+
+  test('ignores cross-repo refs like - [ ] owner/repo#42', () => {
+    const refs = parseSubIssues('- [ ] owner/repo#42');
+    expect(refs).toHaveLength(0);
+  });
+
+  test('ignores plain task items without #N reference', () => {
+    const refs = parseSubIssues('- [ ] Do some work without an issue number');
+    expect(refs).toHaveLength(0);
+  });
+
+  test('returns empty array for body with no task items', () => {
+    const body = '## Description\n\nThis is a regular issue body with no tasks.';
+    const refs = parseSubIssues(body);
+    expect(refs).toHaveLength(0);
+  });
+
+  test('returns empty array for empty string', () => {
+    expect(parseSubIssues('')).toHaveLength(0);
+  });
+
+  test('records correct lineIndex in multiline body', () => {
+    const body = ['# Epic Title', '', 'Some description.', '', '- [ ] #5', '- [x] #6'].join('\n');
+    const refs = parseSubIssues(body);
+    expect(refs).toHaveLength(2);
+    expect(refs[0].lineIndex).toBe(4);
+    expect(refs[1].lineIndex).toBe(5);
+  });
+});
+
+describe('flipChecklistItem', () => {
+  test('flips [ ] to [x] for the target sub-issue', () => {
+    const body = '- [ ] #42\n- [ ] #99';
+    const result = flipChecklistItem(body, 42, true);
+    expect(result).toBe('- [x] #42\n- [ ] #99');
+  });
+
+  test('flips [x] to [ ] for the target sub-issue', () => {
+    const body = '- [x] #42\n- [x] #99';
+    const result = flipChecklistItem(body, 42, false);
+    expect(result).toBe('- [ ] #42\n- [x] #99');
+  });
+
+  test('preserves surrounding markdown byte-for-byte', () => {
+    const body = [
+      '# My Epic',
+      '',
+      'Here is some context.',
+      '',
+      '```bash',
+      'echo hello',
+      '```',
+      '',
+      '- [ ] #7',
+      '',
+      '## Footer',
+    ].join('\n');
+
+    const result = flipChecklistItem(body, 7, true);
+
+    // Only the checkbox line should change
+    const expected = body.replace('- [ ] #7', '- [x] #7');
+    expect(result).toBe(expected);
+  });
+
+  test('returns body unchanged when target sub-issue is not present', () => {
+    const body = '- [ ] #42\n- [ ] #99';
+    const result = flipChecklistItem(body, 55, true);
+    expect(result).toBe(body);
+  });
+
+  test('only affects the first matching line when multiple exist', () => {
+    // Duplicate lines shouldn't happen in practice, but the function should be deterministic.
+    const body = '- [ ] #42\n- [ ] #42';
+    const result = flipChecklistItem(body, 42, true);
+    // Only the first occurrence is flipped
+    expect(result).toBe('- [x] #42\n- [ ] #42');
+  });
+
+  test('handles indented lines correctly', () => {
+    const body = '  - [ ] #42';
+    const result = flipChecklistItem(body, 42, true);
+    expect(result).toBe('  - [x] #42');
+  });
+});
+
+describe('looksLikeEpic', () => {
+  test('returns true when body contains at least 3 sub-issue refs', () => {
+    const body = '- [ ] #1\n- [ ] #2\n- [ ] #3';
+    expect(looksLikeEpic(body)).toBe(true);
+  });
+
+  test('returns true when body contains more than 3 sub-issue refs', () => {
+    const body = '- [ ] #1\n- [ ] #2\n- [ ] #3\n- [ ] #4\n- [ ] #5';
+    expect(looksLikeEpic(body)).toBe(true);
+  });
+
+  test('returns false when body contains exactly 2 sub-issue refs', () => {
+    const body = '- [ ] #1\n- [ ] #2';
+    expect(looksLikeEpic(body)).toBe(false);
+  });
+
+  test('returns false when body contains exactly 1 sub-issue ref', () => {
+    const body = '- [ ] #1';
+    expect(looksLikeEpic(body)).toBe(false);
+  });
+
+  test('returns false when body contains zero sub-issue refs', () => {
+    const body = '## Just a regular issue\n\nSome description.';
+    expect(looksLikeEpic(body)).toBe(false);
+  });
+
+  test('returns false for empty body', () => {
+    expect(looksLikeEpic('')).toBe(false);
+  });
+});
+
+describe('buildEpicSummary', () => {
+  test('returns correct doneCount and totalCount for mixed checked/unchecked', () => {
+    const issue = makeIssue({
+      number: 165,
+      title: 'Hybrid Routing',
+      body: [
+        '- [x] #10',
+        '- [ ] #20',
+        '- [x] #30',
+        '- [ ] #40',
+        '- [x] #50',
+      ].join('\n'),
+    });
+
+    const summary = buildEpicSummary(issue);
+
+    expect(summary.number).toBe(165);
+    expect(summary.title).toBe('Hybrid Routing');
+    expect(summary.totalCount).toBe(5);
+    expect(summary.doneCount).toBe(3);
+    expect(summary.subIssues).toHaveLength(5);
+  });
+
+  test('returns doneCount=0 when all items are unchecked', () => {
+    const issue = makeIssue({
+      body: '- [ ] #1\n- [ ] #2\n- [ ] #3',
+    });
+    const summary = buildEpicSummary(issue);
+    expect(summary.doneCount).toBe(0);
+    expect(summary.totalCount).toBe(3);
+  });
+
+  test('returns doneCount equal to totalCount when all items are checked', () => {
+    const issue = makeIssue({
+      body: '- [x] #1\n- [x] #2',
+    });
+    const summary = buildEpicSummary(issue);
+    expect(summary.doneCount).toBe(2);
+    expect(summary.totalCount).toBe(2);
+  });
+
+  test('returns totalCount=0 for body with no task items', () => {
+    const issue = makeIssue({ body: 'No tasks here.' });
+    const summary = buildEpicSummary(issue);
+    expect(summary.totalCount).toBe(0);
+    expect(summary.doneCount).toBe(0);
+    expect(summary.subIssues).toHaveLength(0);
+  });
+
+  test('each subIssue ref has correct number and checked state', () => {
+    const issue = makeIssue({
+      body: '- [ ] #7\n- [x] #8',
+    });
+    const summary = buildEpicSummary(issue);
+    expect(summary.subIssues[0]).toMatchObject({ number: 7, checked: false });
+    expect(summary.subIssues[1]).toMatchObject({ number: 8, checked: true });
+  });
+});

--- a/tests/lib/eval-runner-repo-prompts.test.ts
+++ b/tests/lib/eval-runner-repo-prompts.test.ts
@@ -44,6 +44,7 @@ const makeConfig = (overrides?: Partial<Config>): Config => ({
   pipeline: {},
   evalIncludeAgentPrompts: true,
   evalIncludeSkills: true,
+    preferEpics: false,
   ...overrides,
 } as Config);
 

--- a/tests/lib/learning.test.ts
+++ b/tests/lib/learning.test.ts
@@ -78,6 +78,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalTimeout: 300,
     evalIncludeAgentPrompts: true,
     evalIncludeSkills: true,
+    preferEpics: false,
     autoCapture: true,
     skipPostSessionReview: false,
     skipPostSessionSecurity: false,

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -1,4 +1,4 @@
-import { processIssue, processBatch } from '../../src/lib/pipeline';
+import { processIssue, processBatch, buildPRBody } from '../../src/lib/pipeline';
 import type { SessionContext } from '../../src/lib/session';
 
 // Mock all dependencies
@@ -476,5 +476,45 @@ describe('processBatch', () => {
     expect(mockCleanupWorktree).toHaveBeenCalledWith(
       expect.not.objectContaining({ preserveIfCommits: true }),
     );
+  });
+});
+
+describe('buildPRBody', () => {
+  const defaultReviewGate = {
+    passed: true,
+    summary: 'Looks good',
+    findings: [],
+  };
+
+  test('contains Closes #<issueNum> reference', () => {
+    const body = buildPRBody(42, 'My feature', defaultReviewGate, '', true, true, false, '');
+    expect(body).toContain('Closes #42');
+  });
+
+  test('contains Part of #<epicNum> when epicNum is provided', () => {
+    const body = buildPRBody(42, 'My feature', defaultReviewGate, '', true, true, false, '', 165);
+    expect(body).toContain('Closes #42');
+    expect(body).toContain('Part of #165');
+  });
+
+  test('does NOT contain Part of when epicNum is not provided', () => {
+    const body = buildPRBody(42, 'My feature', defaultReviewGate, '', true, true, false, '');
+    expect(body).not.toContain('Part of');
+  });
+
+  test('includes test results section with pass/fail status', () => {
+    const body = buildPRBody(42, 'My feature', defaultReviewGate, 'Tests: 10 passed', true, true, false, '');
+    expect(body).toContain('Test Results');
+    expect(body).toContain('PASS');
+  });
+
+  test('shows SKIPPED for verification when verifySkipped is true', () => {
+    const body = buildPRBody(42, 'My feature', defaultReviewGate, '', true, false, true, '');
+    expect(body).toContain('SKIPPED');
+  });
+
+  test('shows FAIL for verification when verifyPassing is false and not skipped', () => {
+    const body = buildPRBody(42, 'My feature', defaultReviewGate, '', true, false, false, '');
+    expect(body).toContain('FAIL');
   });
 });

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -148,6 +148,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalTimeout: 300,
     evalIncludeAgentPrompts: true,
     evalIncludeSkills: true,
+    preferEpics: false,
     autoCapture: true,
     skipPostSessionReview: false,
     skipPostSessionSecurity: false,

--- a/tests/lib/session.test.ts
+++ b/tests/lib/session.test.ts
@@ -79,6 +79,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalTimeout: 300,
     evalIncludeAgentPrompts: true,
     evalIncludeSkills: true,
+    preferEpics: false,
     autoCapture: true,
     skipPostSessionReview: false,
     skipPostSessionSecurity: false,

--- a/tests/lib/session.test.ts
+++ b/tests/lib/session.test.ts
@@ -146,6 +146,46 @@ describe('createSession', () => {
     );
     expect(checkoutCalls).toHaveLength(0);
   });
+
+  test('generates epic-scoped session name when epicNum and epicTitle are provided', () => {
+    const session = createSession(makeConfig(), { epicNum: 165, epicTitle: 'Hybrid Routing' });
+
+    expect(session.name).toBe('session/epic-165-hybrid-routing');
+    expect(session.branch).toBe('session/epic-165-hybrid-routing');
+  });
+
+  test('sets session.epic to the epicNum', () => {
+    const session = createSession(makeConfig(), { epicNum: 165, epicTitle: 'Hybrid Routing' });
+    expect(session.epic).toBe(165);
+  });
+
+  test('generates epic-scoped session name with only epicNum when epicTitle is absent', () => {
+    const session = createSession(makeConfig(), { epicNum: 42 });
+    expect(session.name).toBe('session/epic-42');
+  });
+
+  test('slugifies epicTitle correctly (lowercase, hyphens)', () => {
+    const session = createSession(makeConfig(), { epicNum: 7, epicTitle: 'Multi-Word Title With Spaces!' });
+    expect(session.name).toBe('session/epic-7-multi-word-title-with-spaces');
+  });
+
+  test('draft PR title uses Epic #<N>: <title> format when autoMerge is enabled', () => {
+    // autoMerge triggers draft PR creation
+    mockExec.mockImplementation((cmd: string) => {
+      // branch doesn't exist so it gets created
+      if (cmd.includes('rev-parse --verify')) return { stdout: '', stderr: '', exitCode: 1 };
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/99');
+
+    createSession(makeConfig({ autoMerge: true }), { epicNum: 165, epicTitle: 'Hybrid Routing' });
+
+    expect(mockCreatePR).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Epic #165: Hybrid Routing',
+      }),
+    );
+  });
 });
 
 describe('saveResult', () => {

--- a/tests/lib/testing.test.ts
+++ b/tests/lib/testing.test.ts
@@ -65,6 +65,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalTimeout: 300,
     evalIncludeAgentPrompts: true,
     evalIncludeSkills: true,
+    preferEpics: false,
     autoCapture: true,
     skipPostSessionReview: false,
     skipPostSessionSecurity: false,

--- a/tests/lib/verify-epic.test.ts
+++ b/tests/lib/verify-epic.test.ts
@@ -1,0 +1,334 @@
+import { verifyEpic } from '../../src/lib/verify-epic.js';
+import type { VerifyEpicInput } from '../../src/lib/verify-epic.js';
+import type { Issue } from '../../src/lib/github.js';
+import type { Config } from '../../src/lib/config.js';
+
+// Mock spawnAgent (the agent runner) and ghExec (used to fetch diffs)
+jest.mock('../../src/lib/agent.js', () => ({
+  spawnAgent: jest.fn(),
+}));
+
+jest.mock('../../src/lib/rate-limit.js', () => ({
+  ghExec: jest.fn(),
+}));
+
+jest.mock('../../src/lib/logger.js', () => ({
+  log: {
+    info: jest.fn(),
+    success: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    step: jest.fn(),
+    dry: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+import { spawnAgent } from '../../src/lib/agent.js';
+import { ghExec } from '../../src/lib/rate-limit.js';
+
+const mockSpawnAgent = spawnAgent as jest.MockedFunction<typeof spawnAgent>;
+const mockGhExec = ghExec as jest.MockedFunction<typeof ghExec>;
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    repo: 'owner/repo',
+    repoOwner: 'owner',
+    project: 1,
+    agent: 'claude',
+    model: 'opus',
+    reviewModel: 'opus',
+    pollInterval: 60,
+    dryRun: false,
+    baseBranch: 'master',
+    logDir: 'logs',
+    labelReady: 'ready',
+    maxTestRetries: 3,
+    testCommand: 'pnpm test',
+    devCommand: 'pnpm dev',
+    skipTests: false,
+    skipReview: false,
+    skipInstall: false,
+    skipPreflight: false,
+    skipVerify: false,
+    skipLearn: false,
+    skipE2e: false,
+    autoMerge: false,
+    mergeTo: '',
+    autoCleanup: true,
+    runFull: false,
+    verbose: false,
+    maxIssues: 0,
+    maxSessionDuration: 0,
+    milestone: '',
+    harnesses: [],
+    setupCommand: '',
+    evalDir: '.alpha-loop/evals',
+    evalModel: '',
+    skipEval: false,
+    evalTimeout: 300,
+    evalIncludeAgentPrompts: true,
+    evalIncludeSkills: true,
+    preferEpics: false,
+    autoCapture: true,
+    skipPostSessionReview: false,
+    skipPostSessionSecurity: false,
+    batch: false,
+    batchSize: 5,
+    smokeTest: '',
+    agentTimeout: 1800,
+    pricing: {},
+    pipeline: {},
+    ...overrides,
+  };
+}
+
+function makeIssue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    number: 1,
+    title: 'Test issue',
+    body: '## AC\n- [ ] Something works',
+    labels: [],
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Partial<VerifyEpicInput> = {}): VerifyEpicInput {
+  return {
+    epic: makeIssue({ number: 165, title: 'Hybrid Routing', body: '## Epic AC\n- [ ] Routing works' }),
+    subIssues: [
+      makeIssue({ number: 10, title: 'Sub A' }),
+      makeIssue({ number: 11, title: 'Sub B' }),
+    ],
+    mergedPRUrls: [
+      'https://github.com/owner/repo/pull/201',
+      'https://github.com/owner/repo/pull/202',
+    ],
+    ...overrides,
+  };
+}
+
+const STUB_LOGS_DIR = '/tmp/epic-verify-logs';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  // Default: gh pr diff returns an empty diff (non-zero = no diff available)
+  mockGhExec.mockReturnValue({ exitCode: 0, stdout: '', stderr: '' });
+});
+
+describe('verifyEpic', () => {
+  test('returns verdict=pass when agent output contains valid json fence with verdict pass', async () => {
+    const agentOutput = `
+Here is my assessment:
+
+\`\`\`json
+{
+  "verdict": "pass",
+  "summary": "All criteria met.",
+  "findings": [
+    { "issueNum": 10, "criterion": "Routing works", "verdict": "met", "notes": "Covered by tests" }
+  ]
+}
+\`\`\`
+`;
+    mockSpawnAgent.mockResolvedValue({ exitCode: 0, output: agentOutput, duration: 3000 });
+
+    const result = await verifyEpic(makeInput(), makeConfig(), STUB_LOGS_DIR);
+
+    expect(result.verdict).toBe('pass');
+    expect(result.parsed.verdict).toBe('pass');
+    expect(result.parsed.summary).toBe('All criteria met.');
+    expect(result.parsed.findings).toHaveLength(1);
+    expect(result.parsed.findings[0]).toMatchObject({ issueNum: 10, verdict: 'met' });
+  });
+
+  test('returns verdict=partial when agent output contains verdict partial', async () => {
+    const agentOutput = `
+\`\`\`json
+{
+  "verdict": "partial",
+  "summary": "Some criteria met.",
+  "findings": [
+    { "issueNum": 10, "criterion": "Routing works", "verdict": "partial", "notes": "Partially covered" },
+    { "issueNum": 11, "criterion": "Auth works", "verdict": "missing" }
+  ]
+}
+\`\`\`
+`;
+    mockSpawnAgent.mockResolvedValue({ exitCode: 0, output: agentOutput, duration: 3000 });
+
+    const result = await verifyEpic(makeInput(), makeConfig(), STUB_LOGS_DIR);
+
+    expect(result.verdict).toBe('partial');
+    expect(result.parsed.findings).toHaveLength(2);
+  });
+
+  test('returns DEFAULT_VERDICT (partial) when agent output has no json fence', async () => {
+    mockSpawnAgent.mockResolvedValue({
+      exitCode: 0,
+      output: 'I reviewed the epic but could not produce a structured output.',
+      duration: 2000,
+    });
+
+    const result = await verifyEpic(makeInput(), makeConfig(), STUB_LOGS_DIR);
+
+    expect(result.verdict).toBe('partial');
+    expect(result.parsed.summary).toContain('could not be parsed');
+    expect(result.parsed.findings).toHaveLength(0);
+  });
+
+  test('caps verdict at partial when at least one mergedPRUrl is null even if agent says pass', async () => {
+    const agentOutput = `
+\`\`\`json
+{
+  "verdict": "pass",
+  "summary": "All evaluated criteria passed.",
+  "findings": [
+    { "issueNum": 10, "criterion": "Routing works", "verdict": "met" }
+  ]
+}
+\`\`\`
+`;
+    mockSpawnAgent.mockResolvedValue({ exitCode: 0, output: agentOutput, duration: 3000 });
+
+    // Sub-issue 11 has no merged PR
+    const input = makeInput({ mergedPRUrls: ['https://github.com/owner/repo/pull/201', null] });
+
+    const result = await verifyEpic(input, makeConfig(), STUB_LOGS_DIR);
+
+    // Even though agent said pass, verdict must be capped to partial
+    expect(result.verdict).toBe('partial');
+    // Comment should mention the cap
+    expect(result.comment).toMatch(/capped/i);
+  });
+
+  test('does NOT cap verdict at partial when all mergedPRUrls are present and agent says pass', async () => {
+    const agentOutput = `
+\`\`\`json
+{
+  "verdict": "pass",
+  "summary": "All criteria met.",
+  "findings": []
+}
+\`\`\`
+`;
+    mockSpawnAgent.mockResolvedValue({ exitCode: 0, output: agentOutput, duration: 3000 });
+
+    // All sub-issues have merged PRs
+    const result = await verifyEpic(makeInput(), makeConfig(), STUB_LOGS_DIR);
+
+    expect(result.verdict).toBe('pass');
+  });
+
+  test('normalizes invalid finding verdict strings to unclear', async () => {
+    const agentOutput = `
+\`\`\`json
+{
+  "verdict": "partial",
+  "summary": "Mixed results.",
+  "findings": [
+    { "issueNum": 10, "criterion": "Something", "verdict": "DEFINITELY_MET", "notes": "typo in verdict" },
+    { "issueNum": 11, "criterion": "Other thing", "verdict": "met" }
+  ]
+}
+\`\`\`
+`;
+    mockSpawnAgent.mockResolvedValue({ exitCode: 0, output: agentOutput, duration: 3000 });
+
+    const result = await verifyEpic(makeInput(), makeConfig(), STUB_LOGS_DIR);
+
+    // Invalid verdict "DEFINITELY_MET" should be normalized to "unclear"
+    const invalidFinding = result.parsed.findings.find((f) => f.issueNum === 10);
+    expect(invalidFinding?.verdict).toBe('unclear');
+
+    // Valid verdict "met" should be preserved
+    const validFinding = result.parsed.findings.find((f) => f.issueNum === 11);
+    expect(validFinding?.verdict).toBe('met');
+  });
+
+  test('returns DEFAULT_VERDICT when agent call throws', async () => {
+    mockSpawnAgent.mockRejectedValue(new Error('Agent process crashed'));
+
+    const result = await verifyEpic(makeInput(), makeConfig(), STUB_LOGS_DIR);
+
+    expect(result.verdict).toBe('partial');
+    expect(result.parsed.summary).toContain('could not be parsed');
+  });
+
+  test('returns DEFAULT_VERDICT when agent output contains invalid JSON', async () => {
+    mockSpawnAgent.mockResolvedValue({
+      exitCode: 0,
+      output: '```json\n{ "verdict": "pass", INVALID JSON }\n```',
+      duration: 2000,
+    });
+
+    const result = await verifyEpic(makeInput(), makeConfig(), STUB_LOGS_DIR);
+
+    expect(result.verdict).toBe('partial');
+    expect(result.parsed.findings).toHaveLength(0);
+  });
+
+  test('picks up the last json fence when multiple fences appear in output', async () => {
+    const agentOutput = `
+First fence (should be ignored):
+\`\`\`json
+{ "verdict": "fail", "summary": "Draft", "findings": [] }
+\`\`\`
+
+Final fence (authoritative):
+\`\`\`json
+{ "verdict": "pass", "summary": "Authoritative result.", "findings": [] }
+\`\`\`
+`;
+    mockSpawnAgent.mockResolvedValue({ exitCode: 0, output: agentOutput, duration: 3000 });
+
+    const result = await verifyEpic(makeInput(), makeConfig(), STUB_LOGS_DIR);
+
+    expect(result.verdict).toBe('pass');
+    expect(result.parsed.summary).toBe('Authoritative result.');
+  });
+
+  test('formats comment with sub-issue table', async () => {
+    const agentOutput = `
+\`\`\`json
+{
+  "verdict": "pass",
+  "summary": "All done.",
+  "findings": [
+    { "issueNum": 10, "criterion": "Routing works", "verdict": "met" },
+    { "issueNum": 11, "criterion": "Auth works", "verdict": "met" }
+  ]
+}
+\`\`\`
+`;
+    mockSpawnAgent.mockResolvedValue({ exitCode: 0, output: agentOutput, duration: 3000 });
+
+    const result = await verifyEpic(makeInput(), makeConfig(), STUB_LOGS_DIR);
+
+    expect(result.comment).toContain('## Epic Verification');
+    expect(result.comment).toContain('#10');
+    expect(result.comment).toContain('#11');
+    expect(result.comment).toContain('PASS');
+  });
+
+  test('uses reviewModel when set in config', async () => {
+    mockSpawnAgent.mockResolvedValue({ exitCode: 0, output: '```json\n{"verdict":"pass","summary":"ok","findings":[]}\n```', duration: 1000 });
+
+    await verifyEpic(makeInput(), makeConfig({ reviewModel: 'sonnet' }), STUB_LOGS_DIR);
+
+    expect(mockSpawnAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'sonnet' }),
+    );
+  });
+
+  test('falls back to config.model when reviewModel is not set', async () => {
+    mockSpawnAgent.mockResolvedValue({ exitCode: 0, output: '```json\n{"verdict":"pass","summary":"ok","findings":[]}\n```', duration: 1000 });
+
+    await verifyEpic(makeInput(), makeConfig({ reviewModel: '', model: 'haiku' }), STUB_LOGS_DIR);
+
+    expect(mockSpawnAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'haiku' }),
+    );
+  });
+});

--- a/tests/lib/verify.test.ts
+++ b/tests/lib/verify.test.ts
@@ -53,6 +53,7 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     evalTimeout: 300,
     evalIncludeAgentPrompts: true,
     evalIncludeSkills: true,
+    preferEpics: false,
     autoCapture: true,
     skipPostSessionReview: false,
     skipPostSessionSecurity: false,


### PR DESCRIPTION
Closes #171

## Summary

Adds first-class epic support to `alpha-loop run`. An "epic" is a GitHub issue with the `epic` label whose body contains a `- [ ] #N` task-list of sub-issue refs. The loop auto-discovers open epics, processes sub-issues in checklist order, flips checklist boxes as sub-issues merge, and runs a verification pass that closes the epic (or flags it for human review).

See [`docs/epics.md`](docs/epics.md) for the full feature guide.

## What's new

- **CLI flags**: `--epic <N>`, `--skip-epic`, `--verify-only <N>`
- **Picker**: epics listed above milestones in the interactive picker (TTY only)
- **Execution**: sub-issues processed in checklist order, non-ready ones skipped with warning, `epic`-labeled issues excluded from normal `ready` flow in all paths (flat, milestone, project board)
- **Checklist auto-flip**: epic body task-list boxes flip `- [ ]` → `- [x]` after each sub-issue merges (surgical line replacement, preserves all surrounding markdown)
- **Verification pass**: when the last sub-issue is done, a new `verifyEpic` module evaluates each sub-issue's AC against its merged PR diff using the review model. Emits a structured comment on the epic. On `pass` → closes the epic; on `partial`/`fail` → adds `needs-human-input`.
- **`--verify-only`**: permissive re-run — works even if not all sub-issues merged yet (verdict caps at `partial`).
- **Labels**: `alpha-loop init` now creates `epic` (purple) and `needs-human-input` (rose).
- **Session**: `SessionContext.epic` field, session slug becomes `epic-N-title`.
- **PR bodies**: sub-issue PRs append `Part of #<epic>`.
- **Config**: `prefer_epics: true` — auto-select when exactly one open epic exists.

## Architecture

- `src/lib/epics.ts` — pure primitives (parse, flip, summary). Throws on body mismatch; one-agent-per-epic is the contract.
- `src/lib/verify-epic.ts` — separate `EpicVerdict` type (not extending `GateResult`). Parses JSON fences from agent output, permissive mode caps unmerged at `partial`.
- `src/lib/github.ts` — `listEpics`, `getEpicSubIssues`, `updateEpicChecklist`, `getMergedPRForIssue`.
- `src/commands/run.ts` — refactored `pickMilestone()` → unified `pickTarget()`, epic execution flow, post-loop verification trigger.

## Review fixes applied

The branch was reviewed before open — two critical issues were caught and fixed:
- **`--dry-run` + `--epic`** previously mutated the live epic body. Checklist flip now gated on `!config.dryRun`.
- **`--no-epic`** collided with Commander's `--no-X` semantics (set `options.epic = false`, then crashed in `gh issue view false`). Renamed to `--skip-epic`.
- Added numeric validation for `--epic` and `--verify-only` to avoid cryptic `#NaN` errors.

## Tests

773 tests passing (up from 723). Net +50:
- `tests/lib/epics.test.ts` — 27 tests for parse/flip/summary primitives
- `tests/lib/verify-epic.test.ts` — 12 tests for verdict parsing and permissive mode
- Extensions to `pipeline.test.ts` (6) and `session.test.ts` (6) for epic-scoped behaviors

## Docs

- `docs/epics.md` (new, 218 lines): full workflow guide, detection rules, skip rules, verification, safety rails, non-goals, worked example
- `README.md`: new `### Epics` subsection + command table entries + run-options additions
- `CLAUDE.md`: epic commands added to the reference

## Test plan

- [ ] `alpha-loop run --epic 165 --dry-run` — should log "Would flip..." lines, never mutate GitHub state
- [ ] `alpha-loop run --epic 165 --once` — processes first ready sub-issue, flips its box, logs "verification deferred", exits
- [ ] `alpha-loop run --epic 165` — full end-to-end on real epic with 7 sub-issues
- [ ] Post-run: verify the epic body has checkboxes flipped and the verification comment is posted
- [ ] `alpha-loop run --skip-epic` — skips epic picker, still allows milestone selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)