### PR TITLE
feat: Retry-with-escalation: local tool-call failure falls back to frontier (closes #160)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ sessions/
 .alpha-loop/sessions/
 .alpha-loop/traces/
 .alpha-loop/auth/
+.alpha-loop/escalation-state.json
 logs/*
 !logs/.gitkeep
 .env

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { log } from '../lib/logger.js';
 import type { PipelineResult } from '../lib/pipeline.js';
+import type { EscalationEvent } from '../lib/escalation.js';
 
 type SessionManifest = {
   name: string;
@@ -201,6 +202,21 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
   console.log(`Duration: ${formatDuration(totalDuration)}`);
   console.log('');
 
+  // Stage-revert banner: if any issue in this session has an active revert event, flag it.
+  const activeReverts = new Set<string>();
+  for (const r of results) {
+    for (const ev of r.escalationEvents ?? []) {
+      if (ev.type === 'stage_revert' || ev.type === 'stage_revert_active') {
+        activeReverts.add(`${ev.stage}: ${ev.from_model} -> ${ev.to_model}`);
+      }
+    }
+  }
+  if (activeReverts.size > 0) {
+    console.log('Stage reverts active (pinned to fallback):');
+    for (const line of activeReverts) console.log(`  ! ${line}`);
+    console.log('');
+  }
+
   console.log('Issues:');
   for (const result of results) {
     const symbol = result.status === 'success' ? '\u2713' : '\u2717';
@@ -225,6 +241,25 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
     console.log(
       `           ${statusText.padEnd(12)} ${durStr.padEnd(10)} ${tests}  ${verify}`
     );
+
+    // Escalation events, grouped by stage, printed inline under the stage row.
+    const events = result.escalationEvents ?? [];
+    if (events.length > 0) {
+      const byStage = new Map<string, EscalationEvent[]>();
+      for (const ev of events) {
+        const list = byStage.get(ev.stage) ?? [];
+        list.push(ev);
+        byStage.set(ev.stage, list);
+      }
+      for (const [stage, stageEvents] of byStage) {
+        for (const ev of stageEvents) {
+          const symbol = ev.type === 'escalation' ? '\u21b3' : '!';
+          console.log(
+            `           ${symbol} ${ev.type}: ${stage} [${ev.from_model} \u2192 ${ev.to_model}] reason=${ev.reason} (turn ${ev.turn_index})`
+          );
+        }
+      }
+    }
   }
 
   console.log('');

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -45,7 +45,27 @@ export type RoutingFallbackMode = 'escalate' | 'retry' | 'fail';
 export type RoutingFallback = {
   on_tool_error: RoutingFallbackMode;
   escalate_to?: RoutingStageConfig;
+  /** Number of recent turns to track per stage for the rolling-error guardrail (default 10). */
+  escalation_window_issues?: number;
+  /** Rolling-error-rate threshold that triggers a stage revert (default 0.08 = 8%). */
+  escalation_error_threshold?: number;
+  /** How long a stage stays pinned to the fallback after the threshold fires (default 24h). */
+  escalation_revert_ms?: number;
 };
+
+/** Normalized fallback policy returned by getFallbackPolicy. */
+export type FallbackPolicy = {
+  on_tool_error: RoutingFallbackMode;
+  escalate_to?: RoutingStageConfig;
+  escalation_window_issues: number;
+  escalation_error_threshold: number;
+  escalation_revert_ms: number;
+};
+
+/** Default guardrail values — 10-issue rolling window, 8% error threshold, 24-hour revert. */
+export const DEFAULT_ESCALATION_WINDOW = 10;
+export const DEFAULT_ESCALATION_ERROR_THRESHOLD = 0.08;
+export const DEFAULT_ESCALATION_REVERT_MS = 24 * 60 * 60 * 1000;
 
 /** Per-stage routing configuration for the Loop. */
 export type RoutingConfig = {
@@ -432,6 +452,38 @@ function parseRoutingConfig(raw: unknown): RoutingConfig | undefined {
           fallback.escalate_to = escalate;
         }
       }
+      if (f.escalation_window_issues !== undefined) {
+        if (typeof f.escalation_window_issues === 'number' && Number.isFinite(f.escalation_window_issues) && f.escalation_window_issues > 0) {
+          fallback.escalation_window_issues = Math.floor(f.escalation_window_issues);
+        } else {
+          console.warn(
+            `[config] routing.fallback.escalation_window_issues: expected a positive number (got ${String(f.escalation_window_issues)})`,
+          );
+        }
+      }
+      if (f.escalation_error_threshold !== undefined) {
+        if (
+          typeof f.escalation_error_threshold === 'number' &&
+          Number.isFinite(f.escalation_error_threshold) &&
+          f.escalation_error_threshold >= 0 &&
+          f.escalation_error_threshold <= 1
+        ) {
+          fallback.escalation_error_threshold = f.escalation_error_threshold;
+        } else {
+          console.warn(
+            `[config] routing.fallback.escalation_error_threshold: expected a number between 0 and 1 (got ${String(f.escalation_error_threshold)})`,
+          );
+        }
+      }
+      if (f.escalation_revert_ms !== undefined) {
+        if (typeof f.escalation_revert_ms === 'number' && Number.isFinite(f.escalation_revert_ms) && f.escalation_revert_ms > 0) {
+          fallback.escalation_revert_ms = Math.floor(f.escalation_revert_ms);
+        } else {
+          console.warn(
+            `[config] routing.fallback.escalation_revert_ms: expected a positive number of milliseconds (got ${String(f.escalation_revert_ms)})`,
+          );
+        }
+      }
       result.fallback = fallback;
       populated = true;
     } else if (f.on_tool_error !== undefined) {
@@ -634,6 +686,22 @@ export function resolveRoutingStage(
   if (!stageCfg) return undefined;
   const endpoint = routing.endpoints?.[stageCfg.endpoint];
   return { model: stageCfg.model, endpoint };
+}
+
+/**
+ * Return the normalized fallback policy for a config, or null when routing has
+ * no fallback configured. Fills guardrail fields with defaults.
+ */
+export function getFallbackPolicy(config: Config): FallbackPolicy | null {
+  const fallback = config.routing?.fallback;
+  if (!fallback) return null;
+  return {
+    on_tool_error: fallback.on_tool_error,
+    escalate_to: fallback.escalate_to,
+    escalation_window_issues: fallback.escalation_window_issues ?? DEFAULT_ESCALATION_WINDOW,
+    escalation_error_threshold: fallback.escalation_error_threshold ?? DEFAULT_ESCALATION_ERROR_THRESHOLD,
+    escalation_revert_ms: fallback.escalation_revert_ms ?? DEFAULT_ESCALATION_REVERT_MS,
+  };
 }
 
 /**

--- a/src/lib/escalation.ts
+++ b/src/lib/escalation.ts
@@ -1,0 +1,306 @@
+/**
+ * Retry-with-escalation: when a local-model stage emits malformed tool calls
+ * or fails structural checks twice within the same turn, auto-escalate that
+ * turn to the configured frontier fallback model. Also implements the 24h
+ * rolling-rate guardrail that pins a stage to fallback when the primary's
+ * tool-error rate exceeds the configured threshold.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { RoutingStageName, FallbackPolicy } from './config.js';
+
+/** Reason classes we detect in agent output. */
+export type ToolErrorKind = 'json_parse' | 'unknown_tool' | 'schema_validation';
+
+/** Structured classification of a tool-call error found in agent output. */
+export type ToolErrorClassification = {
+  kind: ToolErrorKind;
+  reason: string;
+};
+
+/** One tool-call failure attempt tracked within a single turn. */
+export type TurnErrorState = {
+  /** Classified errors seen in this turn so far, in encounter order. */
+  errors: ToolErrorClassification[];
+  /** Whether this turn has already been escalated once (max 1 per turn). */
+  escalated: boolean;
+};
+
+/** Structured event recorded when escalation or guardrail logic fires. */
+export type EscalationEvent = {
+  type: 'escalation' | 'stage_revert' | 'stage_revert_active' | 'needs_human_input';
+  stage: RoutingStageName;
+  from_model: string;
+  to_model: string;
+  reason: string;
+  turn_index: number;
+  issue: number;
+  ts: string;
+};
+
+/** Per-stage record of a single turn outcome (used by the rolling guardrail). */
+export type TurnRecord = {
+  /** Whether any tool-call error was classified in the turn. */
+  errored: boolean;
+  /** Whether this turn was escalated to the fallback model. */
+  escalated: boolean;
+  /** Epoch ms when the turn completed. */
+  timestampMs: number;
+};
+
+/** Serialized guardrail state persisted to disk. */
+type EscalationState = {
+  /** Rolling window of turns per stage — newest appended. */
+  history: Partial<Record<RoutingStageName, TurnRecord[]>>;
+  /** Active revert pins per stage (epoch ms the pin expires). */
+  reverts: Partial<Record<RoutingStageName, number>>;
+};
+
+const EMPTY_STATE: EscalationState = { history: {}, reverts: {} };
+
+/**
+ * Patterns used to classify tool-call errors found in agent output.
+ *
+ * We scan only the last ~4KB of output to avoid matching code the agent wrote
+ * (e.g. docstrings containing the word "ZodError" or "unknown tool"). If the
+ * signal appears anywhere further up, it's far more likely to be content than
+ * a genuine error.
+ */
+const CLASSIFY_TAIL_CHARS = 4000;
+
+const JSON_PARSE_PATTERNS: RegExp[] = [
+  /SyntaxError:\s*Unexpected token/i,
+  /SyntaxError:\s*Expected.*JSON/i,
+  /JSON\.parse\s*\(/,
+  /Unexpected end of JSON input/i,
+  /Invalid JSON in tool (call|arguments?)/i,
+  /failed to parse tool arguments?/i,
+  /malformed (tool[- ])?(call|arguments?|json)/i,
+];
+
+const UNKNOWN_TOOL_PATTERNS: RegExp[] = [
+  /unknown tool[: ]/i,
+  /tool not (found|defined|registered)/i,
+  /no such tool[: ]/i,
+  /unrecognized tool[: ]/i,
+];
+
+const SCHEMA_VALIDATION_PATTERNS: RegExp[] = [
+  /ZodError/,
+  /"code":\s*"invalid_type"/,
+  /invalid_type/i,
+  /required field.*missing/i,
+  /schema validation failed/i,
+  /does not match schema/i,
+  /parameter .+ is required/i,
+];
+
+/**
+ * Classify a single tool-call failure signal in agent output.
+ * Returns null when no classified pattern is found.
+ *
+ * Use `classifyToolErrors` to detect multiple distinct failures in one turn.
+ */
+export function classifyToolError(output: string): ToolErrorClassification | null {
+  if (!output) return null;
+  const tail = output.slice(-CLASSIFY_TAIL_CHARS);
+
+  for (const p of JSON_PARSE_PATTERNS) {
+    const m = tail.match(p);
+    if (m) return { kind: 'json_parse', reason: m[0].trim() };
+  }
+  for (const p of UNKNOWN_TOOL_PATTERNS) {
+    const m = tail.match(p);
+    if (m) return { kind: 'unknown_tool', reason: m[0].trim() };
+  }
+  for (const p of SCHEMA_VALIDATION_PATTERNS) {
+    const m = tail.match(p);
+    if (m) return { kind: 'schema_validation', reason: m[0].trim() };
+  }
+  return null;
+}
+
+/**
+ * Scan an output buffer for every classified tool-call failure occurrence.
+ * Returned in encounter order; duplicates of the same exact reason are kept —
+ * two hits means two consecutive errors, which is the escalation trigger.
+ */
+export function classifyToolErrors(output: string): ToolErrorClassification[] {
+  if (!output) return [];
+  const tail = output.slice(-CLASSIFY_TAIL_CHARS);
+  const hits: Array<{ index: number; classification: ToolErrorClassification }> = [];
+
+  const scan = (patterns: RegExp[], kind: ToolErrorKind): void => {
+    for (const p of patterns) {
+      const globalPattern = new RegExp(p.source, p.flags.includes('g') ? p.flags : p.flags + 'g');
+      let m: RegExpExecArray | null;
+      while ((m = globalPattern.exec(tail)) !== null) {
+        hits.push({ index: m.index, classification: { kind, reason: m[0].trim() } });
+        if (m.index === globalPattern.lastIndex) globalPattern.lastIndex++;
+      }
+    }
+  };
+
+  scan(JSON_PARSE_PATTERNS, 'json_parse');
+  scan(UNKNOWN_TOOL_PATTERNS, 'unknown_tool');
+  scan(SCHEMA_VALIDATION_PATTERNS, 'schema_validation');
+
+  hits.sort((a, b) => a.index - b.index);
+  return hits.map((h) => h.classification);
+}
+
+/** Start a new per-turn error-state object. */
+export function newTurnState(): TurnErrorState {
+  return { errors: [], escalated: false };
+}
+
+/**
+ * Record tool-call errors from an output into the turn state.
+ * Returns true when the turn has reached the 2-error escalation threshold
+ * AND hasn't already been escalated.
+ */
+export function shouldEscalate(turn: TurnErrorState, output: string): boolean {
+  if (turn.escalated) return false;
+  const newErrors = classifyToolErrors(output);
+  if (newErrors.length === 0) return false;
+  turn.errors.push(...newErrors);
+  return turn.errors.length >= 2;
+}
+
+/**
+ * Rolling-window guardrail that tracks per-stage tool-error rates across
+ * recent turns and pins a stage to fallback when the rate exceeds the
+ * configured threshold. All time comes from the injected `now()` so tests
+ * can advance fake timers.
+ */
+export class EscalationTracker {
+  private state: EscalationState;
+  private readonly statePath: string | null;
+  private readonly nowFn: () => number;
+
+  constructor(options: { statePath?: string | null; now?: () => number } = {}) {
+    this.statePath = options.statePath ?? null;
+    this.nowFn = options.now ?? (() => Date.now());
+    this.state = this.load();
+  }
+
+  now(): number {
+    return this.nowFn();
+  }
+
+  /** Append a turn outcome for a stage. Trims to the rolling window size. */
+  recordTurn(entry: {
+    stage: RoutingStageName;
+    errored: boolean;
+    escalated: boolean;
+    timestampMs?: number;
+    windowSize: number;
+  }): void {
+    const history = this.state.history[entry.stage] ?? [];
+    history.push({
+      errored: entry.errored,
+      escalated: entry.escalated,
+      timestampMs: entry.timestampMs ?? this.nowFn(),
+    });
+    while (history.length > entry.windowSize) history.shift();
+    this.state.history[entry.stage] = history;
+    this.save();
+  }
+
+  /** Current rolling error rate for a stage (0..1). Returns 0 when no data. */
+  errorRate(stage: RoutingStageName): number {
+    const history = this.state.history[stage] ?? [];
+    if (history.length === 0) return 0;
+    const errored = history.filter((h) => h.errored).length;
+    return errored / history.length;
+  }
+
+  /** Whether the stage is currently pinned to fallback. */
+  isStageReverted(stage: RoutingStageName, now?: number): boolean {
+    const pin = this.state.reverts[stage];
+    if (pin == null) return false;
+    const current = now ?? this.nowFn();
+    if (current >= pin) {
+      delete this.state.reverts[stage];
+      this.save();
+      return false;
+    }
+    return true;
+  }
+
+  /** Pin a stage to fallback until `untilMs`. */
+  markRevert(stage: RoutingStageName, untilMs: number): void {
+    this.state.reverts[stage] = untilMs;
+    this.save();
+  }
+
+  /**
+   * Evaluate whether the stage should be pinned to fallback. Call after
+   * recordTurn(). Returns true when a new revert was just applied.
+   */
+  maybeTriggerRevert(stage: RoutingStageName, policy: FallbackPolicy): boolean {
+    if (this.isStageReverted(stage)) return false;
+    const history = this.state.history[stage] ?? [];
+    if (history.length < policy.escalation_window_issues) return false;
+    const rate = this.errorRate(stage);
+    if (rate > policy.escalation_error_threshold) {
+      this.markRevert(stage, this.nowFn() + policy.escalation_revert_ms);
+      return true;
+    }
+    return false;
+  }
+
+  /** When the current pin expires (epoch ms) or null if unpinned. */
+  revertUntil(stage: RoutingStageName): number | null {
+    const pin = this.state.reverts[stage];
+    return pin ?? null;
+  }
+
+  private load(): EscalationState {
+    if (!this.statePath || !existsSync(this.statePath)) {
+      return { history: {}, reverts: {} };
+    }
+    try {
+      const raw = readFileSync(this.statePath, 'utf-8');
+      const parsed = JSON.parse(raw) as Partial<EscalationState>;
+      return {
+        history: parsed.history ?? {},
+        reverts: parsed.reverts ?? {},
+      };
+    } catch {
+      return { history: {}, reverts: {} };
+    }
+  }
+
+  private save(): void {
+    if (!this.statePath) return;
+    try {
+      mkdirSync(dirname(this.statePath), { recursive: true });
+      writeFileSync(this.statePath, JSON.stringify(this.state, null, 2) + '\n');
+    } catch {
+      // Non-fatal — guardrail is a best-effort cache.
+    }
+  }
+}
+
+/** Default filesystem location for the persisted guardrail state. */
+export function defaultEscalationStatePath(projectDir?: string): string {
+  return join(projectDir ?? process.cwd(), '.alpha-loop', 'escalation-state.json');
+}
+
+/**
+ * Append a structured escalation event to the traces ndjson log.
+ * Silent on failure — telemetry should never break the pipeline.
+ */
+export function appendEscalationEventToTrace(
+  runDir: string,
+  event: EscalationEvent,
+): void {
+  try {
+    mkdirSync(runDir, { recursive: true });
+    const path = join(runDir, 'events.ndjson');
+    writeFileSync(path, JSON.stringify(event) + '\n', { flag: 'a' });
+  } catch {
+    // Non-fatal.
+  }
+}

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -5,7 +5,16 @@ import { mkdirSync, readFileSync, writeFileSync, unlinkSync, existsSync } from '
 import { join } from 'node:path';
 import { log } from './logger.js';
 import { exec } from './shell.js';
-import { spawnAgent } from './agent.js';
+import { spawnAgent, buildEndpointEnv } from './agent.js';
+import type { AgentOptions } from './agent.js';
+import {
+  classifyToolError,
+  classifyToolErrors,
+  EscalationTracker,
+  defaultEscalationStatePath,
+  appendEscalationEventToTrace,
+} from './escalation.js';
+import type { EscalationEvent } from './escalation.js';
 import { setupWorktree, cleanupWorktree } from './worktree.js';
 import {
   assignIssue,
@@ -40,10 +49,11 @@ import {
   writeCosts,
   computeScores,
   computeCosts,
+  runDir,
 } from './traces.js';
 import type { StepCost, PipelineResultForScores } from './traces.js';
-import { estimateCost } from './config.js';
-import type { Config } from './config.js';
+import { estimateCost, getFallbackPolicy, resolveRoutingStage } from './config.js';
+import type { Config, RoutingStageName } from './config.js';
 import type { AgentResult } from './agent.js';
 import type { SessionContext } from './session.js';
 
@@ -309,7 +319,161 @@ export type PipelineResult = {
   verifySkipped: boolean;
   duration: number;
   filesChanged: number;
+  /** Structured escalation events recorded while processing this issue. */
+  escalationEvents?: EscalationEvent[];
 };
+
+/** Per-issue context for the escalation wrapper. */
+type StageContext = {
+  stage: RoutingStageName;
+  issueNum: number;
+  turnIndex: number;
+  session: SessionContext;
+  tracker: EscalationTracker;
+  events: EscalationEvent[];
+};
+
+/**
+ * Invoke an agent with retry-with-escalation and the rolling-rate guardrail.
+ *
+ * Resolves the stage's routing (model + endpoint), runs the agent once, and
+ * if the output contains two or more classified tool-call errors escalates
+ * the turn to the configured fallback model. Escalation is scoped to the
+ * current turn: the caller's next invocation reverts to the primary model.
+ *
+ * Also honors the guardrail — when the stage is pinned to fallback because
+ * the recent error rate exceeded the threshold, the primary is skipped
+ * entirely and the fallback runs up-front.
+ */
+async function spawnStageAgent(
+  options: AgentOptions,
+  config: Config,
+  ctx: StageContext,
+): Promise<AgentResult> {
+  const policy = getFallbackPolicy(config);
+  const primary = resolveRoutingStage(config, ctx.stage);
+  const primaryModel = primary?.model ?? options.model;
+  const primaryEndpoint = primary?.endpoint;
+  const primaryEnv = primaryEndpoint ? buildEndpointEnv(primaryEndpoint, primaryModel) : undefined;
+
+  const hasEscalateTarget = policy?.escalate_to !== undefined;
+  const escalateTo = policy?.escalate_to;
+  const escalateEndpoint = escalateTo
+    ? config.routing?.endpoints?.[escalateTo.endpoint]
+    : undefined;
+  const escalateEnv = escalateTo && escalateEndpoint
+    ? buildEndpointEnv(escalateEndpoint, escalateTo.model)
+    : undefined;
+
+  const nowIso = () => new Date().toISOString();
+  const recordEvent = (event: EscalationEvent) => {
+    ctx.events.push(event);
+    try {
+      appendEscalationEventToTrace(runDir(ctx.session.name), event);
+    } catch { /* non-fatal */ }
+  };
+
+  // Guardrail: stage pinned to fallback — use fallback up-front.
+  const reverted = policy?.on_tool_error === 'escalate'
+    && hasEscalateTarget
+    && ctx.tracker.isStageReverted(ctx.stage);
+
+  if (reverted && escalateTo) {
+    recordEvent({
+      type: 'stage_revert_active',
+      stage: ctx.stage,
+      from_model: primaryModel,
+      to_model: escalateTo.model,
+      reason: 'rolling_error_rate_above_threshold',
+      turn_index: ctx.turnIndex,
+      issue: ctx.issueNum,
+      ts: nowIso(),
+    });
+    const result = await spawnAgent({
+      ...options,
+      model: escalateTo.model,
+      env: escalateEnv,
+    });
+    ctx.tracker.recordTurn({
+      stage: ctx.stage,
+      errored: classifyToolError(result.output) !== null,
+      escalated: true,
+      windowSize: policy.escalation_window_issues,
+    });
+    return result;
+  }
+
+  // Normal primary invocation.
+  const firstResult = await spawnAgent({
+    ...options,
+    model: primaryModel,
+    env: primaryEnv,
+  });
+
+  const classified = classifyToolErrors(firstResult.output);
+  const errored = classified.length > 0;
+  let escalated = false;
+  let finalResult = firstResult;
+
+  if (
+    policy?.on_tool_error === 'escalate'
+    && hasEscalateTarget
+    && escalateTo
+    && classified.length >= 2
+  ) {
+    const last = classified[classified.length - 1];
+    recordEvent({
+      type: 'escalation',
+      stage: ctx.stage,
+      from_model: primaryModel,
+      to_model: escalateTo.model,
+      reason: last.kind,
+      turn_index: ctx.turnIndex,
+      issue: ctx.issueNum,
+      ts: nowIso(),
+    });
+    finalResult = await spawnAgent({
+      ...options,
+      model: escalateTo.model,
+      env: escalateEnv,
+    });
+    escalated = true;
+  }
+
+  if (policy) {
+    ctx.tracker.recordTurn({
+      stage: ctx.stage,
+      errored,
+      escalated,
+      windowSize: policy.escalation_window_issues,
+    });
+    if (ctx.tracker.maybeTriggerRevert(ctx.stage, policy)) {
+      const untilMs = ctx.tracker.revertUntil(ctx.stage) ?? 0;
+      recordEvent({
+        type: 'stage_revert',
+        stage: ctx.stage,
+        from_model: primaryModel,
+        to_model: escalateTo?.model ?? primaryModel,
+        reason: `rolling_error_rate_above_${policy.escalation_error_threshold}`,
+        turn_index: ctx.turnIndex,
+        issue: ctx.issueNum,
+        ts: nowIso(),
+      });
+      recordEvent({
+        type: 'needs_human_input',
+        stage: ctx.stage,
+        from_model: primaryModel,
+        to_model: escalateTo?.model ?? primaryModel,
+        reason: `stage_pinned_to_fallback_until_${new Date(untilMs).toISOString()}`,
+        turn_index: ctx.turnIndex,
+        issue: ctx.issueNum,
+        ts: nowIso(),
+      });
+    }
+  }
+
+  return finalResult;
+}
 
 /**
  * Process a single issue through the full pipeline.
@@ -322,11 +486,25 @@ export async function processIssue(
   body: string,
   config: Config,
   session: SessionContext,
+  trackerOverride?: EscalationTracker,
 ): Promise<PipelineResult> {
   const startTime = Date.now();
   const projectDir = process.cwd();
   const stepCosts: StepCost[] = [];
   const stepsCompleted: string[] = [];
+  const escalationEvents: EscalationEvent[] = [];
+  const tracker = trackerOverride ?? new EscalationTracker({
+    statePath: defaultEscalationStatePath(projectDir),
+  });
+  let turnCounter = 0;
+  const stageCtx = (stage: RoutingStageName): StageContext => ({
+    stage,
+    issueNum,
+    turnIndex: ++turnCounter,
+    session,
+    tracker,
+    events: escalationEvents,
+  });
 
   // Setup logging
   mkdirSync(session.logsDir, { recursive: true });
@@ -420,7 +598,7 @@ Rules:
       // Trace the plan prompt
       tracePrompt(session.name, issueNum, 'plan', planPrompt);
 
-      const planResult = await spawnAgent({
+      const planResult = await spawnStageAgent({
         agent: config.agent,
         model: config.model,
         prompt: planPrompt,
@@ -428,7 +606,7 @@ Rules:
         logFile: join(session.logsDir, `issue-${issueNum}-plan.log`),
         verbose: config.verbose,
         timeout: config.agentTimeout * 1000,
-      });
+      }, config, stageCtx('plan'));
 
       // Trace the plan output and costs
       traceOutput(session.name, issueNum, 'plan', planResult.output);
@@ -498,7 +676,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     // Trace the implement prompt
     tracePrompt(session.name, issueNum, 'implement', implementPrompt);
 
-    const implResult = await spawnAgent({
+    const implResult = await spawnStageAgent({
       agent: config.agent,
       model: config.model,
       prompt: implementPrompt,
@@ -507,7 +685,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
       logFile: join(session.logsDir, `issue-${issueNum}-implement.log`),
       verbose: config.verbose,
       timeout: config.agentTimeout * 1000,
-    });
+    }, config, stageCtx('build'));
 
     // Trace the implement output and costs
     traceOutput(session.name, issueNum, 'implement', implResult.output);
@@ -589,7 +767,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
         // Trace fix prompt
         tracePrompt(session.name, issueNum, `fix-${attempt}`, fixPrompt);
 
-        const fixResult = await spawnAgent({
+        const fixResult = await spawnStageAgent({
           agent: config.agent,
           model: config.model,
           prompt: fixPrompt,
@@ -598,7 +776,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           logFile: join(session.logsDir, `issue-${issueNum}-fix-${attempt}.log`),
           verbose: config.verbose,
           timeout: config.agentTimeout * 1000,
-        });
+        }, config, stageCtx('test_write'));
 
         // Trace fix output and costs
         traceOutput(session.name, issueNum, `fix-${attempt}`, fixResult.output);
@@ -653,7 +831,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
         // Trace review prompt
         tracePrompt(session.name, issueNum, `review${attempt > 1 ? `-${attempt}` : ''}`, reviewPrompt);
 
-        const reviewResult = await spawnAgent({
+        const reviewResult = await spawnStageAgent({
           agent: config.agent,
           model: config.reviewModel,
           prompt: reviewPrompt,
@@ -661,7 +839,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           logFile: join(session.logsDir, `issue-${issueNum}-review${attempt > 1 ? `-${attempt}` : ''}.log`),
           verbose: config.verbose,
           timeout: config.agentTimeout * 1000,
-        });
+        }, config, stageCtx('review'));
 
         // Trace review output and costs
         traceOutput(session.name, issueNum, `review${attempt > 1 ? `-${attempt}` : ''}`, reviewResult.output);
@@ -695,7 +873,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
         // Trace review-fix prompt
         tracePrompt(session.name, issueNum, `review-fix-${attempt}`, fixPrompt);
 
-        const reviewFixResult = await spawnAgent({
+        const reviewFixResult = await spawnStageAgent({
           agent: config.agent,
           model: config.model,
           prompt: fixPrompt,
@@ -704,7 +882,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           logFile: join(session.logsDir, `issue-${issueNum}-review-fix-${attempt}.log`),
           verbose: config.verbose,
           timeout: config.agentTimeout * 1000,
-        });
+        }, config, stageCtx('build'));
 
         // Trace review-fix output and costs
         traceOutput(session.name, issueNum, `review-fix-${attempt}`, reviewFixResult.output);
@@ -804,7 +982,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           // Trace verify-fix prompt
           tracePrompt(session.name, issueNum, `verify-fix-${attempt}`, fixPrompt);
 
-          const verifyFixResult = await spawnAgent({
+          const verifyFixResult = await spawnStageAgent({
             agent: config.agent,
             model: config.model,
             prompt: fixPrompt,
@@ -813,7 +991,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
             logFile: join(session.logsDir, `issue-${issueNum}-verify-fix-${attempt}.log`),
             verbose: config.verbose,
             timeout: config.agentTimeout * 1000,
-          });
+          }, config, stageCtx('test_exec'));
 
           // Trace verify-fix output and costs
           traceOutput(session.name, issueNum, `verify-fix-${attempt}`, verifyFixResult.output);
@@ -1080,6 +1258,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     verifySkipped,
     duration,
     filesChanged,
+    escalationEvents: escalationEvents.length > 0 ? escalationEvents : undefined,
   };
 
   // Save result to session

--- a/tests/lib/config.test.ts
+++ b/tests/lib/config.test.ts
@@ -17,6 +17,10 @@ import {
   resolveStepConfig,
   resolveRoutingStage,
   selectRoutingProfile,
+  getFallbackPolicy,
+  DEFAULT_ESCALATION_WINDOW,
+  DEFAULT_ESCALATION_ERROR_THRESHOLD,
+  DEFAULT_ESCALATION_REVERT_MS,
 } from '../../src/lib/config.js';
 import type { Config, PipelineConfig } from '../../src/lib/config.js';
 
@@ -626,6 +630,101 @@ routing:
       },
     });
     expect(config.routing?.profile).toBe('all-frontier');
+  });
+
+  it('parses guardrail fields under fallback', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  fallback:
+    on_tool_error: escalate
+    escalate_to: { model: claude-sonnet-4-6, endpoint: anthropic }
+    escalation_window_issues: 20
+    escalation_error_threshold: 0.05
+    escalation_revert_ms: 3600000
+`,
+    );
+    const config = loadConfig();
+    expect(config.routing?.fallback?.escalation_window_issues).toBe(20);
+    expect(config.routing?.fallback?.escalation_error_threshold).toBe(0.05);
+    expect(config.routing?.fallback?.escalation_revert_ms).toBe(3_600_000);
+  });
+
+  it('drops invalid guardrail values and warns', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  fallback:
+    on_tool_error: escalate
+    escalate_to: { model: claude-sonnet-4-6, endpoint: anthropic }
+    escalation_window_issues: -3
+    escalation_error_threshold: 1.5
+    escalation_revert_ms: "not a number"
+`,
+    );
+    const config = loadConfig();
+    expect(config.routing?.fallback?.escalation_window_issues).toBeUndefined();
+    expect(config.routing?.fallback?.escalation_error_threshold).toBeUndefined();
+    expect(config.routing?.fallback?.escalation_revert_ms).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe('getFallbackPolicy', () => {
+  let warnSpy: jest.SpyInstance;
+  beforeEach(() => { warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { warnSpy.mockRestore(); });
+
+  it('returns null when routing has no fallback', () => {
+    const config = loadConfig();
+    expect(getFallbackPolicy(config)).toBeNull();
+  });
+
+  it('fills defaults when only on_tool_error is configured', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  fallback:
+    on_tool_error: escalate
+    escalate_to: { model: claude-sonnet-4-6, endpoint: anthropic }
+`,
+    );
+    const policy = getFallbackPolicy(loadConfig());
+    expect(policy).not.toBeNull();
+    expect(policy!.on_tool_error).toBe('escalate');
+    expect(policy!.escalation_window_issues).toBe(DEFAULT_ESCALATION_WINDOW);
+    expect(policy!.escalation_error_threshold).toBe(DEFAULT_ESCALATION_ERROR_THRESHOLD);
+    expect(policy!.escalation_revert_ms).toBe(DEFAULT_ESCALATION_REVERT_MS);
+  });
+
+  it('respects explicit overrides from config', () => {
+    writeFileSync(
+      join(tempDir, '.alpha-loop.yaml'),
+      `repo: owner/repo
+routing:
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  fallback:
+    on_tool_error: escalate
+    escalate_to: { model: claude-sonnet-4-6, endpoint: anthropic }
+    escalation_window_issues: 5
+    escalation_error_threshold: 0.2
+    escalation_revert_ms: 1000
+`,
+    );
+    const policy = getFallbackPolicy(loadConfig());
+    expect(policy!.escalation_window_issues).toBe(5);
+    expect(policy!.escalation_error_threshold).toBe(0.2);
+    expect(policy!.escalation_revert_ms).toBe(1000);
   });
 });
 

--- a/tests/lib/escalation.test.ts
+++ b/tests/lib/escalation.test.ts
@@ -1,0 +1,255 @@
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  classifyToolError,
+  classifyToolErrors,
+  EscalationTracker,
+  newTurnState,
+  shouldEscalate,
+  defaultEscalationStatePath,
+  appendEscalationEventToTrace,
+} from '../../src/lib/escalation.js';
+import type { EscalationEvent } from '../../src/lib/escalation.js';
+import type { FallbackPolicy } from '../../src/lib/config.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-escalation-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('classifyToolError', () => {
+  it('returns null on empty output', () => {
+    expect(classifyToolError('')).toBeNull();
+    expect(classifyToolError('all good')).toBeNull();
+  });
+
+  it('detects a JSON.parse failure as json_parse', () => {
+    const output = 'some text\nSyntaxError: Unexpected token } in JSON at position 42\n';
+    const r = classifyToolError(output);
+    expect(r?.kind).toBe('json_parse');
+  });
+
+  it('detects an unknown tool name', () => {
+    const output = 'attempted to call tool but got: unknown tool: frobnicate';
+    const r = classifyToolError(output);
+    expect(r?.kind).toBe('unknown_tool');
+  });
+
+  it('detects a schema validation failure (ZodError)', () => {
+    const output = 'ZodError: [ { "code": "invalid_type", "expected": "string" } ]';
+    const r = classifyToolError(output);
+    expect(r?.kind).toBe('schema_validation');
+  });
+
+  it('only inspects the tail — signal earlier in output is ignored', () => {
+    // "ZodError" appears at the very start, then thousands of chars of clean output.
+    const noise = 'ok\n'.repeat(2000);
+    const output = `ZodError at startup\n${noise}`;
+    expect(classifyToolError(output)).toBeNull();
+  });
+});
+
+describe('classifyToolErrors', () => {
+  it('returns every classified failure in encounter order', () => {
+    const output = [
+      'something went wrong',
+      'SyntaxError: Unexpected token } in JSON',
+      'unknown tool: frobnicate',
+      'ZodError: invalid_type',
+    ].join('\n');
+    const errors = classifyToolErrors(output);
+    const kinds = errors.map((e) => e.kind);
+    expect(kinds).toContain('json_parse');
+    expect(kinds).toContain('unknown_tool');
+    expect(kinds).toContain('schema_validation');
+  });
+
+  it('returns empty for clean output', () => {
+    expect(classifyToolErrors('no problem here')).toEqual([]);
+  });
+});
+
+describe('shouldEscalate / per-turn counter', () => {
+  it('does not trigger on a single error', () => {
+    const turn = newTurnState();
+    expect(shouldEscalate(turn, 'SyntaxError: Unexpected token')).toBe(false);
+    expect(turn.errors.length).toBe(1);
+  });
+
+  it('triggers after two classified errors within the same turn', () => {
+    const turn = newTurnState();
+    expect(shouldEscalate(turn, 'SyntaxError: Unexpected token')).toBe(false);
+    expect(shouldEscalate(turn, 'unknown tool: missing')).toBe(true);
+  });
+
+  it('triggers when one output contains two errors', () => {
+    const turn = newTurnState();
+    const output = 'SyntaxError: Unexpected token }\nunknown tool: missing\n';
+    expect(shouldEscalate(turn, output)).toBe(true);
+  });
+
+  it('does not re-trigger once a turn has already been escalated', () => {
+    const turn = newTurnState();
+    shouldEscalate(turn, 'SyntaxError: a\nunknown tool: b');
+    turn.escalated = true;
+    expect(shouldEscalate(turn, 'ZodError: invalid_type')).toBe(false);
+  });
+
+  it('a fresh turn starts with a clean counter — single-turn scope', () => {
+    const turnA = newTurnState();
+    shouldEscalate(turnA, 'SyntaxError: Unexpected token }\nunknown tool: foo');
+    expect(turnA.errors.length).toBeGreaterThanOrEqual(2);
+
+    const turnB = newTurnState();
+    expect(shouldEscalate(turnB, 'SyntaxError: Unexpected token }')).toBe(false);
+    expect(turnB.errors.length).toBe(1);
+  });
+});
+
+describe('EscalationTracker — rolling-rate guardrail', () => {
+  const policy: FallbackPolicy = {
+    on_tool_error: 'escalate',
+    escalate_to: { model: 'claude-sonnet-4-6', endpoint: 'anthropic' },
+    escalation_window_issues: 10,
+    escalation_error_threshold: 0.08,
+    escalation_revert_ms: 24 * 60 * 60 * 1000,
+  };
+
+  it('does not revert until the full window has accumulated', () => {
+    let now = 1_000_000;
+    const tracker = new EscalationTracker({ now: () => now });
+    for (let i = 0; i < 9; i++) {
+      tracker.recordTurn({ stage: 'build', errored: true, escalated: true, windowSize: policy.escalation_window_issues });
+    }
+    expect(tracker.maybeTriggerRevert('build', policy)).toBe(false);
+    expect(tracker.isStageReverted('build')).toBe(false);
+  });
+
+  it('reverts when error rate exceeds threshold within the window', () => {
+    let now = 1_000_000;
+    const tracker = new EscalationTracker({ now: () => now });
+    // 2 errors out of 10 = 20% > 8%
+    for (let i = 0; i < 8; i++) {
+      tracker.recordTurn({ stage: 'build', errored: false, escalated: false, windowSize: policy.escalation_window_issues });
+    }
+    for (let i = 0; i < 2; i++) {
+      tracker.recordTurn({ stage: 'build', errored: true, escalated: true, windowSize: policy.escalation_window_issues });
+    }
+    expect(tracker.maybeTriggerRevert('build', policy)).toBe(true);
+    expect(tracker.isStageReverted('build')).toBe(true);
+  });
+
+  it('clears the revert after the 24h window expires', () => {
+    let now = 1_000_000;
+    const tracker = new EscalationTracker({ now: () => now });
+    for (let i = 0; i < 8; i++) {
+      tracker.recordTurn({ stage: 'build', errored: false, escalated: false, windowSize: 10 });
+    }
+    for (let i = 0; i < 2; i++) {
+      tracker.recordTurn({ stage: 'build', errored: true, escalated: true, windowSize: 10 });
+    }
+    tracker.maybeTriggerRevert('build', policy);
+    expect(tracker.isStageReverted('build')).toBe(true);
+
+    // Still pinned 23h later
+    now += 23 * 60 * 60 * 1000;
+    expect(tracker.isStageReverted('build')).toBe(true);
+
+    // Expired after 24h + 1ms
+    now += 60 * 60 * 1000 + 1;
+    expect(tracker.isStageReverted('build')).toBe(false);
+  });
+
+  it('recovers after the guardrail window — subsequent clean runs reset the rate', () => {
+    let now = 1_000_000;
+    const tracker = new EscalationTracker({ now: () => now });
+    // Fill with failures
+    for (let i = 0; i < 10; i++) {
+      tracker.recordTurn({ stage: 'build', errored: true, escalated: true, windowSize: 10 });
+    }
+    expect(tracker.errorRate('build')).toBe(1);
+    expect(tracker.maybeTriggerRevert('build', policy)).toBe(true);
+
+    // Let the revert expire.
+    now += policy.escalation_revert_ms + 1;
+    expect(tracker.isStageReverted('build')).toBe(false);
+
+    // Add clean runs — rolling window shifts failures out.
+    for (let i = 0; i < 10; i++) {
+      tracker.recordTurn({ stage: 'build', errored: false, escalated: false, windowSize: 10 });
+    }
+    expect(tracker.errorRate('build')).toBe(0);
+    // New revert should NOT fire on clean data.
+    expect(tracker.maybeTriggerRevert('build', policy)).toBe(false);
+  });
+
+  it('persists state to disk and reloads it across instances', () => {
+    const statePath = join(tempDir, 'state.json');
+    let now = 1_000_000;
+    const t1 = new EscalationTracker({ statePath, now: () => now });
+    for (let i = 0; i < 5; i++) {
+      t1.recordTurn({ stage: 'review', errored: true, escalated: false, windowSize: 10 });
+    }
+    t1.markRevert('build', now + 1000);
+
+    expect(existsSync(statePath)).toBe(true);
+
+    // New instance reads the persisted state.
+    const t2 = new EscalationTracker({ statePath, now: () => now });
+    expect(t2.errorRate('review')).toBe(1);
+    expect(t2.isStageReverted('build')).toBe(true);
+  });
+
+  it('tracks stages independently', () => {
+    let now = 1_000_000;
+    const tracker = new EscalationTracker({ now: () => now });
+    for (let i = 0; i < 10; i++) {
+      tracker.recordTurn({ stage: 'build', errored: true, escalated: true, windowSize: 10 });
+    }
+    for (let i = 0; i < 10; i++) {
+      tracker.recordTurn({ stage: 'plan', errored: false, escalated: false, windowSize: 10 });
+    }
+    expect(tracker.maybeTriggerRevert('build', policy)).toBe(true);
+    expect(tracker.maybeTriggerRevert('plan', policy)).toBe(false);
+    expect(tracker.isStageReverted('build')).toBe(true);
+    expect(tracker.isStageReverted('plan')).toBe(false);
+  });
+});
+
+describe('defaultEscalationStatePath', () => {
+  it('places the state file under .alpha-loop/', () => {
+    const p = defaultEscalationStatePath('/tmp/project');
+    expect(p).toBe('/tmp/project/.alpha-loop/escalation-state.json');
+  });
+});
+
+describe('appendEscalationEventToTrace', () => {
+  it('appends each event as one ndjson line', () => {
+    const runDir = join(tempDir, 'run');
+    const event: EscalationEvent = {
+      type: 'escalation',
+      stage: 'build',
+      from_model: 'qwen3-coder-30b-a3b',
+      to_model: 'claude-sonnet-4-6',
+      reason: 'json_parse',
+      turn_index: 1,
+      issue: 42,
+      ts: '2026-04-23T12:00:00.000Z',
+    };
+    appendEscalationEventToTrace(runDir, event);
+    appendEscalationEventToTrace(runDir, { ...event, turn_index: 2 });
+
+    const raw = readFileSync(join(runDir, 'events.ndjson'), 'utf-8').trim();
+    const lines = raw.split('\n');
+    expect(lines.length).toBe(2);
+    expect(JSON.parse(lines[0])).toMatchObject({ type: 'escalation', turn_index: 1 });
+    expect(JSON.parse(lines[1])).toMatchObject({ type: 'escalation', turn_index: 2 });
+  });
+});

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -20,6 +20,7 @@ jest.mock('../../src/lib/logger', () => ({
 
 jest.mock('../../src/lib/agent', () => ({
   spawnAgent: jest.fn(),
+  buildEndpointEnv: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('../../src/lib/worktree', () => ({
@@ -65,10 +66,13 @@ jest.mock('../../src/lib/traces', () => ({
   writeCosts: jest.fn(),
   computeScores: jest.fn().mockReturnValue({}),
   computeCosts: jest.fn().mockReturnValue({}),
+  runDir: jest.fn().mockReturnValue('/tmp/traces/run'),
 }));
 
 jest.mock('../../src/lib/config', () => ({
   estimateCost: jest.fn().mockReturnValue(0),
+  getFallbackPolicy: jest.fn().mockReturnValue(null),
+  resolveRoutingStage: jest.fn().mockReturnValue(undefined),
 }));
 
 jest.mock('../../src/lib/prompts', () => ({
@@ -434,6 +438,218 @@ describe('processIssue', () => {
     expect(mockCleanupWorktree).toHaveBeenCalledWith(
       expect.objectContaining({ preserveIfCommits: true }),
     );
+  });
+});
+
+describe('processIssue — retry-with-escalation', () => {
+  const mockedConfigModule = require('../../src/lib/config');
+  const routedConfig = () => makeConfig({
+    routing: {
+      profile: 'hybrid-v1',
+      endpoints: {
+        anthropic: { type: 'anthropic' as const, base_url: 'https://api.anthropic.com' },
+        lmstudio_local: { type: 'anthropic_compat' as const, base_url: 'http://localhost:1234' },
+      },
+      stages: {
+        plan: { model: 'claude-opus-4-7', endpoint: 'anthropic' },
+        build: { model: 'qwen3-coder-30b-a3b', endpoint: 'lmstudio_local' },
+      },
+      fallback: {
+        on_tool_error: 'escalate',
+        escalate_to: { model: 'claude-sonnet-4-6', endpoint: 'anthropic' },
+      },
+    },
+  });
+
+  const { EscalationTracker } = require('../../src/lib/escalation');
+
+  beforeEach(() => {
+    mockedConfigModule.getFallbackPolicy.mockReset();
+    mockedConfigModule.resolveRoutingStage.mockReset();
+    mockedConfigModule.getFallbackPolicy.mockReturnValue(null);
+    mockedConfigModule.resolveRoutingStage.mockReturnValue(undefined);
+  });
+
+  test('re-invokes the build stage with escalate_to after 2 tool errors in one turn', async () => {
+    mockedConfigModule.getFallbackPolicy.mockReturnValue({
+      on_tool_error: 'escalate',
+      escalate_to: { model: 'claude-sonnet-4-6', endpoint: 'anthropic' },
+      escalation_window_issues: 10,
+      escalation_error_threshold: 0.08,
+      escalation_revert_ms: 86_400_000,
+    });
+    mockedConfigModule.resolveRoutingStage.mockImplementation((_c: any, stage: string) => {
+      if (stage === 'build') return { model: 'qwen3-coder-30b-a3b', endpoint: { type: 'anthropic_compat', base_url: 'http://localhost:1234' } };
+      return undefined;
+    });
+
+    const errorOutput = 'SyntaxError: Unexpected token } in JSON\nunknown tool: frobnicate\n';
+    mockSpawnAgent.mockImplementation(async (options: any) => {
+      if (options.prompt === 'implement prompt' && options.model === 'qwen3-coder-30b-a3b') {
+        return { exitCode: 0, output: errorOutput, duration: 100 };
+      }
+      return { exitCode: 0, output: 'ok', duration: 100 };
+    });
+
+    const tracker = new EscalationTracker({ statePath: null, now: () => 1_000_000 });
+    const result = await (processIssue as any)(42, 'Test', 'Body', routedConfig(), makeSession(), tracker);
+
+    const buildCalls = (mockSpawnAgent as jest.Mock).mock.calls.filter(
+      (c: any[]) => c[0].prompt === 'implement prompt',
+    );
+    // First call with primary, second call with escalated model
+    expect(buildCalls.length).toBe(2);
+    expect(buildCalls[0][0].model).toBe('qwen3-coder-30b-a3b');
+    expect(buildCalls[1][0].model).toBe('claude-sonnet-4-6');
+
+    // Escalation event captured on the result
+    expect(result.escalationEvents).toBeDefined();
+    const esc = result.escalationEvents!.find((e: any) => e.type === 'escalation');
+    expect(esc).toBeDefined();
+    expect(esc!.stage).toBe('build');
+    expect(esc!.from_model).toBe('qwen3-coder-30b-a3b');
+    expect(esc!.to_model).toBe('claude-sonnet-4-6');
+  });
+
+  test('does not escalate when on_tool_error === "fail"', async () => {
+    mockedConfigModule.getFallbackPolicy.mockReturnValue({
+      on_tool_error: 'fail',
+      escalate_to: { model: 'claude-sonnet-4-6', endpoint: 'anthropic' },
+      escalation_window_issues: 10,
+      escalation_error_threshold: 0.08,
+      escalation_revert_ms: 86_400_000,
+    });
+    mockedConfigModule.resolveRoutingStage.mockImplementation((_c: any, stage: string) => {
+      if (stage === 'build') return { model: 'qwen3-coder-30b-a3b', endpoint: { type: 'anthropic_compat', base_url: 'http://localhost:1234' } };
+      return undefined;
+    });
+
+    const errorOutput = 'SyntaxError: Unexpected token\nunknown tool: foo\n';
+    mockSpawnAgent.mockImplementation(async (options: any) => {
+      if (options.prompt === 'implement prompt') {
+        return { exitCode: 0, output: errorOutput, duration: 100 };
+      }
+      return { exitCode: 0, output: 'ok', duration: 100 };
+    });
+
+    const tracker = new EscalationTracker({ statePath: null, now: () => 1_000_000 });
+    const result = await (processIssue as any)(42, 'Test', 'Body', routedConfig(), makeSession(), tracker);
+
+    const buildCalls = (mockSpawnAgent as jest.Mock).mock.calls.filter(
+      (c: any[]) => c[0].prompt === 'implement prompt',
+    );
+    // on_tool_error === 'fail' — no retry, single invocation
+    expect(buildCalls.length).toBe(1);
+    // No escalation event
+    const esc = (result.escalationEvents ?? []).find((e: any) => e.type === 'escalation');
+    expect(esc).toBeUndefined();
+  });
+
+  test('subsequent turn reverts to primary — escalation is single-turn scoped', async () => {
+    mockedConfigModule.getFallbackPolicy.mockReturnValue({
+      on_tool_error: 'escalate',
+      escalate_to: { model: 'claude-sonnet-4-6', endpoint: 'anthropic' },
+      escalation_window_issues: 10,
+      escalation_error_threshold: 0.08,
+      escalation_revert_ms: 86_400_000,
+    });
+    mockedConfigModule.resolveRoutingStage.mockImplementation((_c: any, stage: string) => {
+      if (stage === 'build') return { model: 'qwen3-coder-30b-a3b', endpoint: { type: 'anthropic_compat', base_url: 'http://localhost:1234' } };
+      return undefined;
+    });
+
+    // First build call emits errors (triggers escalation). Test retries cause additional turns.
+    let buildCallIdx = 0;
+    mockSpawnAgent.mockImplementation(async (options: any) => {
+      if (options.prompt === 'implement prompt') {
+        buildCallIdx++;
+        if (buildCallIdx === 1) {
+          // First turn: primary emits errors, will escalate
+          return { exitCode: 0, output: 'SyntaxError: x\nZodError: y', duration: 100 };
+        }
+        // Escalated retry — clean
+        return { exitCode: 0, output: 'ok', duration: 100 };
+      }
+      return { exitCode: 0, output: 'ok', duration: 100 };
+    });
+    // Tests pass immediately — no test_write stage needed
+    mockRunTests.mockReturnValue({ passed: true, output: 'ok' });
+
+    const tracker = new EscalationTracker({ statePath: null, now: () => 1_000_000 });
+    await (processIssue as any)(42, 'Test', 'Body', routedConfig(), makeSession(), tracker);
+
+    // After escalation, the tracker should have recorded one turn for 'build' stage
+    expect(tracker.errorRate('build')).toBeGreaterThan(0);
+  });
+
+  test('stage pinned to fallback emits stage_revert_active when >threshold', async () => {
+    mockedConfigModule.getFallbackPolicy.mockReturnValue({
+      on_tool_error: 'escalate',
+      escalate_to: { model: 'claude-sonnet-4-6', endpoint: 'anthropic' },
+      escalation_window_issues: 10,
+      escalation_error_threshold: 0.08,
+      escalation_revert_ms: 86_400_000,
+    });
+    mockedConfigModule.resolveRoutingStage.mockImplementation((_c: any, stage: string) => {
+      if (stage === 'build') return { model: 'qwen3-coder-30b-a3b', endpoint: { type: 'anthropic_compat', base_url: 'http://localhost:1234' } };
+      return undefined;
+    });
+
+    const tracker = new EscalationTracker({ statePath: null, now: () => 1_000_000 });
+    // Pre-fill the tracker so the build stage is already pinned
+    tracker.markRevert('build', 1_000_000 + 60 * 60 * 1000);
+
+    mockSpawnAgent.mockResolvedValue({ exitCode: 0, output: 'ok', duration: 100 });
+
+    const result = await (processIssue as any)(42, 'Test', 'Body', routedConfig(), makeSession(), tracker);
+
+    // The build stage call should go directly to the fallback model
+    const buildCalls = (mockSpawnAgent as jest.Mock).mock.calls.filter(
+      (c: any[]) => c[0].prompt === 'implement prompt',
+    );
+    expect(buildCalls[0][0].model).toBe('claude-sonnet-4-6');
+
+    // stage_revert_active event recorded
+    const revertEvent = (result.escalationEvents ?? []).find((e: any) => e.type === 'stage_revert_active');
+    expect(revertEvent).toBeDefined();
+    expect(revertEvent!.stage).toBe('build');
+  });
+
+  test('crossing the rolling error threshold emits stage_revert + needs_human_input', async () => {
+    mockedConfigModule.getFallbackPolicy.mockReturnValue({
+      on_tool_error: 'escalate',
+      escalate_to: { model: 'claude-sonnet-4-6', endpoint: 'anthropic' },
+      escalation_window_issues: 4,
+      escalation_error_threshold: 0.08,
+      escalation_revert_ms: 86_400_000,
+    });
+    mockedConfigModule.resolveRoutingStage.mockImplementation((_c: any, stage: string) => {
+      if (stage === 'build') return { model: 'qwen3-coder-30b-a3b', endpoint: { type: 'anthropic_compat', base_url: 'http://localhost:1234' } };
+      return undefined;
+    });
+
+    const tracker = new EscalationTracker({ statePath: null, now: () => 1_000_000 });
+    // Pre-populate 3 errored turns for 'build' — next errored turn will push rate over 0.08
+    for (let i = 0; i < 3; i++) {
+      tracker.recordTurn({ stage: 'build', errored: true, escalated: false, windowSize: 4 });
+    }
+
+    mockSpawnAgent.mockImplementation(async (options: any) => {
+      if (options.prompt === 'implement prompt' && options.model === 'qwen3-coder-30b-a3b') {
+        return { exitCode: 0, output: 'SyntaxError: x\nunknown tool: y', duration: 100 };
+      }
+      return { exitCode: 0, output: 'ok', duration: 100 };
+    });
+
+    const result = await (processIssue as any)(42, 'Test', 'Body', routedConfig(), makeSession(), tracker);
+
+    const events = result.escalationEvents ?? [];
+    const hasRevert = events.some((e: any) => e.type === 'stage_revert');
+    const hasNeedsHuman = events.some((e: any) => e.type === 'needs_human_input');
+    expect(hasRevert).toBe(true);
+    expect(hasNeedsHuman).toBe(true);
+    // Guardrail pin established
+    expect(tracker.isStageReverted('build')).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #160
Part of #165

## Summary

Automated implementation of **Retry-with-escalation: local tool-call failure falls back to frontier**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

All acceptance criteria met: escalation triggers on 2+ tool errors, 24h guardrail with rolling window, single-turn scope, history shows events, fail mode honored. Fixed gitignore for escalation-state.json.

- **WARNING** [FIXED] `.gitignore`: Runtime escalation-state.json was not gitignored, risking accidental commits of per-machine guardrail state.
- **INFO** [OPEN] `src/lib/pipeline.ts`: processBatch still uses raw spawnAgent and does not get routing/escalation behavior. Pre-existing limitation, not introduced by this PR — batch flow had no routing before.
- **INFO** [OPEN] `src/lib/pipeline.ts`: The post-PR 'assumptions' step in processIssue (pipeline.ts:1081) uses raw spawnAgent and is not mapped to the 'summary' routing stage. Minor gap — the summary stage defined in RoutingStageName is not wired through escalation.
- **INFO** [OPEN] `src/lib/escalation.ts`: newTurnState/shouldEscalate APIs exported from escalation.ts are not used by pipeline.ts (which uses classifyToolErrors(...).length >= 2 on a single-output). They are exercised by unit tests and remain useful for streaming scenarios, but the turn-state abstraction is currently dead code inside the pipeline.
- **INFO** [OPEN] `src/lib/pipeline.ts`: RoutingFallbackMode 'retry' is defined but not implemented in spawnStageAgent. Only 'escalate' and 'fail' are handled. Not an AC requirement.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*