### PR TITLE
feat: Per-stage telemetry + cost-per-issue aggregation (alpha-loop report routing) (closes #161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop history` | View session history |
 | `alpha-loop history <name>` | View a specific session |
 | `alpha-loop history <name> --qa` | Show QA checklist for session |
+| `alpha-loop history <name> --telemetry` | Show per-stage telemetry table (see [docs/telemetry.md](docs/telemetry.md)) |
 | `alpha-loop history --clean` | Remove old session data |
+| `alpha-loop report routing` | Aggregate per-stage telemetry + cost-per-issue across sessions |
 | `alpha-loop sync` | Sync templates to configured harnesses (Claude, Codex, Cursor, etc.) |
 | `alpha-loop resume` | Resume stranded work — push branches, review, open PRs |
 | `alpha-loop resume --issue <N>` | Resume a specific issue |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,140 @@
+# Per-Stage Telemetry
+
+Alpha Loop emits one telemetry record per stage invocation so that routing
+decisions — "is this local model good enough for the Build stage?" — can be
+answered with apples-to-apples data across many issues. Session-level cost
+logs hide which stage burned the tokens; per-stage telemetry does not.
+
+## Where it's stored
+
+```
+.alpha-loop/traces/<session>/stages.jsonl
+```
+
+Each line is a JSON object with the following shape:
+
+```json
+{
+  "stage": "implement",
+  "model": "claude-sonnet-4-6",
+  "endpoint": "anthropic-prod",
+  "endpoint_type": "anthropic",
+  "tokens_in": 12480,
+  "tokens_out": 2156,
+  "cost_usd": 0.0598,
+  "wall_time_s": 42.183,
+  "tool_calls": 18,
+  "tool_errors": 1,
+  "stage_success": true,
+  "started_at": "2026-04-23T18:12:34.123Z",
+  "profile": "hybrid-v1",
+  "issue_num": 161
+}
+```
+
+### Field reference
+
+| Field            | Type              | Notes                                                                 |
+|------------------|-------------------|-----------------------------------------------------------------------|
+| `stage`          | string            | `plan`, `implement`, `test_fix`, `review`, `review_fix`, `verify_fix`, `assumptions`, `batch-plan`, `batch-implement`, `batch-test_fix`, `batch-review`, `batch-review_fix` |
+| `model`          | string            | Model id used for this invocation                                     |
+| `endpoint`       | string            | Named endpoint from `routing.endpoints`; `default` when routing isn't used |
+| `endpoint_type`  | string            | `anthropic`, `anthropic_compat` (LM Studio), or `openai_compat` (Ollama) — optional |
+| `tokens_in`      | number            | Input tokens                                                          |
+| `tokens_out`     | number            | Output tokens                                                         |
+| `cost_usd`       | number            | USD cost. Always `0` for `anthropic_compat` / `openai_compat` endpoints |
+| `wall_time_s`    | number            | Wall-clock duration of the agent invocation, in seconds               |
+| `tool_calls`     | number            | Count of `tool_use` blocks in the stream                              |
+| `tool_errors`    | number            | Count of `tool_result` blocks with `is_error: true`, or classifier fallback |
+| `stage_success`  | boolean           | `true` when the agent process exited with code 0                      |
+| `started_at`     | ISO-8601 string   | Timestamp captured at the start of the stage                          |
+| `profile`        | string (optional) | Active routing profile (deterministic pick for multi-profile configs) |
+| `issue_num`      | number (optional) | Issue number the stage was processing                                 |
+
+### Backward compatibility
+
+Sessions that completed before this change contain no `stages.jsonl`. Readers
+(`alpha-loop history <session> --telemetry`, `alpha-loop report routing`) fall
+back to the manifest's embedded `stages` array if present, otherwise print a
+`No per-stage telemetry recorded for this session.` message and continue.
+
+## CLI surface
+
+### `alpha-loop history <session> --telemetry`
+
+Prints a per-stage table for one session:
+
+```
+stage          model                endpoint       tok_in  tok_out  cost_usd  wall_s  tool_err  ok
+plan           claude-sonnet-4-6    anthropic-prod  4,120     890    $0.0147   12.34         0  ok
+implement      qwen3-coder-30b-a3b  lmstudio       18,432   3,101    $0.0000   88.12         2  ok
+review         claude-opus-4-6      anthropic-prod 12,010   1,220    $0.2738   21.40         0  ok
+```
+
+### `alpha-loop report routing [--profile <name>] [--since <dur>] [--json]`
+
+Aggregates across every session in `.alpha-loop/traces/` and joins with
+`.alpha-loop/learnings/session-*.json` manifests to compute shipped-issue
+counts.
+
+Outputs per (stage, model) cells:
+
+- `pipeline_success_rate` — fraction of sessions that shipped a successful
+  issue while this cell was active
+- `cost_per_issue_shipped` — `sum(cost_usd) / shipped_issues`, `null` when no
+  issues shipped
+- `median_wall_time_s` — median wall-clock time per invocation
+- `tool_error_rate` — `sum(tool_errors) / sum(tool_calls)`
+- `delta_*_vs_baseline` — delta vs the highest-cost cell for the same stage
+  (the implicit "all-frontier" reference)
+
+The command accepts zero arguments (all-time, all profiles). A duration may be
+supplied as `30d`, `12h`, `45m`, or `90s`.
+
+### JSON export shape
+
+`alpha-loop report routing --json` emits:
+
+```json
+{
+  "cells": [
+    {
+      "stage": "implement",
+      "model": "claude-sonnet-4-6",
+      "endpoint": "anthropic-prod",
+      "endpoint_type": "anthropic",
+      "profile": "hybrid-v1",
+      "runs": 42,
+      "tokens_in": 524288,
+      "tokens_out": 90123,
+      "total_cost_usd": 2.4510,
+      "pipeline_success_rate": 0.905,
+      "cost_per_issue_shipped": 0.0580,
+      "median_wall_time_s": 41.0,
+      "tool_error_rate": 0.012,
+      "delta_cost_per_issue_shipped_vs_baseline": -0.0120,
+      "delta_median_wall_time_s_vs_baseline": 2.3,
+      "delta_tool_error_rate_vs_baseline": 0.004,
+      "delta_pipeline_success_rate_vs_baseline": -0.02
+    }
+  ],
+  "total_sessions": 6,
+  "total_stages": 128,
+  "total_issues_shipped": 34,
+  "total_cost_usd": 6.7812,
+  "filters": {
+    "profile": "hybrid-v1",
+    "since_ms": 1714000000000,
+    "baseline": "all-frontier"
+  }
+}
+```
+
+The eval system (`alpha-loop eval`) can ingest this JSON directly — every
+field is stable and typed in `src/lib/telemetry.ts` under `RoutingAggregation`.
+
+## Relationship to `costs.json`
+
+`costs.json` in the same trace directory is the existing run-level summary and
+is unchanged. `stages.jsonl` is additive and higher-granularity — one line per
+agent invocation, vs one entry per step aggregated across invocations.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,7 +50,24 @@ program
   .description('View session history')
   .option('--qa', 'Show QA checklist for session')
   .option('--clean', 'Remove old session data')
+  .option('--telemetry', 'Show per-stage telemetry for a session')
   .action(historyCommand);
+
+// Report subcommands — routing A/B analysis, cost-per-issue rollups.
+const reportCmd = program
+  .command('report')
+  .description('Generate cross-session reports (routing, cost, telemetry)');
+
+reportCmd
+  .command('routing')
+  .description('Aggregate per-stage telemetry and cost-per-issue across sessions')
+  .option('--profile <name>', 'Filter to entries with this routing profile')
+  .option('--since <duration>', 'Limit window (e.g. 30d, 12h, 45m)')
+  .option('--json', 'Emit machine-readable JSON instead of a table')
+  .action(async (options) => {
+    const { reportRoutingCommand } = await import('./commands/report.js');
+    reportRoutingCommand(options);
+  });
 
 program
   .command('scan')

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { log } from '../lib/logger.js';
+import { readStageTelemetry } from '../lib/telemetry.js';
+import type { StageTelemetry } from '../lib/telemetry.js';
 import type { PipelineResult } from '../lib/pipeline.js';
 import type { EscalationEvent } from '../lib/escalation.js';
 
@@ -9,6 +11,7 @@ type SessionManifest = {
   branch: string;
   completed: string;
   results: PipelineResult[];
+  stages?: StageTelemetry[];
 };
 
 function formatDuration(seconds: number | undefined): string {
@@ -308,6 +311,73 @@ export function historyQa(sessionsDir: string, sessionName: string): void {
   console.log(fs.readFileSync(qaPath, 'utf-8'));
 }
 
+/**
+ * Load per-stage telemetry for a session. Looks first in the traces dir
+ * (stages.jsonl written during the run), then falls back to the session
+ * manifest's embedded `stages` field for sessions pushed by teammates.
+ */
+function loadStageTelemetry(sessionName: string, projectDir?: string): StageTelemetry[] {
+  const root = projectDir ?? process.cwd();
+  // Trace dirs mirror traces.ts: session/<ts> -> session-<ts>.
+  const traceName = sessionName.replace(/\//g, '-');
+  const traceDir = path.join(root, '.alpha-loop', 'traces', traceName);
+  if (fs.existsSync(path.join(traceDir, 'stages.jsonl'))) {
+    return readStageTelemetry(traceDir);
+  }
+  const manifests = loadManifests(projectDir);
+  const manifest = manifests.get(sessionName);
+  return manifest?.stages ?? [];
+}
+
+function fmtNumber(n: number, digits = 0): string {
+  return n.toLocaleString('en-US', {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+export function historyTelemetry(sessionName: string, projectDir?: string): void {
+  const entries = loadStageTelemetry(sessionName, projectDir);
+  if (entries.length === 0) {
+    console.log(`No per-stage telemetry recorded for this session.`);
+    return;
+  }
+
+  console.log(`Stage telemetry for ${sessionName}:`);
+  console.log('');
+
+  const header = ['stage', 'model', 'endpoint', 'tok_in', 'tok_out', 'cost_usd', 'wall_s', 'tool_err', 'ok'];
+  console.log(header.join('\t'));
+
+  let totalCost = 0;
+  let totalTokensIn = 0;
+  let totalTokensOut = 0;
+  let totalWall = 0;
+  let totalErrs = 0;
+
+  for (const e of entries) {
+    totalCost += e.cost_usd;
+    totalTokensIn += e.tokens_in;
+    totalTokensOut += e.tokens_out;
+    totalWall += e.wall_time_s;
+    totalErrs += e.tool_errors;
+    console.log([
+      e.stage,
+      e.model,
+      e.endpoint,
+      fmtNumber(e.tokens_in),
+      fmtNumber(e.tokens_out),
+      `$${e.cost_usd.toFixed(4)}`,
+      e.wall_time_s.toFixed(2),
+      String(e.tool_errors),
+      e.stage_success ? 'ok' : 'fail',
+    ].join('\t'));
+  }
+
+  console.log('');
+  console.log(`Totals: ${entries.length} stage(s), ${fmtNumber(totalTokensIn)} in / ${fmtNumber(totalTokensOut)} out, $${totalCost.toFixed(4)}, ${totalWall.toFixed(1)}s wall, ${totalErrs} tool error(s)`);
+}
+
 export function historyClean(sessionsDir: string): void {
   const sessions = findSessionDirs(sessionsDir);
 
@@ -344,7 +414,7 @@ export function historyClean(sessionsDir: string): void {
 
 export function historyCommand(
   session: string | undefined,
-  options: { qa?: boolean; clean?: boolean },
+  options: { qa?: boolean; clean?: boolean; telemetry?: boolean },
 ): void {
   const sessionsDir = path.join(process.cwd(), '.alpha-loop', 'sessions');
 
@@ -354,7 +424,9 @@ export function historyCommand(
   }
 
   if (session) {
-    if (options.qa) {
+    if (options.telemetry) {
+      historyTelemetry(session);
+    } else if (options.qa) {
       historyQa(sessionsDir, session);
     } else {
       historyDetail(sessionsDir, session);

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -1,0 +1,43 @@
+/**
+ * `alpha-loop report routing` — aggregate per-stage telemetry across sessions.
+ *
+ * Scans `.alpha-loop/traces/<session>/stages.jsonl` and the session manifests
+ * in `.alpha-loop/learnings/` to compute per (stage, model) cell metrics
+ * (pipeline_success_rate, cost_per_issue_shipped, median_wall_time_s,
+ * tool_error_rate) plus delta columns vs the highest-cost (frontier) baseline
+ * per stage.
+ */
+import {
+  aggregateRouting,
+  formatRoutingReport,
+  parseDuration,
+  readAllStageTelemetry,
+  readSessionManifests,
+} from '../lib/telemetry.js';
+
+export type ReportRoutingOptions = {
+  profile?: string;
+  since?: string;
+  json?: boolean;
+  projectDir?: string;
+};
+
+export function reportRoutingCommand(options: ReportRoutingOptions = {}): void {
+  const projectDir = options.projectDir ?? process.cwd();
+  const items = readAllStageTelemetry(projectDir);
+  const manifests = readSessionManifests(projectDir);
+
+  const sinceMs = options.since
+    ? (() => {
+        const dur = parseDuration(options.since);
+        return dur ? Date.now() - dur : undefined;
+      })()
+    : undefined;
+
+  const agg = aggregateRouting(items, manifests, {
+    profile: options.profile,
+    sinceMs,
+  });
+
+  console.log(formatRoutingReport(agg, { json: options.json }));
+}

--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -4,6 +4,7 @@
 import { spawn } from 'node:child_process';
 import { createWriteStream, type WriteStream } from 'node:fs';
 import { log } from './logger.js';
+import { classifyToolErrors } from './escalation.js';
 import type { RoutingEndpoint } from './config.js';
 
 /**
@@ -25,6 +26,10 @@ export type AgentResult = {
   outputTokens?: number;
   /** Model used for the invocation. */
   model?: string;
+  /** Number of tool_use blocks emitted during the run. */
+  toolCalls?: number;
+  /** Number of tool_result blocks with is_error === true. */
+  toolErrors?: number;
 };
 
 /**
@@ -284,6 +289,9 @@ export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
     let parsedCostUsd: number | undefined;
     let parsedInputTokens: number | undefined;
     let parsedOutputTokens: number | undefined;
+    // Tool-use telemetry (per-stage metrics aggregation).
+    let toolUseCount = 0;
+    let toolErrorCount = 0;
 
     // Pipe prompt via stdin (like: echo "$prompt" | claude -p)
     child.stdin.write(options.prompt);
@@ -344,6 +352,18 @@ export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
               if (typeof usage.input_tokens === 'number') parsedInputTokens = usage.input_tokens;
               if (typeof usage.output_tokens === 'number') parsedOutputTokens = usage.output_tokens;
             }
+          } else if (obj.type === 'assistant') {
+            const msg = obj.message as Record<string, unknown> | undefined;
+            const content = (msg?.content ?? []) as Array<Record<string, unknown>>;
+            for (const block of content) {
+              if (block.type === 'tool_use') toolUseCount++;
+            }
+          } else if (obj.type === 'user') {
+            const msg = obj.message as Record<string, unknown> | undefined;
+            const content = (msg?.content ?? []) as Array<Record<string, unknown>>;
+            for (const block of content) {
+              if (block.type === 'tool_result' && block.is_error === true) toolErrorCount++;
+            }
           }
         } catch { /* not valid JSON, ignore */ }
 
@@ -382,6 +402,11 @@ export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
       resolved = true;
       clearTimeout(timer);
       const duration = Date.now() - startTime;
+      // Fall back to output-string classification when we didn't see structured
+      // tool_result error blocks (e.g. non-stream-json agents like codex).
+      const toolErrorsFinal = toolErrorCount > 0
+        ? toolErrorCount
+        : classifyToolErrors(output).length;
       const result: AgentResult = {
         exitCode,
         output,
@@ -390,6 +415,8 @@ export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
         costUsd: parsedCostUsd,
         inputTokens: parsedInputTokens,
         outputTokens: parsedOutputTokens,
+        toolCalls: toolUseCount,
+        toolErrors: toolErrorsFinal,
       };
       if (logStream) {
         logStream.end(() => {

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -52,10 +52,11 @@ import {
   runDir,
 } from './traces.js';
 import type { StepCost, PipelineResultForScores } from './traces.js';
-import { estimateCost, getFallbackPolicy, resolveRoutingStage } from './config.js';
-import type { Config, RoutingStageName } from './config.js';
+import { estimateCost, getFallbackPolicy, resolveRoutingStage, selectRoutingProfile } from './config.js';
+import type { Config, RoutingStageName, RoutingEndpointType } from './config.js';
 import type { AgentResult } from './agent.js';
 import type { SessionContext } from './session.js';
+import { buildStageTelemetry, writeStageTelemetry } from './telemetry.js';
 
 /** Max diff size to include in learning analysis. */
 const MAX_DIFF_CHARS = 10_000;
@@ -331,7 +332,37 @@ type StageContext = {
   session: SessionContext;
   tracker: EscalationTracker;
   events: EscalationEvent[];
+  /** Populated by spawnStageAgent so callers can record telemetry with endpoint info. */
+  endpointName?: string;
+  endpointType?: RoutingEndpointType;
+  profile?: string;
 };
+
+/**
+ * Build a StageTelemetry entry from the agent result and append it to the
+ * run's stages.jsonl file. Called alongside each stepCosts.push site so that
+ * every stage invocation — not just the top-level session — emits telemetry.
+ */
+function recordStageTelemetry(
+  session: SessionContext,
+  issueNum: number,
+  stage: string,
+  agentResult: AgentResult,
+  config: Config,
+  ctx?: Pick<StageContext, 'endpointName' | 'endpointType' | 'profile'>,
+): void {
+  try {
+    const entry = buildStageTelemetry(agentResult, stage, config, {
+      endpoint: ctx?.endpointName,
+      endpointType: ctx?.endpointType,
+      profile: ctx?.profile,
+      issueNum,
+    });
+    writeStageTelemetry(runDir(session.name), entry);
+  } catch {
+    /* telemetry is best-effort */
+  }
+}
 
 /**
  * Invoke an agent with retry-with-escalation and the rolling-rate guardrail.
@@ -355,6 +386,12 @@ async function spawnStageAgent(
   const primaryModel = primary?.model ?? options.model;
   const primaryEndpoint = primary?.endpoint;
   const primaryEnv = primaryEndpoint ? buildEndpointEnv(primaryEndpoint, primaryModel) : undefined;
+
+  // Expose endpoint info back to the caller so it can tag telemetry.
+  const primaryEndpointName = config.routing?.stages?.[ctx.stage]?.endpoint;
+  ctx.endpointName = primaryEndpointName ?? 'default';
+  ctx.endpointType = primaryEndpoint?.type;
+  ctx.profile = selectRoutingProfile(config, ctx.issueNum);
 
   const hasEscalateTarget = policy?.escalate_to !== undefined;
   const escalateTo = policy?.escalate_to;
@@ -389,6 +426,8 @@ async function spawnStageAgent(
       issue: ctx.issueNum,
       ts: nowIso(),
     });
+    ctx.endpointName = escalateTo.endpoint;
+    ctx.endpointType = escalateEndpoint?.type;
     const result = await spawnAgent({
       ...options,
       model: escalateTo.model,
@@ -432,6 +471,8 @@ async function spawnStageAgent(
       issue: ctx.issueNum,
       ts: nowIso(),
     });
+    ctx.endpointName = escalateTo.endpoint;
+    ctx.endpointType = escalateEndpoint?.type;
     finalResult = await spawnAgent({
       ...options,
       model: escalateTo.model,
@@ -598,6 +639,7 @@ Rules:
       // Trace the plan prompt
       tracePrompt(session.name, issueNum, 'plan', planPrompt);
 
+      const planCtx = stageCtx('plan');
       const planResult = await spawnStageAgent({
         agent: config.agent,
         model: config.model,
@@ -606,11 +648,12 @@ Rules:
         logFile: join(session.logsDir, `issue-${issueNum}-plan.log`),
         verbose: config.verbose,
         timeout: config.agentTimeout * 1000,
-      }, config, stageCtx('plan'));
+      }, config, planCtx);
 
       // Trace the plan output and costs
       traceOutput(session.name, issueNum, 'plan', planResult.output);
       stepCosts.push(buildStepCost('plan', issueNum, planResult, config));
+      recordStageTelemetry(session, issueNum, 'plan', planResult, config, planCtx);
 
       // Detect transient errors (usage limits) during planning
       if (planResult.exitCode !== 0 && isTransientError(planResult.output)) {
@@ -676,6 +719,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     // Trace the implement prompt
     tracePrompt(session.name, issueNum, 'implement', implementPrompt);
 
+    const implCtx = stageCtx('build');
     const implResult = await spawnStageAgent({
       agent: config.agent,
       model: config.model,
@@ -685,11 +729,12 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
       logFile: join(session.logsDir, `issue-${issueNum}-implement.log`),
       verbose: config.verbose,
       timeout: config.agentTimeout * 1000,
-    }, config, stageCtx('build'));
+    }, config, implCtx);
 
     // Trace the implement output and costs
     traceOutput(session.name, issueNum, 'implement', implResult.output);
     stepCosts.push(buildStepCost('implement', issueNum, implResult, config));
+    recordStageTelemetry(session, issueNum, 'implement', implResult, config, implCtx);
 
     if (implResult.exitCode !== 0) {
       // Auto-commit any uncommitted work before deciding on cleanup
@@ -767,6 +812,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
         // Trace fix prompt
         tracePrompt(session.name, issueNum, `fix-${attempt}`, fixPrompt);
 
+        const fixCtx = stageCtx('test_write');
         const fixResult = await spawnStageAgent({
           agent: config.agent,
           model: config.model,
@@ -776,11 +822,12 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           logFile: join(session.logsDir, `issue-${issueNum}-fix-${attempt}.log`),
           verbose: config.verbose,
           timeout: config.agentTimeout * 1000,
-        }, config, stageCtx('test_write'));
+        }, config, fixCtx);
 
         // Trace fix output and costs
         traceOutput(session.name, issueNum, `fix-${attempt}`, fixResult.output);
         stepCosts.push(buildStepCost('test_fix', issueNum, fixResult, config));
+        recordStageTelemetry(session, issueNum, 'test_fix', fixResult, config, fixCtx);
         stepsCompleted.push(`fix-${attempt}`);
 
         // Auto-commit fixes
@@ -831,6 +878,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
         // Trace review prompt
         tracePrompt(session.name, issueNum, `review${attempt > 1 ? `-${attempt}` : ''}`, reviewPrompt);
 
+        const reviewCtx = stageCtx('review');
         const reviewResult = await spawnStageAgent({
           agent: config.agent,
           model: config.reviewModel,
@@ -839,11 +887,12 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           logFile: join(session.logsDir, `issue-${issueNum}-review${attempt > 1 ? `-${attempt}` : ''}.log`),
           verbose: config.verbose,
           timeout: config.agentTimeout * 1000,
-        }, config, stageCtx('review'));
+        }, config, reviewCtx);
 
         // Trace review output and costs
         traceOutput(session.name, issueNum, `review${attempt > 1 ? `-${attempt}` : ''}`, reviewResult.output);
         stepCosts.push(buildStepCost('review', issueNum, reviewResult, config));
+        recordStageTelemetry(session, issueNum, 'review', reviewResult, config, reviewCtx);
 
         reviewOutput = reviewResult.output;
       } catch {
@@ -873,6 +922,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
         // Trace review-fix prompt
         tracePrompt(session.name, issueNum, `review-fix-${attempt}`, fixPrompt);
 
+        const reviewFixCtx = stageCtx('build');
         const reviewFixResult = await spawnStageAgent({
           agent: config.agent,
           model: config.model,
@@ -882,11 +932,12 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           logFile: join(session.logsDir, `issue-${issueNum}-review-fix-${attempt}.log`),
           verbose: config.verbose,
           timeout: config.agentTimeout * 1000,
-        }, config, stageCtx('build'));
+        }, config, reviewFixCtx);
 
         // Trace review-fix output and costs
         traceOutput(session.name, issueNum, `review-fix-${attempt}`, reviewFixResult.output);
         stepCosts.push(buildStepCost('review', issueNum, reviewFixResult, config));
+        recordStageTelemetry(session, issueNum, 'review_fix', reviewFixResult, config, reviewFixCtx);
 
         // Auto-commit if agent didn't
         const fixStatus = exec('git status --porcelain', { cwd: worktreePath });
@@ -982,6 +1033,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           // Trace verify-fix prompt
           tracePrompt(session.name, issueNum, `verify-fix-${attempt}`, fixPrompt);
 
+          const verifyFixCtx = stageCtx('test_exec');
           const verifyFixResult = await spawnStageAgent({
             agent: config.agent,
             model: config.model,
@@ -991,11 +1043,12 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
             logFile: join(session.logsDir, `issue-${issueNum}-verify-fix-${attempt}.log`),
             verbose: config.verbose,
             timeout: config.agentTimeout * 1000,
-          }, config, stageCtx('test_exec'));
+          }, config, verifyFixCtx);
 
           // Trace verify-fix output and costs
           traceOutput(session.name, issueNum, `verify-fix-${attempt}`, verifyFixResult.output);
           stepCosts.push(buildStepCost('verify', issueNum, verifyFixResult, config));
+          recordStageTelemetry(session, issueNum, 'verify_fix', verifyFixResult, config, verifyFixCtx);
 
           // Auto-commit if agent didn't
           const fixStatus = exec('git status --porcelain', { cwd: worktreePath });
@@ -1090,6 +1143,9 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
       traceOutput(session.name, issueNum, 'assumptions', assumptionsResult.output);
       stepCosts.push(buildStepCost('assumptions', issueNum, assumptionsResult, config));
+      recordStageTelemetry(session, issueNum, 'assumptions', assumptionsResult, config, {
+        profile: selectRoutingProfile(config, issueNum),
+      });
 
       if (assumptionsResult.exitCode === 0 && assumptionsResult.output.trim()) {
         commentIssue(config.repo, issueNum,
@@ -1383,6 +1439,9 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
       traceOutput(session.name, issues[0].number, 'batch-plan', planResult.output);
       stepCosts.push(buildStepCost('plan', issues[0].number, planResult, config));
+      recordStageTelemetry(session, issues[0].number, 'batch-plan', planResult, config, {
+        profile: selectRoutingProfile(config, issues[0].number),
+      });
 
       if (planResult.exitCode !== 0 && isTransientError(planResult.output)) {
         log.warn('Agent hit a transient error during batch planning — re-queuing all issues');
@@ -1443,6 +1502,9 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
     traceOutput(session.name, issues[0].number, 'batch-implement', implResult.output);
     stepCosts.push(buildStepCost('implement', issues[0].number, implResult, config));
+    recordStageTelemetry(session, issues[0].number, 'batch-implement', implResult, config, {
+      profile: selectRoutingProfile(config, issues[0].number),
+    });
 
     if (implResult.exitCode !== 0) {
       // Auto-commit any uncommitted work before deciding on cleanup
@@ -1533,6 +1595,9 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
         traceOutput(session.name, issues[0].number, `batch-fix-${attempt}`, fixResult.output);
         stepCosts.push(buildStepCost('test_fix', issues[0].number, fixResult, config));
+        recordStageTelemetry(session, issues[0].number, 'batch-test_fix', fixResult, config, {
+          profile: selectRoutingProfile(config, issues[0].number),
+        });
 
         const fixStatus = exec('git status --porcelain', { cwd: worktreePath });
         if (fixStatus.stdout.trim()) {
@@ -1580,6 +1645,9 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
         traceOutput(session.name, issues[0].number, `batch-review${attempt > 1 ? `-${attempt}` : ''}`, reviewResult.output);
         stepCosts.push(buildStepCost('review', issues[0].number, reviewResult, config));
+        recordStageTelemetry(session, issues[0].number, 'batch-review', reviewResult, config, {
+          profile: selectRoutingProfile(config, issues[0].number),
+        });
         reviewOutput = reviewResult.output;
       } catch {
         log.warn('Batch review failed, continuing without review');
@@ -1617,6 +1685,9 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
         traceOutput(session.name, issues[0].number, `batch-review-fix-${attempt}`, reviewFixResult.output);
         stepCosts.push(buildStepCost('review', issues[0].number, reviewFixResult, config));
+        recordStageTelemetry(session, issues[0].number, 'batch-review_fix', reviewFixResult, config, {
+          profile: selectRoutingProfile(config, issues[0].number),
+        });
 
         const fixStatus = exec('git status --porcelain', { cwd: worktreePath });
         if (fixStatus.stdout.trim()) {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -7,6 +7,8 @@ import { log } from './logger.js';
 import { exec, formatTimestamp } from './shell.js';
 import { ghExec } from './rate-limit.js';
 import { createPR, updateProjectStatus } from './github.js';
+import { readStageTelemetry } from './telemetry.js';
+import { runDir } from './traces.js';
 import type { Config } from './config.js';
 import type { PipelineResult, GateResult } from './pipeline.js';
 
@@ -223,7 +225,14 @@ export async function finalizeSession(
   mkdirSync(learningsDir, { recursive: true });
 
   const manifestName = `session-${session.name.replace(/\//g, '-')}.json`;
-  const manifest = {
+  const stageEntries = (() => {
+    try {
+      return readStageTelemetry(runDir(session.name, projectDir));
+    } catch {
+      return [];
+    }
+  })();
+  const manifest: Record<string, unknown> = {
     name: session.name,
     branch: session.branch,
     completed: new Date().toISOString(),
@@ -238,6 +247,9 @@ export async function finalizeSession(
       filesChanged: r.filesChanged,
     })),
   };
+  if (stageEntries.length > 0) {
+    manifest.stages = stageEntries;
+  }
   writeFileSync(join(learningsDir, manifestName), JSON.stringify(manifest, null, 2) + '\n');
   log.info(`Session manifest saved: ${manifestName}`);
 

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,0 +1,482 @@
+/**
+ * Per-Stage Telemetry — granular metrics per pipeline stage invocation.
+ *
+ * Session-level cost logs hide which stage burned the tokens. For A/B routing
+ * analysis we need apples-to-apples metrics per (stage, model) cell across many
+ * issues. This module defines the StageTelemetry record, persistence helpers
+ * (stages.jsonl in the trace dir), and aggregation math for the
+ * `alpha-loop report routing` command.
+ */
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { estimateCost } from './config.js';
+import type { Config, RoutingEndpointType } from './config.js';
+import type { AgentResult } from './agent.js';
+
+/** One per-stage telemetry record. Written once per agent invocation. */
+export type StageTelemetry = {
+  /** Pipeline stage name (plan, implement, test_fix, review, verify, assumptions, batch-*). */
+  stage: string;
+  /** Model used for the invocation. */
+  model: string;
+  /** Named routing endpoint the stage hit (or 'default' if routing wasn't used). */
+  endpoint: string;
+  /** Protocol shape of the endpoint — used to identify local vs frontier. */
+  endpoint_type?: RoutingEndpointType;
+  /** Input tokens consumed. */
+  tokens_in: number;
+  /** Output tokens generated. */
+  tokens_out: number;
+  /** Cost in USD. Local-endpoint invocations record 0. */
+  cost_usd: number;
+  /** Wall-clock time in seconds (float). */
+  wall_time_s: number;
+  /** Count of tool_use blocks emitted by the agent. */
+  tool_calls: number;
+  /** Count of tool_result blocks flagged is_error. */
+  tool_errors: number;
+  /** Whether the stage invocation succeeded (exit code 0). */
+  stage_success: boolean;
+  /** ISO timestamp at start of invocation. */
+  started_at: string;
+  /** Routing profile that was active for this invocation, if any. */
+  profile?: string;
+  /** Issue number this stage was processing. */
+  issue_num?: number;
+};
+
+/** A session manifest reference loaded by the reporter. */
+export type SessionManifestLite = {
+  name: string;
+  completed?: string;
+  results?: Array<{
+    issueNum: number;
+    status: 'success' | 'failure';
+    filesChanged?: number;
+    prUrl?: string;
+  }>;
+  stages?: StageTelemetry[];
+};
+
+/** Aggregated per-cell metrics, grouped by (stage, model). */
+export type RoutingCell = {
+  stage: string;
+  model: string;
+  endpoint?: string;
+  endpoint_type?: RoutingEndpointType;
+  profile?: string;
+  runs: number;
+  tokens_in: number;
+  tokens_out: number;
+  total_cost_usd: number;
+  pipeline_success_rate: number;
+  cost_per_issue_shipped: number | null;
+  median_wall_time_s: number;
+  tool_error_rate: number;
+  delta_cost_per_issue_shipped_vs_baseline?: number | null;
+  delta_median_wall_time_s_vs_baseline?: number | null;
+  delta_tool_error_rate_vs_baseline?: number | null;
+  delta_pipeline_success_rate_vs_baseline?: number | null;
+};
+
+/** Aggregation result, grouped by (stage, model), plus global totals. */
+export type RoutingAggregation = {
+  cells: RoutingCell[];
+  total_sessions: number;
+  total_stages: number;
+  total_issues_shipped: number;
+  total_cost_usd: number;
+  filters: {
+    profile?: string;
+    since_ms?: number;
+    baseline: string;
+  };
+};
+
+/**
+ * Build a StageTelemetry record from an AgentResult and stage context.
+ *
+ * Uses the agent's reported cost/tokens when present. Falls back to the
+ * pricing table (0 for local endpoints since pricing entries are 0/0).
+ */
+export function buildStageTelemetry(
+  agentResult: AgentResult,
+  stage: string,
+  config: Config,
+  ctx: {
+    endpoint?: string;
+    endpointType?: RoutingEndpointType;
+    profile?: string;
+    issueNum?: number;
+    startedAt?: string;
+  },
+): StageTelemetry {
+  const model = agentResult.model || config.model;
+  const endpointName = ctx.endpoint ?? 'default';
+  const isLocal = ctx.endpointType === 'anthropic_compat' || ctx.endpointType === 'openai_compat';
+
+  let tokensIn: number;
+  let tokensOut: number;
+  let costUsd: number;
+
+  if (
+    agentResult.costUsd != null &&
+    agentResult.inputTokens != null &&
+    agentResult.outputTokens != null
+  ) {
+    tokensIn = agentResult.inputTokens;
+    tokensOut = agentResult.outputTokens;
+    costUsd = isLocal ? 0 : agentResult.costUsd;
+  } else {
+    // Estimate tokens from output length (chars / 4 ≈ tokens).
+    tokensOut = Math.round(agentResult.output.length / 4);
+    tokensIn = Math.round(tokensOut * 1.3);
+    costUsd = isLocal ? 0 : estimateCost(model, tokensIn, tokensOut, config.pricing);
+  }
+
+  return {
+    stage,
+    model,
+    endpoint: endpointName,
+    endpoint_type: ctx.endpointType,
+    tokens_in: tokensIn,
+    tokens_out: tokensOut,
+    cost_usd: Math.round(costUsd * 1_000_000) / 1_000_000,
+    wall_time_s: Math.round((agentResult.duration / 1000) * 1000) / 1000,
+    tool_calls: agentResult.toolCalls ?? 0,
+    tool_errors: agentResult.toolErrors ?? 0,
+    stage_success: agentResult.exitCode === 0,
+    started_at: ctx.startedAt ?? new Date(Date.now() - agentResult.duration).toISOString(),
+    profile: ctx.profile,
+    issue_num: ctx.issueNum,
+  };
+}
+
+function stagesJsonlPath(runDirPath: string): string {
+  return join(runDirPath, 'stages.jsonl');
+}
+
+/**
+ * Append a stage telemetry entry to the run's stages.jsonl file.
+ * Creates the file and parent directory when needed.
+ */
+export function writeStageTelemetry(runDirPath: string, entry: StageTelemetry): void {
+  mkdirSync(runDirPath, { recursive: true });
+  const line = JSON.stringify(entry) + '\n';
+  appendFileSync(stagesJsonlPath(runDirPath), line);
+}
+
+/**
+ * Read all stage telemetry entries for a single run.
+ * Returns an empty array if the file doesn't exist or has parse errors.
+ */
+export function readStageTelemetry(runDirPath: string): StageTelemetry[] {
+  const filePath = stagesJsonlPath(runDirPath);
+  if (!existsSync(filePath)) return [];
+  const raw = readFileSync(filePath, 'utf-8');
+  const entries: StageTelemetry[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      entries.push(JSON.parse(trimmed) as StageTelemetry);
+    } catch {
+      /* skip invalid line */
+    }
+  }
+  return entries;
+}
+
+/**
+ * Scan `.alpha-loop/traces/` under the given project dir and return all
+ * stage telemetry entries across all runs, each tagged with its session name.
+ */
+export function readAllStageTelemetry(
+  projectDir?: string,
+): Array<{ session: string; entries: StageTelemetry[] }> {
+  const root = join(projectDir ?? process.cwd(), '.alpha-loop', 'traces');
+  if (!existsSync(root)) return [];
+  const out: Array<{ session: string; entries: StageTelemetry[] }> = [];
+  for (const name of readdirSync(root)) {
+    const dir = join(root, name);
+    const entries = readStageTelemetry(dir);
+    if (entries.length > 0) {
+      out.push({ session: name, entries });
+    }
+  }
+  return out;
+}
+
+/**
+ * Load session manifests written to `.alpha-loop/learnings/` by finalizeSession.
+ * Used by the reporter to join cost data with shipped-issue counts.
+ */
+export function readSessionManifests(projectDir?: string): SessionManifestLite[] {
+  const dir = join(projectDir ?? process.cwd(), '.alpha-loop', 'learnings');
+  if (!existsSync(dir)) return [];
+  const out: SessionManifestLite[] = [];
+  for (const file of readdirSync(dir)) {
+    if (!file.startsWith('session-') || !file.endsWith('.json')) continue;
+    try {
+      const raw = readFileSync(join(dir, file), 'utf-8');
+      const parsed = JSON.parse(raw) as SessionManifestLite;
+      if (parsed.name) out.push(parsed);
+    } catch {
+      /* skip invalid */
+    }
+  }
+  return out;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Aggregate stage telemetry across sessions into per (stage, model) cells.
+ *
+ * - `pipeline_success_rate`: fraction of parent sessions that shipped a
+ *   successful issue while this (stage, model) cell was active.
+ * - `cost_per_issue_shipped`: total cost across this cell divided by the
+ *   number of shipped (status=success, filesChanged>0) issues in the sessions
+ *   where this cell ran.
+ * - `median_wall_time_s`: median wall_time_s across invocations.
+ * - `tool_error_rate`: sum(tool_errors) / sum(tool_calls || runs).
+ * - Delta columns compare each cell against the cell at the same `stage` with
+ *   `model` matching the baseline. When `baseline` is 'all-frontier' (default)
+ *   we pick the highest-cost cell per stage as the baseline (frontier).
+ */
+export function aggregateRouting(
+  items: Array<{ session: string; entries: StageTelemetry[] }>,
+  manifests: SessionManifestLite[],
+  opts: { profile?: string; sinceMs?: number; baseline?: string } = {},
+): RoutingAggregation {
+  const baseline = opts.baseline ?? 'all-frontier';
+  const manifestByName = new Map<string, SessionManifestLite>();
+  for (const m of manifests) manifestByName.set(m.name, m);
+
+  type Bucket = {
+    stage: string;
+    model: string;
+    endpoint?: string;
+    endpoint_type?: RoutingEndpointType;
+    profile?: string;
+    runs: number;
+    tokens_in: number;
+    tokens_out: number;
+    total_cost_usd: number;
+    wall_times: number[];
+    tool_calls: number;
+    tool_errors: number;
+    sessions: Set<string>;
+  };
+
+  const buckets = new Map<string, Bucket>();
+  const sessionShipped = new Map<string, number>();
+  const sessionsSeen = new Set<string>();
+  let totalStages = 0;
+
+  for (const { session, entries } of items) {
+    const sessionName = deriveSessionName(session);
+    const manifest = manifestByName.get(sessionName) ?? manifestByName.get(session);
+    // Count shipped issues per session (success + filesChanged > 0).
+    if (manifest && !sessionShipped.has(session)) {
+      const shipped = (manifest.results ?? []).filter(
+        (r) => r.status === 'success' && (r.filesChanged ?? 0) > 0,
+      ).length;
+      sessionShipped.set(session, shipped);
+    }
+
+    for (const e of entries) {
+      if (opts.profile && e.profile !== opts.profile) continue;
+      if (opts.sinceMs && new Date(e.started_at).getTime() < opts.sinceMs) continue;
+
+      sessionsSeen.add(session);
+      totalStages++;
+
+      const key = `${e.stage}::${e.model}`;
+      let bucket = buckets.get(key);
+      if (!bucket) {
+        bucket = {
+          stage: e.stage,
+          model: e.model,
+          endpoint: e.endpoint,
+          endpoint_type: e.endpoint_type,
+          profile: e.profile,
+          runs: 0,
+          tokens_in: 0,
+          tokens_out: 0,
+          total_cost_usd: 0,
+          wall_times: [],
+          tool_calls: 0,
+          tool_errors: 0,
+          sessions: new Set(),
+        };
+        buckets.set(key, bucket);
+      }
+      bucket.runs++;
+      bucket.tokens_in += e.tokens_in;
+      bucket.tokens_out += e.tokens_out;
+      bucket.total_cost_usd += e.cost_usd;
+      bucket.wall_times.push(e.wall_time_s);
+      bucket.tool_calls += e.tool_calls;
+      bucket.tool_errors += e.tool_errors;
+      bucket.sessions.add(session);
+    }
+  }
+
+  let totalCost = 0;
+  let totalIssuesShipped = 0;
+  for (const s of sessionsSeen) totalIssuesShipped += sessionShipped.get(s) ?? 0;
+
+  const cells: RoutingCell[] = [];
+  for (const b of buckets.values()) {
+    totalCost += b.total_cost_usd;
+
+    // Shipped issues among sessions that ran this (stage, model).
+    let shipped = 0;
+    let successfulSessions = 0;
+    for (const s of b.sessions) {
+      const perSession = sessionShipped.get(s) ?? 0;
+      shipped += perSession;
+      if (perSession > 0) successfulSessions++;
+    }
+    const pipeline_success_rate = b.sessions.size > 0 ? successfulSessions / b.sessions.size : 0;
+    const cost_per_issue_shipped = shipped > 0 ? b.total_cost_usd / shipped : null;
+    const tool_error_rate = b.tool_calls > 0 ? b.tool_errors / b.tool_calls : (b.runs > 0 ? b.tool_errors / b.runs : 0);
+
+    cells.push({
+      stage: b.stage,
+      model: b.model,
+      endpoint: b.endpoint,
+      endpoint_type: b.endpoint_type,
+      profile: b.profile,
+      runs: b.runs,
+      tokens_in: b.tokens_in,
+      tokens_out: b.tokens_out,
+      total_cost_usd: Math.round(b.total_cost_usd * 10000) / 10000,
+      pipeline_success_rate: Math.round(pipeline_success_rate * 1000) / 1000,
+      cost_per_issue_shipped: cost_per_issue_shipped != null ? Math.round(cost_per_issue_shipped * 10000) / 10000 : null,
+      median_wall_time_s: Math.round(median(b.wall_times) * 1000) / 1000,
+      tool_error_rate: Math.round(tool_error_rate * 10000) / 10000,
+    });
+  }
+
+  // Pick per-stage baseline: the cell with the highest total_cost_usd
+  // (treats frontier models as the reference point). Stable for ties: first seen wins.
+  const baselineByStage = new Map<string, RoutingCell>();
+  for (const cell of cells) {
+    const current = baselineByStage.get(cell.stage);
+    if (!current || cell.total_cost_usd > current.total_cost_usd) {
+      baselineByStage.set(cell.stage, cell);
+    }
+  }
+
+  for (const cell of cells) {
+    const b = baselineByStage.get(cell.stage);
+    if (!b || b === cell) {
+      cell.delta_cost_per_issue_shipped_vs_baseline = null;
+      cell.delta_median_wall_time_s_vs_baseline = null;
+      cell.delta_tool_error_rate_vs_baseline = null;
+      cell.delta_pipeline_success_rate_vs_baseline = null;
+      continue;
+    }
+    cell.delta_cost_per_issue_shipped_vs_baseline =
+      cell.cost_per_issue_shipped != null && b.cost_per_issue_shipped != null
+        ? Math.round((cell.cost_per_issue_shipped - b.cost_per_issue_shipped) * 10000) / 10000
+        : null;
+    cell.delta_median_wall_time_s_vs_baseline =
+      Math.round((cell.median_wall_time_s - b.median_wall_time_s) * 1000) / 1000;
+    cell.delta_tool_error_rate_vs_baseline =
+      Math.round((cell.tool_error_rate - b.tool_error_rate) * 10000) / 10000;
+    cell.delta_pipeline_success_rate_vs_baseline =
+      Math.round((cell.pipeline_success_rate - b.pipeline_success_rate) * 1000) / 1000;
+  }
+
+  cells.sort((a, b) => (a.stage.localeCompare(b.stage) || a.model.localeCompare(b.model)));
+
+  return {
+    cells,
+    total_sessions: sessionsSeen.size,
+    total_stages: totalStages,
+    total_issues_shipped: totalIssuesShipped,
+    total_cost_usd: Math.round(totalCost * 10000) / 10000,
+    filters: {
+      profile: opts.profile,
+      since_ms: opts.sinceMs,
+      baseline,
+    },
+  };
+}
+
+/**
+ * Trace directory names stored on disk include a replaced slash (e.g.
+ * `session-20260401-120000`). Session manifests reference the original
+ * `session/20260401-120000` form. This helper mirrors `traces.ts:runDir`.
+ */
+function deriveSessionName(dirName: string): string {
+  if (dirName.startsWith('session-')) {
+    return dirName.replace(/^session-/, 'session/');
+  }
+  return dirName;
+}
+
+/**
+ * Format an aggregation as a human-readable table or JSON string.
+ */
+export function formatRoutingReport(agg: RoutingAggregation, opts: { json?: boolean } = {}): string {
+  if (opts.json) {
+    return JSON.stringify(agg, null, 2);
+  }
+
+  if (agg.cells.length === 0) {
+    return 'No per-stage telemetry recorded yet. Run alpha-loop with `routing:` configured to populate stages.jsonl.';
+  }
+
+  const lines: string[] = [];
+  lines.push(`Routing report — ${agg.total_sessions} session(s), ${agg.total_stages} stage invocation(s), ${agg.total_issues_shipped} shipped`);
+  if (agg.filters.profile) lines.push(`  Profile: ${agg.filters.profile}`);
+  if (agg.filters.since_ms) lines.push(`  Since: ${new Date(agg.filters.since_ms).toISOString()}`);
+  lines.push(`  Baseline: ${agg.filters.baseline} (highest-cost cell per stage)`);
+  lines.push('');
+
+  const header = ['stage', 'model', 'runs', 'tok_in', 'tok_out', 'cost_usd', 'cost/issue', 'wall_s', 'err_rate', 'Δcost/issue'];
+  lines.push(header.join('\t'));
+  for (const c of agg.cells) {
+    const costPerIssue = c.cost_per_issue_shipped != null ? `$${c.cost_per_issue_shipped.toFixed(4)}` : 'n/a';
+    const delta = c.delta_cost_per_issue_shipped_vs_baseline;
+    const deltaStr = delta == null ? '—' : (delta >= 0 ? `+$${delta.toFixed(4)}` : `-$${Math.abs(delta).toFixed(4)}`);
+    lines.push([
+      c.stage,
+      c.model,
+      String(c.runs),
+      String(c.tokens_in),
+      String(c.tokens_out),
+      `$${c.total_cost_usd.toFixed(4)}`,
+      costPerIssue,
+      c.median_wall_time_s.toFixed(2),
+      c.tool_error_rate.toFixed(4),
+      deltaStr,
+    ].join('\t'));
+  }
+  lines.push('');
+  lines.push(`Total cost: $${agg.total_cost_usd.toFixed(4)}`);
+  return lines.join('\n');
+}
+
+/**
+ * Parse a duration string like "30d", "12h", "45m", "90s" into milliseconds.
+ * Returns undefined when the input is empty or unparseable.
+ */
+export function parseDuration(input: string | undefined): number | undefined {
+  if (!input) return undefined;
+  const match = /^(\d+)([smhd])$/.exec(input.trim());
+  if (!match) return undefined;
+  const n = parseInt(match[1], 10);
+  const unit = match[2];
+  const mult = unit === 's' ? 1000 : unit === 'm' ? 60_000 : unit === 'h' ? 3_600_000 : 86_400_000;
+  return n * mult;
+}

--- a/tests/commands/history.test.ts
+++ b/tests/commands/history.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { historyList, historyDetail, historyQa, historyClean } from '../../src/commands/history';
+import { historyList, historyDetail, historyQa, historyClean, historyTelemetry } from '../../src/commands/history';
 
 function createTempDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'history-test-'));
@@ -152,6 +152,70 @@ describe('history', () => {
       const errorOutput = errorSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
       expect(errorOutput).toContain('QA checklist not found');
       errorSpy.mockRestore();
+    });
+  });
+
+  describe('historyTelemetry', () => {
+    it('prints a table of stage telemetry entries from stages.jsonl', () => {
+      const tracesDir = path.join(tmpDir, '.alpha-loop', 'traces', 'session-20260423-120000');
+      fs.mkdirSync(tracesDir, { recursive: true });
+      const entries = [
+        {
+          stage: 'plan', model: 'sonnet', endpoint: 'anthropic-prod',
+          tokens_in: 1000, tokens_out: 500, cost_usd: 0.015,
+          wall_time_s: 5.5, tool_calls: 3, tool_errors: 0,
+          stage_success: true, started_at: '2026-04-23T12:00:00.000Z',
+        },
+        {
+          stage: 'implement', model: 'qwen', endpoint: 'lmstudio',
+          tokens_in: 5000, tokens_out: 1500, cost_usd: 0,
+          wall_time_s: 40, tool_calls: 12, tool_errors: 2,
+          stage_success: true, started_at: '2026-04-23T12:05:00.000Z',
+        },
+      ];
+      fs.writeFileSync(
+        path.join(tracesDir, 'stages.jsonl'),
+        entries.map((e) => JSON.stringify(e)).join('\n') + '\n',
+      );
+
+      historyTelemetry('session/20260423-120000', tmpDir);
+
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('Stage telemetry');
+      expect(output).toContain('plan');
+      expect(output).toContain('implement');
+      expect(output).toContain('sonnet');
+      expect(output).toContain('qwen');
+      expect(output).toContain('lmstudio');
+      expect(output).toContain('Totals: 2 stage(s)');
+    });
+
+    it('prints graceful message when no telemetry exists (legacy session)', () => {
+      historyTelemetry('session/missing', tmpDir);
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('No per-stage telemetry recorded for this session.');
+    });
+
+    it('falls back to manifest.stages when stages.jsonl is missing', () => {
+      const learningsDir = path.join(tmpDir, '.alpha-loop', 'learnings');
+      fs.mkdirSync(learningsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(learningsDir, 'session-session-20260423-000000.json'),
+        JSON.stringify({
+          name: 'session/20260423-000000',
+          results: [],
+          stages: [{
+            stage: 'plan', model: 'sonnet', endpoint: 'anthropic',
+            tokens_in: 10, tokens_out: 5, cost_usd: 0.001,
+            wall_time_s: 1, tool_calls: 0, tool_errors: 0,
+            stage_success: true, started_at: '2026-04-23T00:00:00.000Z',
+          }],
+        }),
+      );
+      historyTelemetry('session/20260423-000000', tmpDir);
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('plan');
+      expect(output).toContain('sonnet');
     });
   });
 

--- a/tests/commands/report.test.ts
+++ b/tests/commands/report.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { reportRoutingCommand } from '../../src/commands/report';
+import type { StageTelemetry } from '../../src/lib/telemetry';
+
+function seedSession(
+  projectDir: string,
+  session: string,
+  entries: StageTelemetry[],
+  manifest: { shipped: number; failed?: number },
+): void {
+  // traces dir uses session with / replaced by -
+  const traceName = session.replace(/\//g, '-');
+  const traceDir = join(projectDir, '.alpha-loop', 'traces', traceName);
+  mkdirSync(traceDir, { recursive: true });
+  writeFileSync(
+    join(traceDir, 'stages.jsonl'),
+    entries.map((e) => JSON.stringify(e)).join('\n') + '\n',
+  );
+
+  const learningsDir = join(projectDir, '.alpha-loop', 'learnings');
+  mkdirSync(learningsDir, { recursive: true });
+  const results = [];
+  for (let i = 0; i < manifest.shipped; i++) {
+    results.push({ issueNum: i + 1, status: 'success', filesChanged: 1 });
+  }
+  for (let i = 0; i < (manifest.failed ?? 0); i++) {
+    results.push({ issueNum: 100 + i, status: 'failure', filesChanged: 0 });
+  }
+  writeFileSync(
+    join(learningsDir, `session-${session.replace(/\//g, '-')}.json`),
+    JSON.stringify({ name: session, results }),
+  );
+}
+
+function entry(partial: Partial<StageTelemetry>): StageTelemetry {
+  return {
+    stage: 'plan',
+    model: 'model',
+    endpoint: 'default',
+    tokens_in: 100,
+    tokens_out: 50,
+    cost_usd: 0.01,
+    wall_time_s: 1,
+    tool_calls: 1,
+    tool_errors: 0,
+    stage_success: true,
+    started_at: '2026-04-23T00:00:00.000Z',
+    ...partial,
+  };
+}
+
+describe('reportRoutingCommand', () => {
+  let tmp: string;
+  let logs: string[];
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'report-test-'));
+    logs = [];
+    logSpy = jest.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('emits a friendly message when no telemetry exists (zero-arg default)', () => {
+    reportRoutingCommand({ projectDir: tmp });
+    expect(logs.join('\n')).toContain('No per-stage telemetry recorded yet');
+  });
+
+  it('runs with zero arguments and aggregates all sessions', () => {
+    seedSession(tmp, 'session/A', [entry({ stage: 'implement', model: 'sonnet', cost_usd: 0.5 })], { shipped: 2 });
+    seedSession(tmp, 'session/B', [entry({ stage: 'implement', model: 'sonnet', cost_usd: 0.5 })], { shipped: 2 });
+    reportRoutingCommand({ projectDir: tmp });
+    const output = logs.join('\n');
+    expect(output).toContain('2 session(s)');
+    expect(output).toContain('implement');
+    expect(output).toContain('sonnet');
+  });
+
+  it('emits valid JSON matching the documented schema when --json set', () => {
+    seedSession(tmp, 'session/A', [
+      entry({ stage: 'plan', model: 'opus', cost_usd: 0.2 }),
+      entry({ stage: 'implement', model: 'sonnet', cost_usd: 0.3, profile: 'hybrid-v1' }),
+    ], { shipped: 3 });
+
+    reportRoutingCommand({ projectDir: tmp, json: true });
+
+    const output = logs.join('\n');
+    const parsed = JSON.parse(output);
+    expect(parsed).toHaveProperty('cells');
+    expect(parsed).toHaveProperty('total_sessions');
+    expect(parsed).toHaveProperty('total_stages');
+    expect(parsed).toHaveProperty('total_issues_shipped');
+    expect(parsed).toHaveProperty('total_cost_usd');
+    expect(parsed).toHaveProperty('filters');
+    expect(parsed.filters.baseline).toBe('all-frontier');
+    expect(Array.isArray(parsed.cells)).toBe(true);
+    const implCell = parsed.cells.find((c: { stage: string }) => c.stage === 'implement');
+    expect(implCell).toBeDefined();
+    expect(implCell.cost_per_issue_shipped).toBeCloseTo(0.1, 4);
+  });
+
+  it('filters by --profile', () => {
+    seedSession(tmp, 'session/A', [
+      entry({ stage: 'implement', model: 'a', cost_usd: 0.1, profile: 'alpha' }),
+      entry({ stage: 'implement', model: 'b', cost_usd: 0.2, profile: 'beta' }),
+    ], { shipped: 1 });
+
+    reportRoutingCommand({ projectDir: tmp, json: true, profile: 'alpha' });
+    const parsed = JSON.parse(logs.join('\n'));
+    expect(parsed.cells).toHaveLength(1);
+    expect(parsed.cells[0].model).toBe('a');
+    expect(parsed.filters.profile).toBe('alpha');
+  });
+
+  it('filters by --since duration', () => {
+    const nowIso = new Date().toISOString();
+    const oldIso = '2020-01-01T00:00:00.000Z';
+    seedSession(tmp, 'session/A', [
+      entry({ stage: 'implement', model: 'old', started_at: oldIso }),
+      entry({ stage: 'implement', model: 'new', started_at: nowIso }),
+    ], { shipped: 1 });
+
+    reportRoutingCommand({ projectDir: tmp, json: true, since: '30d' });
+    const parsed = JSON.parse(logs.join('\n'));
+    expect(parsed.cells.map((c: { model: string }) => c.model)).toEqual(['new']);
+  });
+});

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -69,10 +69,16 @@ jest.mock('../../src/lib/traces', () => ({
   runDir: jest.fn().mockReturnValue('/tmp/traces/run'),
 }));
 
+jest.mock('../../src/lib/telemetry', () => ({
+  buildStageTelemetry: jest.fn().mockReturnValue({}),
+  writeStageTelemetry: jest.fn(),
+}));
+
 jest.mock('../../src/lib/config', () => ({
   estimateCost: jest.fn().mockReturnValue(0),
   getFallbackPolicy: jest.fn().mockReturnValue(null),
   resolveRoutingStage: jest.fn().mockReturnValue(undefined),
+  selectRoutingProfile: jest.fn().mockReturnValue(undefined),
 }));
 
 jest.mock('../../src/lib/prompts', () => ({

--- a/tests/lib/telemetry.test.ts
+++ b/tests/lib/telemetry.test.ts
@@ -1,0 +1,445 @@
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  buildStageTelemetry,
+  writeStageTelemetry,
+  readStageTelemetry,
+  readAllStageTelemetry,
+  readSessionManifests,
+  aggregateRouting,
+  parseDuration,
+  formatRoutingReport,
+} from '../../src/lib/telemetry';
+import type { StageTelemetry, SessionManifestLite } from '../../src/lib/telemetry';
+import type { Config } from '../../src/lib/config';
+import type { AgentResult } from '../../src/lib/agent';
+
+function baseConfig(): Config {
+  return {
+    repo: 'owner/repo',
+    repoOwner: 'owner',
+    project: 1,
+    agent: 'claude',
+    model: 'claude-sonnet-4-6',
+    reviewModel: 'claude-opus-4-6',
+    pollInterval: 60,
+    dryRun: false,
+    baseBranch: 'master',
+    logDir: 'logs',
+    labelReady: 'ready',
+    maxTestRetries: 3,
+    testCommand: 'pnpm test',
+    devCommand: 'pnpm dev',
+    skipTests: false,
+    skipReview: false,
+    skipInstall: false,
+    skipPreflight: false,
+    skipVerify: false,
+    skipLearn: false,
+    skipE2e: false,
+    maxIssues: 0,
+    maxSessionDuration: 0,
+    milestone: '',
+    autoMerge: true,
+    mergeTo: '',
+    autoCleanup: true,
+    runFull: false,
+    verbose: false,
+    harnesses: [],
+    setupCommand: '',
+    evalDir: '.alpha-loop/evals',
+    evalModel: '',
+    skipEval: false,
+    evalTimeout: 300,
+    autoCapture: true,
+    skipPostSessionReview: false,
+    skipPostSessionSecurity: false,
+    batch: false,
+    batchSize: 5,
+    smokeTest: '',
+    agentTimeout: 1800,
+    pricing: {
+      'claude-opus-4-6': { input: 15.0, output: 75.0 },
+      'claude-sonnet-4-6': { input: 3.0, output: 15.0 },
+      'qwen3-coder-30b-a3b': { input: 0, output: 0 },
+    },
+    pipeline: {},
+    evalIncludeAgentPrompts: true,
+    evalIncludeSkills: true,
+    preferEpics: false,
+  };
+}
+
+describe('buildStageTelemetry', () => {
+  it('uses reported tokens and cost for frontier endpoints', () => {
+    const cfg = baseConfig();
+    const res: AgentResult = {
+      exitCode: 0,
+      output: 'ok',
+      duration: 1234,
+      costUsd: 0.0598,
+      inputTokens: 10_000,
+      outputTokens: 2_000,
+      toolCalls: 5,
+      toolErrors: 1,
+      model: 'claude-sonnet-4-6',
+    };
+    const entry = buildStageTelemetry(res, 'implement', cfg, {
+      endpoint: 'anthropic-prod',
+      endpointType: 'anthropic',
+      profile: 'hybrid-v1',
+      issueNum: 42,
+    });
+    expect(entry.stage).toBe('implement');
+    expect(entry.model).toBe('claude-sonnet-4-6');
+    expect(entry.endpoint).toBe('anthropic-prod');
+    expect(entry.endpoint_type).toBe('anthropic');
+    expect(entry.tokens_in).toBe(10_000);
+    expect(entry.tokens_out).toBe(2_000);
+    expect(entry.cost_usd).toBe(0.0598);
+    expect(entry.wall_time_s).toBe(1.234);
+    expect(entry.tool_calls).toBe(5);
+    expect(entry.tool_errors).toBe(1);
+    expect(entry.stage_success).toBe(true);
+    expect(entry.profile).toBe('hybrid-v1');
+    expect(entry.issue_num).toBe(42);
+  });
+
+  it('zeroes cost for anthropic_compat (local LM Studio) endpoints', () => {
+    const cfg = baseConfig();
+    const res: AgentResult = {
+      exitCode: 0,
+      output: 'ok',
+      duration: 5_000,
+      costUsd: 0.12, // Agent reported a cost — should be ignored for local.
+      inputTokens: 10_000,
+      outputTokens: 2_000,
+      model: 'qwen3-coder-30b-a3b',
+    };
+    const entry = buildStageTelemetry(res, 'implement', cfg, {
+      endpoint: 'lmstudio',
+      endpointType: 'anthropic_compat',
+    });
+    expect(entry.cost_usd).toBe(0);
+    expect(entry.tokens_in).toBe(10_000);
+    expect(entry.tokens_out).toBe(2_000);
+  });
+
+  it('zeroes cost for openai_compat (Ollama) endpoints', () => {
+    const cfg = baseConfig();
+    const res: AgentResult = {
+      exitCode: 0,
+      output: 'ok',
+      duration: 5_000,
+      model: 'qwen3-coder-30b-a3b',
+    };
+    const entry = buildStageTelemetry(res, 'implement', cfg, {
+      endpoint: 'ollama',
+      endpointType: 'openai_compat',
+    });
+    expect(entry.cost_usd).toBe(0);
+  });
+
+  it('falls back to estimated tokens from output length when agent lacks cost data', () => {
+    const cfg = baseConfig();
+    const res: AgentResult = {
+      exitCode: 1,
+      output: 'x'.repeat(400), // ~100 output tokens, 130 input tokens.
+      duration: 1_000,
+      model: 'claude-sonnet-4-6',
+    };
+    const entry = buildStageTelemetry(res, 'plan', cfg, {
+      endpoint: 'anthropic',
+      endpointType: 'anthropic',
+    });
+    expect(entry.tokens_out).toBeGreaterThan(0);
+    expect(entry.tokens_in).toBeGreaterThan(0);
+    expect(entry.cost_usd).toBeGreaterThan(0);
+    expect(entry.stage_success).toBe(false);
+  });
+
+  it('defaults tool counts to 0 when agent result lacks them', () => {
+    const cfg = baseConfig();
+    const res: AgentResult = {
+      exitCode: 0,
+      output: '',
+      duration: 500,
+      model: 'claude-sonnet-4-6',
+    };
+    const entry = buildStageTelemetry(res, 'plan', cfg, {});
+    expect(entry.tool_calls).toBe(0);
+    expect(entry.tool_errors).toBe(0);
+    expect(entry.endpoint).toBe('default');
+  });
+});
+
+describe('writeStageTelemetry / readStageTelemetry', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'telemetry-test-')); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it('appends jsonl and reads back entries in order', () => {
+    const entry1: StageTelemetry = {
+      stage: 'plan', model: 'a', endpoint: 'x',
+      tokens_in: 1, tokens_out: 2, cost_usd: 0.1,
+      wall_time_s: 1, tool_calls: 0, tool_errors: 0,
+      stage_success: true, started_at: '2026-04-23T00:00:00.000Z',
+    };
+    const entry2: StageTelemetry = { ...entry1, stage: 'implement', model: 'b' };
+    writeStageTelemetry(tmp, entry1);
+    writeStageTelemetry(tmp, entry2);
+    const entries = readStageTelemetry(tmp);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].stage).toBe('plan');
+    expect(entries[1].model).toBe('b');
+  });
+
+  it('returns empty array for missing file', () => {
+    expect(readStageTelemetry(join(tmp, 'does-not-exist'))).toEqual([]);
+  });
+
+  it('skips malformed lines without crashing', () => {
+    mkdirSync(tmp, { recursive: true });
+    writeFileSync(join(tmp, 'stages.jsonl'), 'not valid json\n{"stage":"ok","model":"m","endpoint":"e","tokens_in":0,"tokens_out":0,"cost_usd":0,"wall_time_s":0,"tool_calls":0,"tool_errors":0,"stage_success":true,"started_at":"x"}\n');
+    const entries = readStageTelemetry(tmp);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].stage).toBe('ok');
+  });
+});
+
+describe('aggregateRouting', () => {
+  function entry(
+    stage: string,
+    model: string,
+    cost: number,
+    wall: number,
+    toolCalls: number,
+    toolErrors: number,
+    profile?: string,
+    started?: string,
+  ): StageTelemetry {
+    return {
+      stage, model, endpoint: 'e',
+      tokens_in: 100, tokens_out: 50, cost_usd: cost,
+      wall_time_s: wall, tool_calls: toolCalls, tool_errors: toolErrors,
+      stage_success: true,
+      started_at: started ?? '2026-04-23T00:00:00.000Z',
+      profile,
+    };
+  }
+
+  function manifest(name: string, shipped: number, failed = 0): SessionManifestLite {
+    const results = [];
+    for (let i = 0; i < shipped; i++) {
+      results.push({ issueNum: i + 1, status: 'success' as const, filesChanged: 3, prUrl: `url/${i}` });
+    }
+    for (let i = 0; i < failed; i++) {
+      results.push({ issueNum: 100 + i, status: 'failure' as const, filesChanged: 0 });
+    }
+    return { name, completed: '2026-04-23T00:00:00.000Z', results };
+  }
+
+  it('computes cost_per_issue_shipped from cost/shipped', () => {
+    const items = [
+      { session: 'session-20260423-000000', entries: [entry('implement', 'sonnet', 1.0, 10, 10, 1)] },
+    ];
+    const manifests = [manifest('session/20260423-000000', 4)]; // 4 shipped issues.
+    const agg = aggregateRouting(items, manifests, { baseline: 'all-frontier' });
+    expect(agg.cells).toHaveLength(1);
+    expect(agg.cells[0].cost_per_issue_shipped).toBeCloseTo(0.25, 4);
+  });
+
+  it('groups multi-model sessions correctly and sums cost across stages', () => {
+    const items = [
+      {
+        session: 'session-A',
+        entries: [
+          entry('plan', 'opus', 0.5, 5, 5, 0),
+          entry('implement', 'sonnet', 0.3, 30, 20, 1),
+          entry('implement', 'sonnet', 0.2, 20, 15, 0),
+        ],
+      },
+    ];
+    const manifests = [manifest('session/A', 2)];
+    const agg = aggregateRouting(items, manifests);
+    expect(agg.total_cost_usd).toBeCloseTo(1.0, 4);
+    const implementCell = agg.cells.find((c) => c.stage === 'implement')!;
+    expect(implementCell.runs).toBe(2);
+    expect(implementCell.total_cost_usd).toBeCloseTo(0.5, 4);
+    expect(implementCell.cost_per_issue_shipped).toBeCloseTo(0.25, 4);
+  });
+
+  it('computes median wall time across invocations', () => {
+    const items = [
+      {
+        session: 'S',
+        entries: [
+          entry('implement', 'm', 0.1, 10, 1, 0),
+          entry('implement', 'm', 0.1, 30, 1, 0),
+          entry('implement', 'm', 0.1, 50, 1, 0),
+        ],
+      },
+    ];
+    const agg = aggregateRouting(items, [manifest('S', 1)]);
+    expect(agg.cells[0].median_wall_time_s).toBe(30);
+  });
+
+  it('computes tool_error_rate from error/call ratio', () => {
+    const items = [
+      {
+        session: 'S',
+        entries: [entry('implement', 'm', 0.1, 10, 100, 8)],
+      },
+    ];
+    const agg = aggregateRouting(items, [manifest('S', 1)]);
+    expect(agg.cells[0].tool_error_rate).toBeCloseTo(0.08, 4);
+  });
+
+  it('computes delta vs all-frontier baseline (highest-cost cell per stage)', () => {
+    const items = [
+      {
+        session: 'S1',
+        entries: [
+          entry('implement', 'opus', 2.0, 40, 10, 0),      // Frontier baseline (costly).
+          entry('implement', 'qwen-local', 0.0, 30, 10, 2), // Local cell.
+        ],
+      },
+    ];
+    const manifests = [manifest('S1', 1)];
+    const agg = aggregateRouting(items, manifests);
+    const local = agg.cells.find((c) => c.model === 'qwen-local')!;
+    const frontier = agg.cells.find((c) => c.model === 'opus')!;
+    expect(frontier.delta_cost_per_issue_shipped_vs_baseline).toBeNull();
+    expect(local.delta_cost_per_issue_shipped_vs_baseline).toBeLessThan(0); // Cheaper.
+    expect(local.delta_median_wall_time_s_vs_baseline).toBe(-10);
+    expect(local.delta_tool_error_rate_vs_baseline).toBeCloseTo(0.2 - 0, 4);
+  });
+
+  it('filters by profile', () => {
+    const items = [
+      {
+        session: 'S',
+        entries: [
+          entry('implement', 'a', 0.1, 10, 1, 0, 'alpha'),
+          entry('implement', 'b', 0.2, 20, 1, 0, 'beta'),
+        ],
+      },
+    ];
+    const agg = aggregateRouting(items, [manifest('S', 1)], { profile: 'alpha' });
+    expect(agg.cells).toHaveLength(1);
+    expect(agg.cells[0].model).toBe('a');
+  });
+
+  it('filters by sinceMs', () => {
+    const oldTs = '2020-01-01T00:00:00.000Z';
+    const newTs = '2026-06-01T00:00:00.000Z';
+    const items = [
+      {
+        session: 'S',
+        entries: [
+          entry('implement', 'old', 0.1, 10, 1, 0, undefined, oldTs),
+          entry('implement', 'new', 0.2, 20, 1, 0, undefined, newTs),
+        ],
+      },
+    ];
+    const cutoff = new Date('2025-01-01T00:00:00.000Z').getTime();
+    const agg = aggregateRouting(items, [manifest('S', 1)], { sinceMs: cutoff });
+    expect(agg.cells.map((c) => c.model)).toEqual(['new']);
+  });
+
+  it('returns cost_per_issue_shipped=null when no shipped issues', () => {
+    const items = [
+      { session: 'S', entries: [entry('implement', 'm', 0.5, 10, 1, 0)] },
+    ];
+    const agg = aggregateRouting(items, [manifest('S', 0, 1)]);
+    expect(agg.cells[0].cost_per_issue_shipped).toBeNull();
+  });
+
+  it('handles sessions without a matching manifest gracefully', () => {
+    const items = [
+      { session: 'S', entries: [entry('implement', 'm', 0.5, 10, 1, 0)] },
+    ];
+    const agg = aggregateRouting(items, []);
+    expect(agg.cells).toHaveLength(1);
+    expect(agg.cells[0].cost_per_issue_shipped).toBeNull();
+    expect(agg.total_issues_shipped).toBe(0);
+  });
+});
+
+describe('parseDuration', () => {
+  it('parses seconds/minutes/hours/days', () => {
+    expect(parseDuration('30s')).toBe(30_000);
+    expect(parseDuration('5m')).toBe(300_000);
+    expect(parseDuration('2h')).toBe(7_200_000);
+    expect(parseDuration('3d')).toBe(3 * 86_400_000);
+  });
+  it('returns undefined for invalid input', () => {
+    expect(parseDuration('')).toBeUndefined();
+    expect(parseDuration('abc')).toBeUndefined();
+    expect(parseDuration(undefined)).toBeUndefined();
+  });
+});
+
+describe('formatRoutingReport', () => {
+  it('returns JSON when json option set', () => {
+    const agg = aggregateRouting(
+      [{ session: 'S', entries: [{ stage: 'plan', model: 'm', endpoint: 'e', tokens_in: 1, tokens_out: 1, cost_usd: 0.1, wall_time_s: 1, tool_calls: 1, tool_errors: 0, stage_success: true, started_at: '2026-04-23T00:00:00.000Z' }] }],
+      [{ name: 'session/S', results: [{ issueNum: 1, status: 'success', filesChanged: 3 }] }],
+    );
+    const str = formatRoutingReport(agg, { json: true });
+    const parsed = JSON.parse(str);
+    expect(parsed.cells).toBeDefined();
+    expect(parsed.filters.baseline).toBe('all-frontier');
+  });
+
+  it('shows friendly message when no cells', () => {
+    const agg = aggregateRouting([], []);
+    const str = formatRoutingReport(agg);
+    expect(str).toContain('No per-stage telemetry recorded yet');
+  });
+});
+
+describe('readAllStageTelemetry / readSessionManifests', () => {
+  let tmp: string;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'telemetry-fs-test-')); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it('scans traces dir and returns per-session entries', () => {
+    const sessionDir = join(tmp, '.alpha-loop', 'traces', 'session-A');
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      join(sessionDir, 'stages.jsonl'),
+      JSON.stringify({ stage: 'plan', model: 'm', endpoint: 'e', tokens_in: 0, tokens_out: 0, cost_usd: 0, wall_time_s: 0, tool_calls: 0, tool_errors: 0, stage_success: true, started_at: 'x' }) + '\n',
+    );
+    const items = readAllStageTelemetry(tmp);
+    expect(items).toHaveLength(1);
+    expect(items[0].session).toBe('session-A');
+    expect(items[0].entries).toHaveLength(1);
+  });
+
+  it('reads session manifests from learnings dir', () => {
+    const learningsDir = join(tmp, '.alpha-loop', 'learnings');
+    mkdirSync(learningsDir, { recursive: true });
+    writeFileSync(
+      join(learningsDir, 'session-session-A.json'),
+      JSON.stringify({ name: 'session/A', results: [{ issueNum: 1, status: 'success', filesChanged: 3 }] }),
+    );
+    const manifests = readSessionManifests(tmp);
+    expect(manifests).toHaveLength(1);
+    expect(manifests[0].name).toBe('session/A');
+  });
+
+  it('returns empty arrays when dirs do not exist', () => {
+    expect(readAllStageTelemetry(tmp)).toEqual([]);
+    expect(readSessionManifests(tmp)).toEqual([]);
+  });
+
+  it('ignores sessions that have only an empty stages.jsonl', () => {
+    const sessionDir = join(tmp, '.alpha-loop', 'traces', 'session-empty');
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, 'stages.jsonl'), '\n');
+    expect(existsSync(join(sessionDir, 'stages.jsonl'))).toBe(true);
+    expect(readAllStageTelemetry(tmp)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #161
Part of #165

## Summary

Automated implementation of **Per-stage telemetry + cost-per-issue aggregation (alpha-loop report routing)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

All acceptance criteria met: per-stage telemetry emitted at every spawnStageAgent site, report routing works zero-arg, JSON schema documented, legacy sessions degrade gracefully, tests pass (892/892), tsc clean.

- **INFO** [OPEN] `src/lib/pipeline.ts`: Non-routed paths (assumptions, batch-*) record telemetry without endpoint_type, so isLocal=false and pricing-table estimation is used — correct today but relies on pricing entries for frontier models being present.
- **INFO** [OPEN] `src/lib/telemetry.ts`: buildStageTelemetry falls back to output.length/4 token estimation when agent lacks usage data. For local endpoints this still reports cost_usd=0, but tokens_in is a heuristic (tokens_out * 1.3). Acceptable for MVP A/B analysis since comparisons are like-for-like.
- **INFO** [OPEN] `src/lib/telemetry.ts`: 'all-frontier' baseline selection picks the highest-cost cell per stage. If a session has only local cells for a stage, that local cell becomes the baseline (delta=null for itself, no frontier to compare against). Behavior is acceptable and explicitly tested.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*