### PR TITLE
feat: Docs: local-model setup guide + example routing profiles (closes #164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,15 @@ routing:
 
 **Backwards compatibility:** If you don't set `routing`, alpha-loop uses the top-level `agent:` / `model:` / `pipeline:` exactly as before — no behavior change.
 
+### Local Model Support
+
+Alpha Loop can run the token-heavy middle of the Loop (Build, Test) against an open-weight coding model on your own machine — typically a 30B-class model in LM Studio or Ollama — while keeping frontier models for Plan and Review. On a 64GB+ Apple Silicon Mac this typically cuts cost-per-issue by 60–80% without sacrificing Plan/Review quality.
+
+- [docs/local-models.md](docs/local-models.md) — hardware prerequisites, install steps for LM Studio 0.4.1+ / Ollama, recommended models (Qwen3-Coder-Next 30B-A3B, Gemma 4 31B, GLM-4.6), Apple Silicon tuning, and troubleshooting.
+- [docs/routing-profiles.md](docs/routing-profiles.md) — copy-pasteable profiles: `all-frontier` (baseline), `hybrid-v1` (recommended default), `all-local` (offline / zero-cost), `budget-hawk` (Haiku cloud + local coder).
+
+Quickest path: install LM Studio 0.4.1+, load `qwen3-coder-30b-a3b`, then drop the `hybrid-v1` block from [docs/routing-profiles.md](docs/routing-profiles.md) into your `.alpha-loop.yaml`. `alpha-loop init` detects Apple Silicon + 64GB+ RAM and points you at these docs automatically.
+
 ## GitHub Setup
 
 ### Labels

--- a/docs/local-models.md
+++ b/docs/local-models.md
@@ -16,11 +16,45 @@ so the `claude` CLI can talk to it directly with one env var — no translation
 proxy. Ollama exposes an OpenAI-compatible `/v1/chat/completions` endpoint, so
 the `codex` CLI works the same way.
 
-## Setup
+For ready-to-copy routing configurations (`all-frontier`, `hybrid-v1`,
+`all-local`, `budget-hawk`) see
+[docs/routing-profiles.md](routing-profiles.md).
 
-### LM Studio
+## Hardware prerequisites
 
-1. Install LM Studio from <https://lmstudio.ai/>.
+Running a 30B-class coding model alongside the rest of alpha-loop is the
+current sweet spot. You want enough unified memory to keep the full KV-cache
+resident at a 64–128K context window while a second model (summary / triage)
+is also loaded.
+
+| Hardware                      | Feasible | Notes                                                      |
+|-------------------------------|----------|------------------------------------------------------------|
+| Apple Silicon M3/M4 Max, 128GB| Yes      | Recommended. Runs Qwen3-Coder-Next 30B-A3B + Gemma 4 31B concurrently at 262K context |
+| Apple Silicon M-series, 64GB  | Yes      | Minimum. Load one 30B coder at a time; swap out for summaries |
+| Apple Silicon, 32GB or less   | No       | Not enough to keep a 30B model + KV cache resident         |
+| CUDA GPU, 48GB+ VRAM          | Yes      | Works, but alpha-loop has only been tuned on Apple Silicon |
+| Intel / AMD without GPU       | No       | CPU-only inference is too slow for the Loop's timeouts     |
+
+The `alpha-loop init` command detects Apple Silicon with ≥64GB RAM and offers
+to point you at the hybrid/local routing docs automatically.
+
+### Recommended models
+
+| Model                        | Role                   | Size  | Notes                                                     |
+|------------------------------|------------------------|-------|-----------------------------------------------------------|
+| Qwen3-Coder-Next 30B-A3B     | Primary coder (Build, Test) | ~46 tok/s on M4 Max 128GB, 262K context. Best open-weight tool-calling tested so far |
+| Gemma 4 31B                  | Utility (Summary, Triage, Learn) | Fast, good at structured-text extraction; cheap to keep co-resident |
+| GLM-4.6                      | Aspirational coder     | Larger | Strong reasoning, but tight on 128GB if a second model is loaded — treat as experimental |
+
+Pricing for these three models is zero in the default pricing table — cost
+telemetry reports `$0` when they're used.
+
+## Install LM Studio or Ollama
+
+### LM Studio (0.4.1+ required for the native Anthropic endpoint)
+
+1. Install LM Studio from <https://lmstudio.ai/>. **Version 0.4.1 or newer** —
+   older builds do not expose `/v1/messages` and will fail the preflight check.
 2. Load a coding-capable model (e.g. `qwen3-coder-30b-a3b`, `glm-4.6`).
 3. Start the server (Developer tab → "Start server"). Default port is `1234`.
 4. Verify it's up:
@@ -100,6 +134,10 @@ Each stage invocation resolves its own env vars. Frontier stages never
 inherit local-endpoint env from a previous local stage — the Loop clears
 `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` between stages that don't need them.
 
+For drop-in profile files under `.alpha-loop/evals/profiles/` (what
+`alpha-loop eval --matrix` and `alpha-loop eval run --profile` consume), see
+[docs/routing-profiles.md](routing-profiles.md).
+
 ## Preflight check
 
 Before a stage routed to a local endpoint runs, Alpha Loop issues
@@ -127,8 +165,26 @@ consumer hardware:
 | `glm-4.6`             | LM Studio    | Strong reasoning                            |
 | `llama3.1:70b`        | Ollama       | OpenAI-compatible route                     |
 
-Pricing for these models is zero in the default pricing table — cost
-telemetry reports $0 when they're used.
+## Apple Silicon tuning
+
+A few LM Studio knobs make the difference between "30 tok/s, stable" and
+"swapping to disk and dying":
+
+- **Context window.** Start at `65536` tokens — plenty for most Loop stages
+  and keeps the KV-cache footprint reasonable. Bump to `131072` or `262144`
+  only on 128GB machines and only when you actually need the headroom
+  (long-diff review passes).
+- **Batch size.** LM Studio's default batch (`512`) is usually right on
+  MLX builds. If you see long-prompt stalls, drop to `256`.
+- **KV-cache quantization.** Leave it at default (`F16`) on 128GB. On 64GB,
+  switch to `Q8_0` — frees ~30% of KV memory for a small quality hit that's
+  invisible on coding tasks.
+- **Prompt caching.** Keep LM Studio's "Keep in memory" on for the primary
+  coder model. The Loop re-uses the same system prompt across Build and Test
+  stages, and cold-reloading a 30B model between stages adds ~10–20s.
+- **Concurrent models.** On 128GB you can keep Qwen3-Coder-Next + Gemma 4
+  co-resident for fast Summary/Learn swaps. On 64GB, only load one at a
+  time and let the `summary` stage fall back to a cloud endpoint.
 
 ## Troubleshooting
 
@@ -138,6 +194,17 @@ telemetry reports $0 when they're used.
 - **"Model … is not loaded"** — the server is up but the expected model id
   isn't currently loaded. In LM Studio, load it via the Chat tab or CLI. In
   Ollama, `ollama pull <model>` first.
+- **Tool-call errors / malformed tool output.** Open-weight models have more
+  variance in tool-call formatting than frontier models. If you see
+  `on_tool_error: escalate` kicking in frequently for a stage, the rolling
+  error-rate guardrail will auto-revert that stage to the frontier fallback
+  after it exceeds `escalation_error_threshold` (default 8% over 10 issues).
+  Check `alpha-loop report routing` for the actual rate.
+- **Escalation not firing.** `fallback.on_tool_error: escalate` only fires on
+  tool-call errors, not on empty/unhelpful output. If a local model is
+  producing low-quality code that passes tool-call parsing, use
+  `alpha-loop eval --matrix` against the `routing-regression` suite to
+  catch it — don't rely on escalation alone.
 - **Port collisions** — both LM Studio and Ollama default to fixed ports
   (1234 and 11434). If you've changed them, update `base_url` in the
   endpoint config.

--- a/docs/routing-profiles.md
+++ b/docs/routing-profiles.md
@@ -1,0 +1,189 @@
+# Routing Profiles
+
+A routing profile is a named recipe for which model runs which Loop stage.
+Alpha Loop ships with a small library of profiles you can copy straight into
+`.alpha-loop.yaml`. They're the same shape `alpha-loop eval run --profile` and
+`alpha-loop eval --matrix` consume, so once a profile is wired, you can also
+A/B it against your eval suite.
+
+Every YAML block below validates against the `RoutingConfig` schema in
+[src/lib/config.ts](../src/lib/config.ts). Field reference lives in the
+[Per-Stage Routing section of the README](../README.md#per-stage-routing).
+
+For hardware, install, and tuning specifics, see
+[docs/local-models.md](local-models.md).
+
+## Choosing a profile
+
+| Profile        | Best when                                     | Tradeoff                                             |
+|----------------|-----------------------------------------------|------------------------------------------------------|
+| `all-frontier` | You need max autonomy & don't care about cost | Highest cost per issue; no local dependency          |
+| `hybrid-v1`    | You have a 64GB+ Mac and want to cut cost     | ~60–80% cost reduction; local coder handles Build/Test; Plan/Review stay frontier |
+| `all-local`    | Offline, zero-cost, privacy-constrained       | Lower pipeline success rate; requires 128GB for a coder + summary model concurrently |
+| `budget-hawk`  | Large batch runs where quality floor > peak   | Haiku everywhere cloud-side — cheap, slower to convergence on hard issues |
+
+Pick one to start. Once you have telemetry, use
+`alpha-loop report routing` to compare cost-per-issue-shipped and
+pipeline-success deltas between profiles on your own issues, then promote
+the winner with `alpha-loop evolve routing`.
+
+## `all-frontier`
+
+Baseline. Every stage runs on an Anthropic frontier model. This is the
+reference profile `alpha-loop eval --matrix` compares against.
+
+```yaml
+routing:
+  profile: all-frontier
+  endpoints:
+    anthropic: { type: anthropic, base_url: "https://api.anthropic.com" }
+  stages:
+    plan:       { model: claude-opus-4-7,   endpoint: anthropic }
+    build:      { model: claude-sonnet-4-6, endpoint: anthropic }
+    test_write: { model: claude-sonnet-4-6, endpoint: anthropic }
+    test_exec:  { model: claude-sonnet-4-6, endpoint: anthropic }
+    review:     { model: claude-sonnet-4-6, endpoint: anthropic }
+    summary:    { model: claude-haiku-4-5,  endpoint: anthropic }
+```
+
+**When this wins:** brand-new agentic workflow where you can't afford a
+regression, or issue sets that are heavy on reasoning-per-token (complex
+migrations, security reviews). Measurement only — not the long-term target.
+
+## `hybrid-v1` (recommended default)
+
+Frontier Opus for Plan, frontier Sonnet for Review, local Qwen3-Coder-Next
+for the token-heavy middle. Gemma 4 handles summary/learn locally.
+Tool-call errors on any local stage escalate back to Sonnet so a stuck local
+run doesn't wedge the Loop.
+
+```yaml
+routing:
+  profile: hybrid-v1
+  endpoints:
+    anthropic:      { type: anthropic,        base_url: "https://api.anthropic.com" }
+    lmstudio_local: { type: anthropic_compat, base_url: "http://localhost:1234" }
+  stages:
+    plan:       { model: claude-opus-4-7,     endpoint: anthropic }
+    build:      { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    test_write: { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    test_exec:  { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    review:     { model: claude-sonnet-4-6,   endpoint: anthropic }
+    summary:    { model: gemma-4-31b,         endpoint: lmstudio_local }
+  fallback:
+    on_tool_error: escalate
+    escalate_to:
+      model: claude-sonnet-4-6
+      endpoint: anthropic
+    escalation_window_issues: 10
+    escalation_error_threshold: 0.08
+```
+
+**When this wins:** you have a 64GB+ Apple Silicon Mac, run the Loop
+frequently, and want to cut the dominant cost (Build + Test) without
+sacrificing Plan/Review judgment. This is the profile `alpha-loop init`
+points you at when it detects qualifying hardware.
+
+## `all-local`
+
+Everything on your machine. No frontier dependency, no network egress, no
+cost. Uses Qwen3-Coder-Next for all coding stages and Gemma 4 via Ollama
+for the summary stage.
+
+```yaml
+routing:
+  profile: all-local
+  endpoints:
+    lmstudio_local: { type: anthropic_compat, base_url: "http://localhost:1234" }
+    ollama_local:   { type: openai_compat,    base_url: "http://localhost:11434/v1" }
+  stages:
+    plan:       { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    build:      { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    test_write: { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    test_exec:  { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    review:     { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    summary:    { model: gemma-4-31b,         endpoint: ollama_local }
+  fallback:
+    on_tool_error: fail
+```
+
+**When this wins:** offline development, privacy-constrained repos, or
+benchmarking open-weight models end-to-end. Expect a lower pipeline-success
+rate than `hybrid-v1` — there's no frontier escalation to catch stuck runs.
+Best paired with `alpha-loop eval --matrix` to quantify the delta against
+`all-frontier` on your own issues before committing.
+
+## `budget-hawk`
+
+Haiku for every cloud-side stage, local for the middle. Designed for large
+batch runs where per-issue cost matters more than peak reasoning quality.
+
+```yaml
+routing:
+  profile: budget-hawk
+  endpoints:
+    anthropic:      { type: anthropic,        base_url: "https://api.anthropic.com" }
+    lmstudio_local: { type: anthropic_compat, base_url: "http://localhost:1234" }
+  stages:
+    plan:       { model: claude-haiku-4-5,    endpoint: anthropic }
+    build:      { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    test_write: { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    test_exec:  { model: qwen3-coder-30b-a3b, endpoint: lmstudio_local }
+    review:     { model: claude-haiku-4-5,    endpoint: anthropic }
+    summary:    { model: claude-haiku-4-5,    endpoint: anthropic }
+  fallback:
+    on_tool_error: escalate
+    escalate_to:
+      model: claude-sonnet-4-6
+      endpoint: anthropic
+```
+
+**When this wins:** bulk triage-style work, doc-touch-up PRs, or any workload
+where you're paying for a lot of issues per day and they're individually
+simple. Haiku is cheap enough that the Plan/Review cost becomes negligible —
+the middle stages dominate, and those are local.
+
+## Comparing profiles with telemetry
+
+Once two or more profiles have run on your repo, compare them:
+
+```bash
+alpha-loop report routing
+alpha-loop report routing --profile hybrid-v1
+alpha-loop report routing --since 30d --json > report.json
+```
+
+The output aggregates per-(stage, model) cells across every session with
+`cost_per_issue_shipped`, `pipeline_success_rate`, and `tool_error_rate`,
+plus deltas against the highest-cost cell for each stage (the implicit
+`all-frontier` reference). This is the metric surface `alpha-loop evolve
+routing` reads when it proposes promotions:
+
+```text
+stage       model                  runs  success  cost/issue  Δcost    tool_err
+plan        claude-opus-4-7          42    0.93    $0.12       —        0.001
+plan        claude-haiku-4-5         18    0.89    $0.01      -$0.11    0.003
+build       claude-sonnet-4-6        42    0.95    $0.18       —        0.004
+build       qwen3-coder-30b-a3b      38    0.91    $0.00      -$0.18    0.017
+review      claude-sonnet-4-6        60    0.97    $0.27       —        0.002
+```
+
+A stage is eligible for promotion to its local candidate when, over ≥30
+runs: cost-per-issue savings ≥ 40%, pipeline-success delta ≥ −3%, and
+tool-error rate < 2%. See the [README's evolve routing
+section](../README.md#routing-promotiondemotion-alpha-loop-evolve-routing)
+for the full promotion/demotion loop.
+
+## Profile files for eval/matrix runs
+
+The above blocks go directly in `.alpha-loop.yaml`. For
+`alpha-loop eval run --profile <name>` and `alpha-loop eval --matrix`, put
+the same content into a file under `.alpha-loop/evals/profiles/<name>.yaml`.
+Three profiles ship with alpha-loop out of the box:
+
+- `.alpha-loop/evals/profiles/all-frontier.yaml`
+- `.alpha-loop/evals/profiles/hybrid-v1.yaml`
+- `.alpha-loop/evals/profiles/all-local.yaml`
+
+Add your own `budget-hawk.yaml` (or any custom profile) in that directory
+and it becomes available to the eval matrix.

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -22,6 +22,7 @@ import { ghExec } from '../lib/rate-limit.js';
 import { log } from '../lib/logger.js';
 import { syncAgentAssets, migrateToTemplates, resolveHarnesses } from './sync.js';
 import { findDistributionTemplatesDir } from '../lib/templates.js';
+import { shouldOfferLocalMode, getTotalMemoryGB } from '../lib/hardware.js';
 
 const CONFIG_FILE = '.alpha-loop.yaml';
 
@@ -186,6 +187,33 @@ const REQUIRED_LABELS = [
   { name: 'epic', color: '8B5CF6', description: 'Tracker issue with sub-issue checklist' },
   { name: 'needs-human-input', color: 'E99695', description: 'Requires human review or decision' },
 ];
+
+/**
+ * On Apple Silicon + 64GB+ RAM, point users at the local-model docs.
+ * Does not modify the YAML — the docs walk the user through the full setup.
+ * Silent on non-matching hardware and non-TTY environments.
+ */
+export async function maybeOfferLocalMode(): Promise<void> {
+  if (!shouldOfferLocalMode()) return;
+  if (!process.stdin.isTTY) return;
+
+  const memGB = Math.round(getTotalMemoryGB());
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(
+      `Detected Apple Silicon + ${memGB}GB RAM. Use hybrid (local build/test + cloud plan/review) mode? [y/N]: `,
+      resolve,
+    );
+  });
+  rl.close();
+
+  if (answer.trim().toLowerCase() === 'y' || answer.trim().toLowerCase() === 'yes') {
+    log.info('Hybrid mode setup is documented in:');
+    log.info('  - docs/local-models.md     (LM Studio / Ollama install, hardware tuning)');
+    log.info('  - docs/routing-profiles.md (copy-pasteable hybrid-v1 routing config)');
+    log.info('Alpha-loop did not modify .alpha-loop.yaml — follow the docs when ready.');
+  }
+}
 
 /**
  * Check for required GitHub labels and interactively create missing ones.
@@ -362,6 +390,7 @@ export async function initCommand(): Promise<void> {
     writeFileSync(CONFIG_FILE, configTemplate(repo));
     log.success(`Created ${CONFIG_FILE}`);
   }
+  await maybeOfferLocalMode();
 
   // --- Step 2: Set up .gitignore ---
   log.step('Step 2: Git ignore');

--- a/src/lib/hardware.ts
+++ b/src/lib/hardware.ts
@@ -1,0 +1,32 @@
+/**
+ * Hardware detection helpers for opting users into hybrid/local routing.
+ *
+ * Used by `alpha-loop init` to decide whether to offer the hybrid/local
+ * routing docs. Detection is intentionally conservative — we only prompt
+ * when we're confident the machine can actually run a 30B-class local coder.
+ */
+import * as os from 'node:os';
+
+const MIN_HYBRID_MEMORY_GB = 64;
+
+/** True on Apple Silicon (M1/M2/M3/M4/…) Macs. */
+export function detectAppleSilicon(): boolean {
+  if (os.platform() !== 'darwin') return false;
+  if (os.arch() !== 'arm64') return false;
+  const cpus = os.cpus();
+  if (!cpus || cpus.length === 0) return false;
+  return /^Apple\s+M\d/i.test(cpus[0]!.model ?? '');
+}
+
+/** Total system memory in gibibytes. */
+export function getTotalMemoryGB(): number {
+  return os.totalmem() / (1024 ** 3);
+}
+
+/**
+ * True when the machine has enough hardware to run the recommended
+ * hybrid-v1 profile (Apple Silicon + at least 64GB RAM).
+ */
+export function shouldOfferLocalMode(): boolean {
+  return detectAppleSilicon() && getTotalMemoryGB() >= MIN_HYBRID_MEMORY_GB;
+}

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -56,6 +56,14 @@ jest.mock('../../src/lib/templates', () => ({
   findDistributionTemplatesDir: jest.fn().mockReturnValue(null),
 }));
 
+// Mock hardware detection — default to non-Apple-Silicon so the hardware prompt
+// doesn't fire in most tests. Specific tests override to exercise the prompt path.
+jest.mock('../../src/lib/hardware', () => ({
+  shouldOfferLocalMode: jest.fn().mockReturnValue(false),
+  getTotalMemoryGB: jest.fn().mockReturnValue(16),
+  detectAppleSilicon: jest.fn().mockReturnValue(false),
+}));
+
 // Mock readline so interactive prompts (label creation, project statuses) don't block tests
 // Default: answer 'y' so label/status creation tests work. Override in specific tests if needed.
 jest.mock('node:readline', () => ({
@@ -205,5 +213,123 @@ describe('init command', () => {
 
     const gitignore = readFileSync(join(tempDir, '.gitignore'), 'utf-8');
     expect(gitignore).not.toContain('.alpha-loop/learnings/');
+  });
+});
+
+describe('hardware-aware local mode prompt', () => {
+  const hardware = jest.requireMock('../../src/lib/hardware') as {
+    shouldOfferLocalMode: jest.Mock;
+    getTotalMemoryGB: jest.Mock;
+    detectAppleSilicon: jest.Mock;
+  };
+  const readline = jest.requireMock('node:readline') as {
+    createInterface: jest.Mock;
+  };
+
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    hardware.shouldOfferLocalMode.mockReturnValue(false);
+    hardware.getTotalMemoryGB.mockReturnValue(16);
+    originalIsTTY = process.stdin.isTTY;
+  });
+
+  afterEach(() => {
+    // Restore stdin.isTTY exactly as we found it
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+  });
+
+  function setTTY(value: boolean): void {
+    Object.defineProperty(process.stdin, 'isTTY', { value, configurable: true });
+  }
+
+  it('does not prompt when hardware does not qualify', async () => {
+    hardware.shouldOfferLocalMode.mockReturnValue(false);
+    setTTY(true);
+
+    // Capture only questions asked from within maybeOfferLocalMode — other
+    // interactive prompts (label creation) use the same mock, so inspect prompts.
+    const questions: string[] = [];
+    readline.createInterface.mockReturnValue({
+      question: jest.fn((prompt: string, cb: (answer: string) => void) => {
+        questions.push(prompt);
+        cb('y');
+      }),
+      close: jest.fn(),
+    });
+
+    await initCommand();
+
+    expect(questions.every((q) => !q.includes('Apple Silicon'))).toBe(true);
+  });
+
+  it('does not prompt when not running in a TTY, even on qualifying hardware', async () => {
+    hardware.shouldOfferLocalMode.mockReturnValue(true);
+    hardware.getTotalMemoryGB.mockReturnValue(128);
+    setTTY(false);
+
+    const questions: string[] = [];
+    readline.createInterface.mockReturnValue({
+      question: jest.fn((prompt: string, cb: (answer: string) => void) => {
+        questions.push(prompt);
+        cb('y');
+      }),
+      close: jest.fn(),
+    });
+
+    await initCommand();
+
+    expect(questions.every((q) => !q.includes('Apple Silicon'))).toBe(true);
+  });
+
+  it('prompts on qualifying hardware + TTY and leaves YAML untouched on yes', async () => {
+    hardware.shouldOfferLocalMode.mockReturnValue(true);
+    hardware.getTotalMemoryGB.mockReturnValue(128);
+    setTTY(true);
+
+    const questions: string[] = [];
+    readline.createInterface.mockReturnValue({
+      question: jest.fn((prompt: string, cb: (answer: string) => void) => {
+        questions.push(prompt);
+        // First prompt (hardware) says yes; subsequent prompts (labels/statuses)
+        // also say yes via default.
+        cb('y');
+      }),
+      close: jest.fn(),
+    });
+
+    await initCommand();
+
+    // Hardware prompt was asked
+    expect(questions.some((q) => q.includes('Apple Silicon'))).toBe(true);
+
+    // YAML is the untouched default template — hardware prompt does not modify it
+    const content = readFileSync(join(tempDir, '.alpha-loop.yaml'), 'utf-8');
+    expect(content).toContain('agent: claude');
+    expect(content).not.toContain('routing:');
+  });
+
+  it('prompts on qualifying hardware but also leaves YAML untouched on no', async () => {
+    hardware.shouldOfferLocalMode.mockReturnValue(true);
+    hardware.getTotalMemoryGB.mockReturnValue(64);
+    setTTY(true);
+
+    const questions: string[] = [];
+    readline.createInterface.mockReturnValue({
+      question: jest.fn((prompt: string, cb: (answer: string) => void) => {
+        questions.push(prompt);
+        // Decline the hardware prompt; other prompts (labels) get 'n' too but
+        // shell mock returns exitCode 1 for gh so they're skipped harmlessly.
+        cb('n');
+      }),
+      close: jest.fn(),
+    });
+
+    await initCommand();
+
+    expect(questions.some((q) => q.includes('Apple Silicon'))).toBe(true);
+    const content = readFileSync(join(tempDir, '.alpha-loop.yaml'), 'utf-8');
+    expect(content).toContain('agent: claude');
+    expect(content).not.toContain('routing:');
   });
 });

--- a/tests/docs/routing-profiles.test.ts
+++ b/tests/docs/routing-profiles.test.ts
@@ -1,0 +1,94 @@
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+
+jest.mock('node:child_process', () => ({
+  execSync: jest.fn(),
+}));
+
+import { loadConfig } from '../../src/lib/config.js';
+
+const DOC_PATH = join(__dirname, '..', '..', 'docs', 'routing-profiles.md');
+const EXPECTED_PROFILES = ['all-frontier', 'hybrid-v1', 'all-local', 'budget-hawk'];
+const EXPECTED_STAGES = ['plan', 'build', 'test_write', 'test_exec', 'review', 'summary'];
+
+function extractYamlBlocks(markdown: string): string[] {
+  const blocks: string[] = [];
+  const fenceOpen = '```yaml\n';
+  const fenceClose = '```';
+  let i = 0;
+  while (true) {
+    const start = markdown.indexOf(fenceOpen, i);
+    if (start === -1) break;
+    const bodyStart = start + fenceOpen.length;
+    const end = markdown.indexOf(fenceClose, bodyStart);
+    if (end === -1) break;
+    blocks.push(markdown.slice(bodyStart, end));
+    i = end + fenceClose.length;
+  }
+  return blocks;
+}
+
+let originalCwd: string;
+let tempDir: string;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-docs-'));
+  process.chdir(tempDir);
+  (execSync as jest.MockedFunction<typeof execSync>).mockImplementation(() => {
+    throw new Error('not a git repo');
+  });
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('docs/routing-profiles.md', () => {
+  const markdown = readFileSync(DOC_PATH, 'utf-8');
+  const blocks = extractYamlBlocks(markdown);
+
+  it('contains one YAML block per documented profile', () => {
+    expect(blocks.length).toBe(EXPECTED_PROFILES.length);
+  });
+
+  it.each(EXPECTED_PROFILES.map((name, idx) => [idx, name]))(
+    'block %i (%s) validates via loadConfig with all 6 stages and resolved endpoints',
+    (idx, profileName) => {
+      const block = blocks[idx]!;
+      const wrapped = [
+        'repo: owner/repo',
+        'label: ready',
+        'base_branch: main',
+        'test_command: pnpm test',
+        block,
+      ].join('\n');
+
+      writeFileSync(join(tempDir, '.alpha-loop.yaml'), wrapped);
+      const config = loadConfig();
+
+      expect(config.routing).toBeDefined();
+      expect(config.routing!.profile).toBe(profileName);
+
+      const stageNames = Object.keys(config.routing!.stages ?? {});
+      for (const s of EXPECTED_STAGES) {
+        expect(stageNames).toContain(s);
+      }
+
+      const endpointNames = Object.keys(config.routing!.endpoints ?? {});
+      for (const [sn, sv] of Object.entries(config.routing!.stages!)) {
+        expect(endpointNames).toContain(sv!.endpoint);
+        expect(typeof sv!.model).toBe('string');
+        expect(sv!.model.length).toBeGreaterThan(0);
+      }
+
+      const escalateTo = config.routing!.fallback?.escalate_to;
+      if (escalateTo) {
+        expect(endpointNames).toContain(escalateTo.endpoint);
+      }
+    },
+  );
+});

--- a/tests/lib/hardware.test.ts
+++ b/tests/lib/hardware.test.ts
@@ -1,0 +1,125 @@
+jest.mock('node:os', () => ({
+  platform: jest.fn(),
+  arch: jest.fn(),
+  cpus: jest.fn(),
+  totalmem: jest.fn(),
+}));
+
+import * as os from 'node:os';
+import {
+  detectAppleSilicon,
+  getTotalMemoryGB,
+  shouldOfferLocalMode,
+} from '../../src/lib/hardware';
+
+const mockedPlatform = os.platform as jest.MockedFunction<typeof os.platform>;
+const mockedArch = os.arch as jest.MockedFunction<typeof os.arch>;
+const mockedCpus = os.cpus as jest.MockedFunction<typeof os.cpus>;
+const mockedTotalmem = os.totalmem as jest.MockedFunction<typeof os.totalmem>;
+
+function setHardware(opts: {
+  platform?: NodeJS.Platform;
+  arch?: NodeJS.Architecture;
+  cpuModel?: string;
+  memGB?: number;
+}): void {
+  mockedPlatform.mockReturnValue(opts.platform ?? 'darwin');
+  mockedArch.mockReturnValue(opts.arch ?? 'arm64');
+  mockedCpus.mockReturnValue([
+    {
+      model: opts.cpuModel ?? 'Apple M4 Max',
+      speed: 0,
+      times: { user: 0, nice: 0, sys: 0, idle: 0, irq: 0 },
+    },
+  ]);
+  mockedTotalmem.mockReturnValue(Math.round((opts.memGB ?? 128) * 1024 ** 3));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('detectAppleSilicon', () => {
+  it('returns true on darwin arm64 with Apple M-series CPU', () => {
+    setHardware({ cpuModel: 'Apple M3 Max' });
+    expect(detectAppleSilicon()).toBe(true);
+  });
+
+  it('matches M1, M2, M3, M4 variants', () => {
+    for (const model of ['Apple M1', 'Apple M2 Pro', 'Apple M3 Ultra', 'Apple M4 Max']) {
+      setHardware({ cpuModel: model });
+      expect(detectAppleSilicon()).toBe(true);
+    }
+  });
+
+  it('returns false on darwin x86_64 (Intel Mac)', () => {
+    setHardware({ arch: 'x64', cpuModel: 'Intel(R) Core(TM) i9' });
+    expect(detectAppleSilicon()).toBe(false);
+  });
+
+  it('returns false on linux arm64', () => {
+    setHardware({ platform: 'linux', cpuModel: 'Apple M1' });
+    expect(detectAppleSilicon()).toBe(false);
+  });
+
+  it('returns false on windows', () => {
+    setHardware({ platform: 'win32', arch: 'x64' });
+    expect(detectAppleSilicon()).toBe(false);
+  });
+
+  it('returns false when arm64 but cpu model is not Apple M-series', () => {
+    setHardware({ cpuModel: 'ARM Cortex-A78' });
+    expect(detectAppleSilicon()).toBe(false);
+  });
+
+  it('returns false when cpus() is empty', () => {
+    mockedPlatform.mockReturnValue('darwin');
+    mockedArch.mockReturnValue('arm64');
+    mockedCpus.mockReturnValue([]);
+    expect(detectAppleSilicon()).toBe(false);
+  });
+});
+
+describe('getTotalMemoryGB', () => {
+  it('converts bytes to gibibytes', () => {
+    mockedTotalmem.mockReturnValue(128 * 1024 ** 3);
+    expect(getTotalMemoryGB()).toBeCloseTo(128, 5);
+  });
+
+  it('returns fractional GB for non-power-of-two sizes', () => {
+    mockedTotalmem.mockReturnValue(48 * 1024 ** 3);
+    expect(getTotalMemoryGB()).toBeCloseTo(48, 5);
+  });
+});
+
+describe('shouldOfferLocalMode', () => {
+  it('returns true on Apple Silicon with 128GB', () => {
+    setHardware({ cpuModel: 'Apple M4 Max', memGB: 128 });
+    expect(shouldOfferLocalMode()).toBe(true);
+  });
+
+  it('returns true on Apple Silicon with exactly 64GB', () => {
+    setHardware({ cpuModel: 'Apple M3 Max', memGB: 64 });
+    expect(shouldOfferLocalMode()).toBe(true);
+  });
+
+  it('returns false on Apple Silicon with 32GB (below threshold)', () => {
+    setHardware({ cpuModel: 'Apple M2 Max', memGB: 32 });
+    expect(shouldOfferLocalMode()).toBe(false);
+  });
+
+  it('returns false on Apple Silicon with 16GB', () => {
+    setHardware({ cpuModel: 'Apple M1', memGB: 16 });
+    expect(shouldOfferLocalMode()).toBe(false);
+  });
+
+  it('returns false on x86_64 Mac even with 128GB', () => {
+    setHardware({ arch: 'x64', cpuModel: 'Intel Xeon W', memGB: 128 });
+    expect(shouldOfferLocalMode()).toBe(false);
+  });
+
+  it('returns false on Linux arm64 even with 128GB', () => {
+    setHardware({ platform: 'linux', cpuModel: 'Apple M1', memGB: 128 });
+    expect(shouldOfferLocalMode()).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #164
Part of #165

## Summary

Automated implementation of **Docs: local-model setup guide + example routing profiles**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | FAIL |

## Code Review

Docs render cleanly, 4 profile YAML blocks validate, init hardware prompt is correctly gated and fully tested; all 1045 tests pass.

- **INFO** [OPEN] `docs/routing-profiles.md`: docs/routing-profiles.md uses model IDs (claude-opus-4-7, qwen3-coder-30b-a3b, gemma-4-31b) that differ from the pre-shipped .alpha-loop/evals/profiles/*.yaml files (claude-sonnet-4-6, qwen3-coder-30b, gemma3-12b), even though docs say 'put the same content' in profile files. Doc YAML is self-contained and valid; divergence from earlier PRs' shipped profiles is non-blocking but could be aligned in a follow-up.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*