### PR TITLE
feat: Add per-stage model routing config schema to .alpha-loop.yaml (closes #158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,42 @@ pipeline:
 
 Use `alpha-loop eval search` to automatically find the best model assignment per step via greedy coordinate descent over your eval suite.
 
+### Per-Stage Routing
+
+For hybrid cloud/local setups, use `routing:` to target different models and endpoints for each Loop stage. This is how you offload token-heavy middle stages (Build, Test) to local open-weight models while keeping frontier models for Plan and Review:
+
+```yaml
+routing:
+  profile: hybrid-v1   # all-frontier | hybrid-v1 | all-local | <custom-name>
+  stages:
+    plan:       { model: claude-opus-4-7,      endpoint: anthropic }
+    build:      { model: qwen3-coder-30b-a3b,  endpoint: lmstudio_local }
+    test_write: { model: qwen3-coder-30b-a3b,  endpoint: lmstudio_local }
+    test_exec:  { model: qwen3-coder-30b-a3b,  endpoint: lmstudio_local }
+    review:     { model: claude-sonnet-4-6,    endpoint: anthropic }
+    summary:    { model: gemma-4-31b,          endpoint: lmstudio_local }
+  endpoints:
+    anthropic:      { type: anthropic,        base_url: "https://api.anthropic.com" }
+    lmstudio_local: { type: anthropic_compat, base_url: "http://localhost:1234" }
+    ollama_local:   { type: openai_compat,    base_url: "http://localhost:11434/v1" }
+  fallback:
+    on_tool_error: escalate          # escalate | retry | fail
+    escalate_to: { model: claude-sonnet-4-6, endpoint: anthropic }
+```
+
+**Stages:** `plan`, `build`, `test_write`, `test_exec`, `review`, `summary` — each takes `{ model, endpoint }` where `endpoint` references a name defined in `routing.endpoints`.
+
+**Endpoint types:** `anthropic` (native Anthropic API), `anthropic_compat` (Anthropic-compatible — e.g. LM Studio), or `openai_compat` (OpenAI-compatible — e.g. Ollama, vLLM).
+
+**Fallback modes:**
+- `escalate` — when a routed stage errors on a tool call, retry on `escalate_to` (typically a frontier model)
+- `retry` — retry on the same model/endpoint
+- `fail` — surface the error without retry
+
+**Profile as a list (A/B):** `profile` may also be an array of names (e.g. `[hybrid-v1, all-local]`). Alpha Loop picks one deterministically per-issue so reruns of the same issue select the same profile — this makes profile comparisons reproducible.
+
+**Backwards compatibility:** If you don't set `routing`, alpha-loop uses the top-level `agent:` / `model:` / `pipeline:` exactly as before — no behavior change.
+
 ## GitHub Setup
 
 ### Labels

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -620,17 +620,13 @@ function fnv1a32(input: string): number {
 /**
  * Resolve the model and endpoint for a specific Loop routing stage.
  *
- * Returns undefined when `config.routing` is absent — callers should fall back
- * to the existing top-level `agent`/`model` behavior in that case.
- *
- * When `routing.profile` is an array, the profile is chosen deterministically
- * from `issueId` so reruns of the same issue pick the same profile (required
- * for reproducible A/B evaluation).
+ * Returns undefined when `config.routing` is absent or the stage isn't
+ * configured — callers should fall back to the existing top-level
+ * `agent`/`model` behavior in that case.
  */
 export function resolveRoutingStage(
   config: Config,
   stage: RoutingStageName,
-  _issueId?: number,
 ): { model: string; endpoint?: RoutingEndpoint } | undefined {
   const routing = config.routing;
   if (!routing) return undefined;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -20,6 +20,62 @@ export type StepConfig = {
 /** Per-step pipeline configuration. */
 export type PipelineConfig = Partial<Record<PipelineStepName, StepConfig>>;
 
+/** The Loop stages that support per-stage routing (model + endpoint). */
+export type RoutingStageName = 'plan' | 'build' | 'test_write' | 'test_exec' | 'review' | 'summary';
+
+/** Per-stage routing configuration — targets a model on a named endpoint. */
+export type RoutingStageConfig = {
+  model: string;
+  endpoint: string;
+};
+
+/** Endpoint protocol/API shape for a routing endpoint. */
+export type RoutingEndpointType = 'anthropic' | 'anthropic_compat' | 'openai_compat';
+
+/** A named endpoint that stages can route to. */
+export type RoutingEndpoint = {
+  type: RoutingEndpointType;
+  base_url: string;
+};
+
+/** How the loop should behave when a routed stage errors out. */
+export type RoutingFallbackMode = 'escalate' | 'retry' | 'fail';
+
+/** Fallback behavior for routed stages. */
+export type RoutingFallback = {
+  on_tool_error: RoutingFallbackMode;
+  escalate_to?: RoutingStageConfig;
+};
+
+/** Per-stage routing configuration for the Loop. */
+export type RoutingConfig = {
+  profile?: string | string[];
+  stages?: Partial<Record<RoutingStageName, RoutingStageConfig>>;
+  endpoints?: Record<string, RoutingEndpoint>;
+  fallback?: RoutingFallback;
+};
+
+const VALID_ROUTING_STAGES: readonly RoutingStageName[] = [
+  'plan',
+  'build',
+  'test_write',
+  'test_exec',
+  'review',
+  'summary',
+] as const;
+
+const VALID_ENDPOINT_TYPES: readonly RoutingEndpointType[] = [
+  'anthropic',
+  'anthropic_compat',
+  'openai_compat',
+] as const;
+
+const VALID_FALLBACK_MODES: readonly RoutingFallbackMode[] = [
+  'escalate',
+  'retry',
+  'fail',
+] as const;
+
 /**
  * Estimate cost in USD from token counts and a pricing table.
  * Returns 0 if the model is not in the pricing table.
@@ -89,6 +145,8 @@ export type Config = {
   pricing: Record<string, ModelPricing>;
   /** Per-step agent/model overrides. */
   pipeline: PipelineConfig;
+  /** Optional per-stage Loop routing (model + endpoint). Absent => no routing applied. */
+  routing?: RoutingConfig;
   /** Include repo-specific agent prompts during eval runs (default: true). */
   evalIncludeAgentPrompts: boolean;
   /** Include repo-specific skills during eval runs (default: true). */
@@ -152,6 +210,9 @@ const DEFAULTS: Config = {
     'gpt-4o-mini': { input: 0.15, output: 0.60 },
     'deepseek-v3': { input: 0.27, output: 1.10 },
     'gemini-2.5-flash': { input: 0.15, output: 0.60 },
+    'qwen3-coder-30b-a3b': { input: 0, output: 0 },
+    'gemma-4-31b': { input: 0, output: 0 },
+    'glm-4.6': { input: 0, output: 0 },
   },
   pipeline: {},
   evalIncludeAgentPrompts: true,
@@ -286,6 +347,103 @@ export function detectRepo(): string | null {
   return null;
 }
 
+function parseRoutingStage(raw: unknown): RoutingStageConfig | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.model !== 'string' || typeof r.endpoint !== 'string') return undefined;
+  return { model: r.model, endpoint: r.endpoint };
+}
+
+function parseRoutingConfig(raw: unknown): RoutingConfig | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const r = raw as Record<string, unknown>;
+  const result: RoutingConfig = {};
+  let populated = false;
+
+  if (typeof r.profile === 'string') {
+    result.profile = r.profile;
+    populated = true;
+  } else if (Array.isArray(r.profile) && r.profile.every((p) => typeof p === 'string')) {
+    result.profile = r.profile as string[];
+    populated = true;
+  }
+
+  const endpoints: Record<string, RoutingEndpoint> = {};
+  if (r.endpoints && typeof r.endpoints === 'object') {
+    for (const [name, value] of Object.entries(r.endpoints as Record<string, unknown>)) {
+      if (!value || typeof value !== 'object') continue;
+      const v = value as Record<string, unknown>;
+      if (typeof v.type !== 'string' || typeof v.base_url !== 'string') {
+        console.warn(`[config] routing.endpoints.${name}: expected { type, base_url }`);
+        continue;
+      }
+      if (!VALID_ENDPOINT_TYPES.includes(v.type as RoutingEndpointType)) {
+        console.warn(
+          `[config] routing.endpoints.${name}: invalid type "${v.type}" (expected one of ${VALID_ENDPOINT_TYPES.join(', ')})`,
+        );
+        continue;
+      }
+      endpoints[name] = { type: v.type as RoutingEndpointType, base_url: v.base_url };
+    }
+    if (Object.keys(endpoints).length > 0) {
+      result.endpoints = endpoints;
+      populated = true;
+    }
+  }
+
+  const stages: Partial<Record<RoutingStageName, RoutingStageConfig>> = {};
+  if (r.stages && typeof r.stages === 'object') {
+    const stagesRaw = r.stages as Record<string, unknown>;
+    for (const [key, value] of Object.entries(stagesRaw)) {
+      if (!VALID_ROUTING_STAGES.includes(key as RoutingStageName)) {
+        console.warn(`[config] routing.stages.${key}: unknown stage name (ignored)`);
+        continue;
+      }
+      const parsed = parseRoutingStage(value);
+      if (!parsed) {
+        console.warn(`[config] routing.stages.${key}: expected { model, endpoint }`);
+        continue;
+      }
+      if (result.endpoints && !(parsed.endpoint in result.endpoints)) {
+        console.warn(
+          `[config] routing.stages.${key}: endpoint "${parsed.endpoint}" is not defined in routing.endpoints (ignored)`,
+        );
+        continue;
+      }
+      stages[key as RoutingStageName] = parsed;
+    }
+    if (Object.keys(stages).length > 0) {
+      result.stages = stages;
+      populated = true;
+    }
+  }
+
+  if (r.fallback && typeof r.fallback === 'object') {
+    const f = r.fallback as Record<string, unknown>;
+    if (typeof f.on_tool_error === 'string' && VALID_FALLBACK_MODES.includes(f.on_tool_error as RoutingFallbackMode)) {
+      const fallback: RoutingFallback = { on_tool_error: f.on_tool_error as RoutingFallbackMode };
+      const escalate = parseRoutingStage(f.escalate_to);
+      if (escalate) {
+        if (result.endpoints && !(escalate.endpoint in result.endpoints)) {
+          console.warn(
+            `[config] routing.fallback.escalate_to: endpoint "${escalate.endpoint}" is not defined in routing.endpoints (ignored)`,
+          );
+        } else {
+          fallback.escalate_to = escalate;
+        }
+      }
+      result.fallback = fallback;
+      populated = true;
+    } else if (f.on_tool_error !== undefined) {
+      console.warn(
+        `[config] routing.fallback.on_tool_error: invalid value "${String(f.on_tool_error)}" (expected one of ${VALID_FALLBACK_MODES.join(', ')})`,
+      );
+    }
+  }
+
+  return populated ? result : undefined;
+}
+
 function loadYamlConfig(configPath: string): Partial<Config> {
   if (!existsSync(configPath)) return {};
 
@@ -332,6 +490,14 @@ function loadYamlConfig(configPath: string): Partial<Config> {
     const ev = parsed.eval as Record<string, unknown>;
     if (ev.include_agent_prompts === false) result.evalIncludeAgentPrompts = false;
     if (ev.include_skills === false) result.evalIncludeSkills = false;
+  }
+
+  // Handle routing nested config (per-stage model + endpoint)
+  if (parsed.routing !== undefined) {
+    const routing = parseRoutingConfig(parsed.routing);
+    if (routing) {
+      result.routing = routing;
+    }
   }
 
   // Handle pricing table (nested object, not in YAML_KEY_MAP)
@@ -394,6 +560,9 @@ export function loadConfig(overrides?: Partial<Config>): Config {
     };
   }
 
+  // Routing precedence is whole-object replacement (overrides > yaml > undefined).
+  const routing = overrides?.routing ?? yamlConfig.routing;
+
   const merged: Config = {
     ...DEFAULTS,
     ...autoDetect,
@@ -402,6 +571,7 @@ export function loadConfig(overrides?: Partial<Config>): Config {
     ...overrides,
     pricing: mergedPricing,
     pipeline: mergedPipeline,
+    routing,
   };
 
   // Validate agent is a known value
@@ -434,4 +604,57 @@ export function resolveStepConfig(
     : config.model;
   const model = stepOverride?.model ?? fallbackModel;
   return { agent, model };
+}
+
+// FNV-1a 32-bit hash of a string. Stable across runs so A/B profile selection
+// is deterministic for a given issueId — needed for reproducible reruns.
+function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = (hash + ((hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24))) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Resolve the model and endpoint for a specific Loop routing stage.
+ *
+ * Returns undefined when `config.routing` is absent — callers should fall back
+ * to the existing top-level `agent`/`model` behavior in that case.
+ *
+ * When `routing.profile` is an array, the profile is chosen deterministically
+ * from `issueId` so reruns of the same issue pick the same profile (required
+ * for reproducible A/B evaluation).
+ */
+export function resolveRoutingStage(
+  config: Config,
+  stage: RoutingStageName,
+  _issueId?: number,
+): { model: string; endpoint?: RoutingEndpoint } | undefined {
+  const routing = config.routing;
+  if (!routing) return undefined;
+  const stageCfg = routing.stages?.[stage];
+  if (!stageCfg) return undefined;
+  const endpoint = routing.endpoints?.[stageCfg.endpoint];
+  return { model: stageCfg.model, endpoint };
+}
+
+/**
+ * Deterministically pick a profile name when `routing.profile` is a list.
+ *
+ * Returns the string profile directly if `profile` is a single string, or a
+ * deterministic choice based on `issueId` when it's an array — so reruns of
+ * the same issue pick the same profile for reproducible A/B evaluation.
+ */
+export function selectRoutingProfile(
+  config: Config,
+  issueId?: number,
+): string | undefined {
+  const profile = config.routing?.profile;
+  if (!profile) return undefined;
+  if (typeof profile === 'string') return profile;
+  if (profile.length === 0) return undefined;
+  if (profile.length === 1 || issueId === undefined) return profile[0];
+  return profile[fnv1a32(String(issueId)) % profile.length];
 }

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -10,7 +10,14 @@ jest.mock('node:child_process', () => ({
 
 const mockedExecSync = execSync as jest.MockedFunction<typeof execSync>;
 
-import { loadConfig, detectRepo, estimateCost, resolveStepConfig } from '../../src/lib/config.js';
+import {
+  loadConfig,
+  detectRepo,
+  estimateCost,
+  resolveStepConfig,
+  resolveRoutingStage,
+  selectRoutingProfile,
+} from '../../src/lib/config.js';
 import type { Config, PipelineConfig } from '../../src/lib/config.js';
 
 let originalCwd: string;
@@ -391,5 +398,291 @@ describe('estimateCost', () => {
     // 3K output tokens at $75/M = $0.225
     const cost = estimateCost('claude-opus-4-6', 10000, 3000, pricing);
     expect(cost).toBeCloseTo(0.375, 3);
+  });
+});
+
+describe('routing config', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('is undefined when no routing key is present', () => {
+    writeFileSync(join(tempDir, '.alpha-loop.yaml'), `repo: owner/repo\nagent: claude\nmodel: claude-sonnet-4-6\n`);
+    const config = loadConfig();
+    expect(config.routing).toBeUndefined();
+    // Existing behavior unchanged
+    expect(config.agent).toBe('claude');
+    expect(resolveStepConfig(config, 'implement').model).toBe('claude-sonnet-4-6');
+  });
+
+  it('loads the full hybrid-v1 example shape', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  profile: hybrid-v1
+  stages:
+    plan:       { model: claude-opus-4-7,      endpoint: anthropic }
+    build:      { model: qwen3-coder-30b-a3b,  endpoint: lmstudio_local }
+    test_write: { model: qwen3-coder-30b-a3b,  endpoint: lmstudio_local }
+    test_exec:  { model: qwen3-coder-30b-a3b,  endpoint: lmstudio_local }
+    review:     { model: claude-sonnet-4-6,    endpoint: anthropic }
+    summary:    { model: gemma-4-31b,          endpoint: lmstudio_local }
+  endpoints:
+    anthropic:      { type: anthropic,        base_url: "https://api.anthropic.com" }
+    lmstudio_local: { type: anthropic_compat, base_url: "http://localhost:1234" }
+    ollama_local:   { type: openai_compat,    base_url: "http://localhost:11434/v1" }
+  fallback:
+    on_tool_error: escalate
+    escalate_to: { model: claude-sonnet-4-6, endpoint: anthropic }
+`,
+    );
+    const config = loadConfig();
+    expect(config.routing).toBeDefined();
+    expect(config.routing?.profile).toBe('hybrid-v1');
+    expect(config.routing?.stages?.plan).toEqual({ model: 'claude-opus-4-7', endpoint: 'anthropic' });
+    expect(config.routing?.stages?.build).toEqual({ model: 'qwen3-coder-30b-a3b', endpoint: 'lmstudio_local' });
+    expect(config.routing?.stages?.test_write).toEqual({ model: 'qwen3-coder-30b-a3b', endpoint: 'lmstudio_local' });
+    expect(config.routing?.stages?.test_exec).toEqual({ model: 'qwen3-coder-30b-a3b', endpoint: 'lmstudio_local' });
+    expect(config.routing?.stages?.review).toEqual({ model: 'claude-sonnet-4-6', endpoint: 'anthropic' });
+    expect(config.routing?.stages?.summary).toEqual({ model: 'gemma-4-31b', endpoint: 'lmstudio_local' });
+    expect(config.routing?.endpoints?.anthropic).toEqual({ type: 'anthropic', base_url: 'https://api.anthropic.com' });
+    expect(config.routing?.endpoints?.lmstudio_local).toEqual({ type: 'anthropic_compat', base_url: 'http://localhost:1234' });
+    expect(config.routing?.endpoints?.ollama_local).toEqual({ type: 'openai_compat', base_url: 'http://localhost:11434/v1' });
+    expect(config.routing?.fallback).toEqual({
+      on_tool_error: 'escalate',
+      escalate_to: { model: 'claude-sonnet-4-6', endpoint: 'anthropic' },
+    });
+  });
+
+  it('preserves profile as a list of strings', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  profile:
+    - hybrid-v1
+    - all-local
+    - all-frontier
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  stages:
+    plan: { model: claude-opus-4-7, endpoint: anthropic }
+`,
+    );
+    const config = loadConfig();
+    expect(config.routing?.profile).toEqual(['hybrid-v1', 'all-local', 'all-frontier']);
+  });
+
+  it('drops unknown stage names without throwing', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  stages:
+    foobar: { model: claude-opus-4-7, endpoint: anthropic }
+    plan:   { model: claude-opus-4-7, endpoint: anthropic }
+`,
+    );
+    const config = loadConfig();
+    expect(config.routing?.stages?.plan).toEqual({ model: 'claude-opus-4-7', endpoint: 'anthropic' });
+    expect((config.routing?.stages as Record<string, unknown>).foobar).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('foobar'));
+  });
+
+  it('drops stages that reference an unknown endpoint', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  stages:
+    plan:  { model: claude-opus-4-7, endpoint: anthropic }
+    build: { model: mystery-model,   endpoint: nonexistent }
+`,
+    );
+    const config = loadConfig();
+    expect(config.routing?.stages?.plan).toBeDefined();
+    expect(config.routing?.stages?.build).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('nonexistent'));
+  });
+
+  it('rejects endpoints with invalid type', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  endpoints:
+    bogus: { type: not_a_real_type, base_url: "http://localhost:1234" }
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+`,
+    );
+    const config = loadConfig();
+    expect(config.routing?.endpoints?.bogus).toBeUndefined();
+    expect(config.routing?.endpoints?.anthropic).toBeDefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not_a_real_type'));
+  });
+
+  it('throws on malformed YAML', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  stages: [ { { this is invalid
+`,
+    );
+    expect(() => loadConfig()).toThrow();
+  });
+
+  it('includes zero-cost local model entries in default pricing', () => {
+    const config = loadConfig();
+    expect(config.pricing['qwen3-coder-30b-a3b']).toEqual({ input: 0, output: 0 });
+    expect(config.pricing['gemma-4-31b']).toEqual({ input: 0, output: 0 });
+    expect(config.pricing['glm-4.6']).toEqual({ input: 0, output: 0 });
+  });
+
+  it('rejects fallback.on_tool_error with invalid value', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  fallback:
+    on_tool_error: bogus_mode
+`,
+    );
+    const config = loadConfig();
+    expect(config.routing?.fallback).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('bogus_mode'));
+  });
+
+  it('routing overrides from CLI replace YAML routing wholesale', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  profile: hybrid-v1
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  stages:
+    plan: { model: claude-opus-4-7, endpoint: anthropic }
+`,
+    );
+    const config = loadConfig({
+      routing: {
+        profile: 'all-frontier',
+        stages: { plan: { model: 'claude-opus-4-7', endpoint: 'anthropic' } },
+        endpoints: { anthropic: { type: 'anthropic', base_url: 'https://api.anthropic.com' } },
+      },
+    });
+    expect(config.routing?.profile).toBe('all-frontier');
+  });
+});
+
+describe('resolveRoutingStage', () => {
+  it('returns undefined when routing is absent', () => {
+    const config = loadConfig();
+    expect(resolveRoutingStage(config, 'plan')).toBeUndefined();
+    expect(resolveRoutingStage(config, 'build', 42)).toBeUndefined();
+  });
+
+  it('returns undefined for stages not declared in routing.stages', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  stages:
+    plan: { model: claude-opus-4-7, endpoint: anthropic }
+`,
+    );
+    const config = loadConfig();
+    expect(resolveRoutingStage(config, 'plan')).toEqual({
+      model: 'claude-opus-4-7',
+      endpoint: { type: 'anthropic', base_url: 'https://api.anthropic.com' },
+    });
+    expect(resolveRoutingStage(config, 'build')).toBeUndefined();
+  });
+
+  it('returns model and resolved endpoint for each configured stage', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  endpoints:
+    anthropic:      { type: anthropic,        base_url: "https://api.anthropic.com" }
+    lmstudio_local: { type: anthropic_compat, base_url: "http://localhost:1234" }
+  stages:
+    plan:  { model: claude-opus-4-7,     endpoint: anthropic }
+    build: { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+`,
+    );
+    const config = loadConfig();
+    expect(resolveRoutingStage(config, 'plan')).toEqual({
+      model: 'claude-opus-4-7',
+      endpoint: { type: 'anthropic', base_url: 'https://api.anthropic.com' },
+    });
+    expect(resolveRoutingStage(config, 'build')).toEqual({
+      model: 'qwen3-coder-30b-a3b',
+      endpoint: { type: 'anthropic_compat', base_url: 'http://localhost:1234' },
+    });
+  });
+});
+
+describe('selectRoutingProfile', () => {
+  it('returns undefined when routing or profile is unset', () => {
+    const noRouting = loadConfig();
+    expect(selectRoutingProfile(noRouting, 1)).toBeUndefined();
+  });
+
+  it('returns the single string profile unchanged', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  profile: hybrid-v1
+  endpoints: { anthropic: { type: anthropic, base_url: "https://api.anthropic.com" } }
+  stages: { plan: { model: claude-opus-4-7, endpoint: anthropic } }
+`,
+    );
+    const config = loadConfig();
+    expect(selectRoutingProfile(config, 42)).toBe('hybrid-v1');
+    expect(selectRoutingProfile(config)).toBe('hybrid-v1');
+  });
+
+  it('deterministically picks the same profile from an array for a given issueId', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  profile:
+    - hybrid-v1
+    - all-local
+    - all-frontier
+  endpoints: { anthropic: { type: anthropic, base_url: "https://api.anthropic.com" } }
+  stages: { plan: { model: claude-opus-4-7, endpoint: anthropic } }
+`,
+    );
+    const config = loadConfig();
+    const a = selectRoutingProfile(config, 158);
+    const b = selectRoutingProfile(config, 158);
+    expect(a).toBe(b);
+    expect(['hybrid-v1', 'all-local', 'all-frontier']).toContain(a);
+    // Different issueIds can land on different profiles — at least two of the
+    // three sampled ids should map to different profiles.
+    const picks = [100, 200, 300, 400, 500, 600, 700].map((id) => selectRoutingProfile(config, id));
+    const unique = new Set(picks);
+    expect(unique.size).toBeGreaterThan(1);
   });
 });

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -593,7 +593,7 @@ describe('resolveRoutingStage', () => {
   it('returns undefined when routing is absent', () => {
     const config = loadConfig();
     expect(resolveRoutingStage(config, 'plan')).toBeUndefined();
-    expect(resolveRoutingStage(config, 'build', 42)).toBeUndefined();
+    expect(resolveRoutingStage(config, 'build')).toBeUndefined();
   });
 
   it('returns undefined for stages not declared in routing.stages', () => {


### PR DESCRIPTION
Closes #158
Part of #165

## Summary

Automated implementation of **Add per-stage model routing config schema to .alpha-loop.yaml**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Schema-only PR for #158 is correct, well-tested, and backwards-compatible; runtime wiring is correctly deferred to sibling sub-issues #159/#160 per epic #165 plan.

- **WARNING** [FIXED] `src/lib/config.ts`: resolveRoutingStage carried an unused _issueId parameter and a JSDoc that described profile-array behavior actually implemented in selectRoutingProfile. Removed the dead parameter and rewrote the JSDoc to describe what the function actually does.
- **INFO** [OPEN] `src/commands/run.ts`: Acceptance criterion 'alpha-loop run --once honors per-stage routing and logs which model ran each stage' is not addressed by this PR. The issue title and epic #165 both scope #158 to schema-only; the runtime wiring requires the LM Studio/Ollama backend (#159) and escalation logic (#160), which are explicitly listed as separate sub-issues. Not blocking — calling out the AC mismatch so it isn't lost.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*