### PR TITLE
feat: Inject parent epic context into sub-issue agents (closes #189)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -11,7 +11,7 @@ import {
   getMergedPRForIssue, updateEpicChecklist, commentIssue, closeIssue, labelIssue,
   type Milestone, type Issue,
 } from '../lib/github.js';
-import { buildEpicSummary } from '../lib/epics.js';
+import { buildEpicSummary, parseSubIssues } from '../lib/epics.js';
 import { verifyEpic } from '../lib/verify-epic.js';
 import { processIssue, processBatch } from '../lib/pipeline.js';
 import { createSession, finalizeSession, type SessionContext } from '../lib/session.js';
@@ -24,7 +24,7 @@ import { syncAgentAssets, resolveHarnesses } from './sync.js';
 import { saveCapturedCase, detectFailureStep } from '../lib/eval.js';
 import { readGateResult, formatGateFindings } from '../lib/pipeline.js';
 import { spawnAgent } from '../lib/agent.js';
-import { buildSessionReviewPrompt } from '../lib/prompts.js';
+import { buildSessionReviewPrompt, type EpicPromptContext } from '../lib/prompts.js';
 import { writeTraceToSubdir } from '../lib/traces.js';
 import { readFileSync, existsSync, renameSync, unlinkSync } from 'node:fs';
 import { validateIssueQueue, printValidationReport, commentOnIncompleteIssues, type ValidationReport } from '../lib/validation.js';
@@ -155,7 +155,7 @@ function askChoice(prompt: string, max: number): Promise<number> {
 }
 
 export type PickTargetResult =
-  | { type: 'epic'; epicNum: number; epicTitle: string }
+  | { type: 'epic'; epicNum: number; epicTitle: string; epic: Issue }
   | { type: 'milestone'; title: string }
   | { type: 'all' };
 
@@ -186,7 +186,7 @@ async function pickTarget(
   if (opts.preferEpics && epics.length === 1) {
     const only = epics[0];
     log.info(`preferEpics: auto-selecting sole open epic #${only.number}`);
-    return { type: 'epic', epicNum: only.number, epicTitle: only.title };
+    return { type: 'epic', epicNum: only.number, epicTitle: only.title, epic: only };
   }
 
   const BOLD = '\x1b[1m';
@@ -236,7 +236,7 @@ async function pickTarget(
   if (choice <= epics.length) {
     const selected = epics[choice - 1];
     log.success(`Epic selected: ${selected.title} (#${selected.number})`);
-    return { type: 'epic', epicNum: selected.number, epicTitle: selected.title };
+    return { type: 'epic', epicNum: selected.number, epicTitle: selected.title, epic: selected };
   }
 
   const milestoneIdx = choice - epics.length - 1;
@@ -303,6 +303,130 @@ async function runEpicVerificationFlow(
   }
 }
 
+type EpicChecklistPromptItem = {
+  issueNum: number;
+  checked: boolean;
+  title?: string;
+};
+
+const MAX_EPIC_BODY_SUMMARY_CHARS = 1200;
+
+function extractChecklistTitle(line: string, issueNum: number): string | undefined {
+  const marker = `#${issueNum}`;
+  const idx = line.indexOf(marker);
+  if (idx === -1) return undefined;
+  const suffix = line.slice(idx + marker.length).trim().replace(/^[-:]\s*/, '').trim();
+  return suffix || undefined;
+}
+
+function parseEpicChecklistForPrompt(body: string): EpicChecklistPromptItem[] {
+  const lines = body.split('\n');
+  return parseSubIssues(body).map((ref) => ({
+    issueNum: ref.number,
+    checked: ref.checked,
+    title: extractChecklistTitle(lines[ref.lineIndex] ?? '', ref.number),
+  }));
+}
+
+function findMarkdownSection(body: string, headingPattern: RegExp): string[] {
+  const lines = body.split('\n');
+  const section: string[] = [];
+  let inSection = false;
+
+  for (const line of lines) {
+    const heading = /^#{1,6}\s+(.+?)\s*$/.exec(line.trim());
+    if (heading) {
+      if (inSection) break;
+      inSection = headingPattern.test(heading[1]);
+      continue;
+    }
+    if (inSection) section.push(line);
+  }
+
+  return section;
+}
+
+function removeMarkdownSection(body: string, headingPattern: RegExp): string {
+  const lines = body.split('\n');
+  const kept: string[] = [];
+  let skip = false;
+
+  for (const line of lines) {
+    const heading = /^#{1,6}\s+(.+?)\s*$/.exec(line.trim());
+    if (heading) {
+      if (skip && !headingPattern.test(heading[1])) {
+        skip = false;
+      } else if (headingPattern.test(heading[1])) {
+        skip = true;
+        continue;
+      }
+    }
+    if (!skip) kept.push(line);
+  }
+
+  return kept.join('\n');
+}
+
+function extractEpicAcceptanceCriteria(body: string): string[] {
+  const section = findMarkdownSection(body, /acceptance criteria/i);
+  if (section.length === 0) return [];
+
+  const listItems = section
+    .map((line) => line.trim())
+    .filter((line) => /^[-*]\s+/.test(line));
+
+  if (listItems.length > 0) return listItems;
+
+  return section
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function summarizeEpicBody(body: string): string {
+  const checklistLines = new Set(parseSubIssues(body).map((ref) => ref.lineIndex));
+  const withoutChecklist = body
+    .split('\n')
+    .filter((_, index) => !checklistLines.has(index))
+    .join('\n');
+  const withoutAcceptance = removeMarkdownSection(withoutChecklist, /acceptance criteria/i);
+  const compact = withoutAcceptance
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+  if (compact.length <= MAX_EPIC_BODY_SUMMARY_CHARS) return compact;
+  return `${compact.slice(0, MAX_EPIC_BODY_SUMMARY_CHARS).trimEnd()}\n...(truncated)`;
+}
+
+function buildEpicPromptContextFromIssue(
+  epic: Issue,
+  checklist: EpicChecklistPromptItem[],
+): EpicPromptContext {
+  return {
+    number: epic.number,
+    title: epic.title,
+    bodySummary: summarizeEpicBody(epic.body),
+    acceptanceCriteria: extractEpicAcceptanceCriteria(epic.body),
+    subIssues: checklist.map((item) => ({
+      issueNum: item.issueNum,
+      title: item.title,
+      checked: item.checked,
+    })),
+  };
+}
+
+function markEpicChecklistItem(
+  checklist: EpicChecklistPromptItem[],
+  context: EpicPromptContext | undefined,
+  issueNum: number,
+  checked: boolean,
+): void {
+  const item = checklist.find((entry) => entry.issueNum === issueNum);
+  if (item) item.checked = checked;
+
+  const contextItem = context?.subIssues.find((entry) => entry.issueNum === issueNum);
+  if (contextItem) contextItem.checked = checked;
+}
+
 /**
  * Run the main loop: poll for issues, process them, finalize session.
  */
@@ -342,6 +466,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
   // --- Target selection (epic or milestone) — must happen before session creation ---
   let activeEpic: number | undefined;
   let activeEpicTitle: string | undefined;
+  let activeEpicIssue: Issue | undefined;
   let activeMilestone = config.milestone;
 
   // --epic <N> overrides everything except --verify-only
@@ -357,6 +482,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
     }
     activeEpic = epic.number;
     activeEpicTitle = epic.title;
+    activeEpicIssue = epic;
     activeMilestone = '';
   }
 
@@ -369,6 +495,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
     if (target.type === 'epic') {
       activeEpic = target.epicNum;
       activeEpicTitle = target.epicTitle;
+      activeEpicIssue = target.epic;
     } else if (target.type === 'milestone') {
       activeMilestone = target.title;
     }
@@ -496,17 +623,30 @@ export async function runCommand(options: RunOptions): Promise<void> {
   // Otherwise, fetch via the usual project/label/milestone path and exclude
   // epic-labeled issues (AC #2: epics never picked up by the normal `ready` flow).
   let issues: Issue[];
+  let epicChecklist: EpicChecklistPromptItem[] = [];
+  let epicPromptContext: EpicPromptContext | undefined;
   if (activeEpic !== undefined) {
     log.info(`Fetching sub-issues of epic #${activeEpic} in checklist order...`);
-    const refs = getEpicSubIssues(config.repo, activeEpic);
+    if (!activeEpicIssue) {
+      const epic = getIssueWithComments(config.repo, activeEpic);
+      if (!epic) {
+        log.error(`Could not fetch epic #${activeEpic}`);
+        process.exit(1);
+      }
+      activeEpicIssue = epic;
+      activeEpicTitle = epic.title;
+    }
+
+    epicChecklist = parseEpicChecklistForPrompt(activeEpicIssue.body);
     issues = [];
-    for (const ref of refs) {
+    for (const ref of epicChecklist) {
       if (ref.checked) continue; // already done
-      const sub = getIssueWithComments(config.repo, ref.number);
+      const sub = getIssueWithComments(config.repo, ref.issueNum);
       if (!sub) {
-        log.warn(`Sub-issue #${ref.number} skipped: could not fetch`);
+        log.warn(`Sub-issue #${ref.issueNum} skipped: could not fetch`);
         continue;
       }
+      ref.title = ref.title ?? sub.title;
       if (sub.labels.includes('epic')) {
         log.warn(`Sub-issue #${sub.number} skipped: is itself an epic (nested epics unsupported in v1)`);
         continue;
@@ -517,6 +657,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
       }
       issues.push(sub);
     }
+    epicPromptContext = buildEpicPromptContextFromIssue(activeEpicIssue, epicChecklist);
   } else {
     const milestoneMsg = activeMilestone ? ` in milestone '${activeMilestone}'` : '';
     log.info(`Fetching issues${milestoneMsg}...`);
@@ -607,7 +748,9 @@ export async function runCommand(options: RunOptions): Promise<void> {
         activeIssueNum = batchIssues[0].number;
 
         try {
-          const results = await processBatch(batchIssues, config, session);
+          const results = epicPromptContext
+            ? await processBatch(batchIssues, config, session, { epicContext: epicPromptContext })
+            : await processBatch(batchIssues, config, session);
           session.results.push(...results);
 
           // Flip epic checklist for each successful sub-issue.
@@ -619,6 +762,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
               if (r.status !== 'success') continue;
               try {
                 updateEpicChecklist(config.repo, activeEpic, r.issueNum, true);
+                markEpicChecklistItem(epicChecklist, epicPromptContext, r.issueNum, true);
               } catch (err) {
                 log.error(`Epic #${activeEpic} checklist update failed for sub-issue #${r.issueNum}: ${err instanceof Error ? err.message : err}`);
                 // One-agent-per-epic contract — halt further processing on body inconsistency
@@ -669,13 +813,22 @@ export async function runCommand(options: RunOptions): Promise<void> {
         activeIssueNum = issue.number;
 
         try {
-          const result = await processIssue(
-            issue.number,
-            issue.title,
-            issue.body,
-            config,
-            session,
-          );
+          const result = epicPromptContext
+            ? await processIssue(
+                issue.number,
+                issue.title,
+                issue.body,
+                config,
+                session,
+                { epicContext: epicPromptContext },
+              )
+            : await processIssue(
+                issue.number,
+                issue.title,
+                issue.body,
+                config,
+                session,
+              );
           session.results.push(result);
 
           // Flip the epic checklist box when this sub-issue succeeded.
@@ -684,6 +837,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
           if (activeEpic !== undefined && result.status === 'success' && !config.dryRun) {
             try {
               updateEpicChecklist(config.repo, activeEpic, issue.number, true);
+              markEpicChecklistItem(epicChecklist, epicPromptContext, issue.number, true);
             } catch (err) {
               log.error(`Epic #${activeEpic} checklist update failed for sub-issue #${issue.number}: ${err instanceof Error ? err.message : err}`);
               // One-agent-per-epic contract — halt further processing on body inconsistency
@@ -712,7 +866,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
   // --- Epic completion check: verify and close if all sub-issues are now done ---
   if (activeEpic !== undefined && !epicAbort && !config.dryRun) {
     try {
-      const remaining = getEpicSubIssues(config.repo, activeEpic).filter((r) => !r.checked);
+      const remaining = epicChecklist.filter((r) => !r.checked);
       if (remaining.length === 0) {
         log.step(`All sub-issues of epic #${activeEpic} are complete — running verification pass`);
         await runEpicVerificationFlow(activeEpic, config, session);
@@ -792,6 +946,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
               testsPassing: r.testsPassing,
             })),
             includeSecurityScan: !config.skipPostSessionSecurity,
+            epicContext: epicPromptContext,
             visionContext,
           });
 

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -27,13 +27,16 @@ import {
   type Comment,
 } from './github.js';
 import {
+  buildIssuePlanPrompt,
   buildImplementPrompt,
   buildReviewPrompt,
   buildAssumptionsPrompt,
   buildBatchPlanPrompt,
   buildBatchImplementPrompt,
   buildBatchReviewPrompt,
+  formatEpicPromptContext,
   type BatchIssue,
+  type EpicPromptContext,
 } from './prompts.js';
 import { runTests } from './testing.js';
 import { runVerify } from './verify.js';
@@ -324,6 +327,29 @@ export type PipelineResult = {
   escalationEvents?: EscalationEvent[];
 };
 
+export type PipelineOptions = {
+  epicContext?: EpicPromptContext;
+};
+
+function resolvePipelineOptions(
+  trackerOrOptions?: EscalationTracker | PipelineOptions,
+  maybeOptions?: PipelineOptions,
+): { trackerOverride?: EscalationTracker; options: PipelineOptions } {
+  if (trackerOrOptions instanceof EscalationTracker) {
+    return { trackerOverride: trackerOrOptions, options: maybeOptions ?? {} };
+  }
+  return { options: trackerOrOptions ?? {} };
+}
+
+function epicPromptOption(options: PipelineOptions): { epicContext?: EpicPromptContext } {
+  return options.epicContext ? { epicContext: options.epicContext } : {};
+}
+
+function formatEpicFixContext(options: PipelineOptions, issueNum: number): string {
+  if (!options.epicContext) return '';
+  return `\n\n${formatEpicPromptContext(options.epicContext)}\n\nUse the parent epic context to keep fixes scoped to issue #${issueNum} while preserving integration with sibling work.`;
+}
+
 /** Per-issue context for the escalation wrapper. */
 type StageContext = {
   stage: RoutingStageName;
@@ -527,16 +553,19 @@ export async function processIssue(
   body: string,
   config: Config,
   session: SessionContext,
-  trackerOverride?: EscalationTracker,
+  trackerOrOptions?: EscalationTracker | PipelineOptions,
+  maybeOptions?: PipelineOptions,
 ): Promise<PipelineResult> {
   const startTime = Date.now();
   const projectDir = process.cwd();
   const stepCosts: StepCost[] = [];
   const stepsCompleted: string[] = [];
   const escalationEvents: EscalationEvent[] = [];
+  const { trackerOverride, options: pipelineOptions } = resolvePipelineOptions(trackerOrOptions, maybeOptions);
   const tracker = trackerOverride ?? new EscalationTracker({
     statePath: defaultEscalationStatePath(projectDir),
   });
+  const epicOption = epicPromptOption(pipelineOptions);
   let turnCounter = 0;
   const stageCtx = (stage: RoutingStageName): StageContext => ({
     stage,
@@ -600,41 +629,12 @@ export async function processIssue(
   const planFileInSession = join(session.logsDir, `plan-issue-${issueNum}.json`);
   if (!config.dryRun) {
     try {
-      const planPrompt = `Analyze this GitHub issue and produce a structured implementation plan.
-
-Issue #${issueNum}: ${title}
-
-${body}
-
-Write a JSON file to: plan-issue-${issueNum}.json
-
-The file must contain ONLY valid JSON with this exact schema:
-
-{
-  "summary": "One-line description of what needs to be done",
-  "files": ["src/path/to/file.ts", "..."],
-  "implementation": "Concise step-by-step plan. What to create, modify, wire up. No issue restatement.",
-  "testing": {
-    "needed": true,
-    "reason": "Why tests are or aren't needed for this change"
-  },
-  "verification": {
-    "needed": false,
-    "method": "playwright",
-    "command": "optional shell command for script/cli/boot/api methods",
-    "instructions": "If needed: specific steps to verify the feature. If not needed: omit this field.",
-    "reason": "Why verification is or isn't needed"
-  }
-}
-
-Rules:
-- testing.needed: true if ANY code changes could affect behavior. false only for docs, config, or comments.
-- verification.needed: true if the issue changes behavior that can be validated at runtime.
-- verification.method: "playwright" for UI changes, "script" for validation scripts, "boot" for service startup checks, "cli" for CLI testing, "api" for API endpoint testing.
-- verification.command: required for script/cli/boot/api methods — the shell command to run. Exit code 0 = pass.
-- verification.instructions: for playwright method, list the exact playwright-cli commands to verify.
-- implementation: be concise and actionable. List files to modify and what to change in each.
-- Write ONLY the JSON file. Do not create any other files or make any code changes.`;
+      const planPrompt = buildIssuePlanPrompt({
+        issueNum,
+        title,
+        body,
+        ...epicOption,
+      });
 
       // Trace the plan prompt
       tracePrompt(session.name, issueNum, 'plan', planPrompt);
@@ -710,6 +710,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
       body,
       comments: issueComments.length > 0 ? issueComments : undefined,
       planContent: plan.implementation || undefined,
+      ...epicOption,
       visionContext: visionContext ?? undefined,
       projectContext: projectContext ?? undefined,
       previousResult: previousResult ?? undefined,
@@ -872,6 +873,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           body,
           comments: issueComments.length > 0 ? issueComments : undefined,
           baseBranch: config.baseBranch,
+          ...epicOption,
           visionContext: loadFileIfExists(join(projectDir, '.alpha-loop', 'vision.md')) ?? undefined,
         });
 
@@ -917,7 +919,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
       if (attempt < config.maxTestRetries) {
         const findings = formatGateFindings(reviewGate, 'Code Review');
-        const fixPrompt = `The code review for issue #${issueNum} found problems that need to be fixed.\n\n${findings}\n\nInstructions:\n1. Address each finding listed above\n2. Run tests to make sure nothing is broken\n3. Commit your fixes with: git commit -m "fix(#${issueNum}): address review findings"`;
+        const fixPrompt = `The code review for issue #${issueNum} found problems that need to be fixed.\n\n${findings}${formatEpicFixContext(pipelineOptions, issueNum)}\n\nInstructions:\n1. Address each finding listed above\n2. Run tests to make sure nothing is broken\n3. Commit your fixes with: git commit -m "fix(#${issueNum}): address review findings"`;
 
         // Trace review-fix prompt
         tracePrompt(session.name, issueNum, `review-fix-${attempt}`, fixPrompt);
@@ -990,6 +992,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
         verifyInstructions: plan.verification.instructions,
         verifyMethod: plan.verification.method,
         verifyCommand: plan.verification.command,
+        ...epicOption,
       });
       verifyOutput = verifyResult.output;
 
@@ -1028,7 +1031,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
             ? formatGateFindings(verifyGate, 'Verification')
             : `## Verification Findings (MUST FIX)\n\n${verifyOutput}`;
 
-          const fixPrompt = `Live verification failed for issue #${issueNum} (attempt ${attempt} of ${config.maxTestRetries}).\n\n${findings}\n\nInstructions:\n1. Read the verification findings and identify the ROOT CAUSE\n2. Fix ONLY code related to issue #${issueNum}\n3. Run tests to make sure nothing is broken\n4. Commit your fixes with: git commit -m "fix(#${issueNum}): address verification findings"`;
+          const fixPrompt = `Live verification failed for issue #${issueNum} (attempt ${attempt} of ${config.maxTestRetries}).\n\n${findings}${formatEpicFixContext(pipelineOptions, issueNum)}\n\nInstructions:\n1. Read the verification findings and identify the ROOT CAUSE\n2. Fix ONLY code related to issue #${issueNum}\n3. Run tests to make sure nothing is broken\n4. Commit your fixes with: git commit -m "fix(#${issueNum}): address verification findings"`;
 
           // Trace verify-fix prompt
           tracePrompt(session.name, issueNum, `verify-fix-${attempt}`, fixPrompt);
@@ -1337,12 +1340,14 @@ export async function processBatch(
   issues: Array<{ number: number; title: string; body: string }>,
   config: Config,
   session: SessionContext,
+  options: PipelineOptions = {},
 ): Promise<PipelineResult[]> {
   const startTime = Date.now();
   const projectDir = process.cwd();
   const stepCosts: StepCost[] = [];
   const stepsCompleted: string[] = [];
   const issueNums = issues.map((i) => i.number);
+  const epicOption = epicPromptOption(options);
 
   mkdirSync(session.logsDir, { recursive: true });
   const logFile = join(session.logsDir, `batch-${issueNums.join('-')}.log`);
@@ -1424,7 +1429,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
   if (!config.dryRun) {
     try {
-      const planPrompt = resumeNote + buildBatchPlanPrompt({ issues: batchIssues });
+      const planPrompt = resumeNote + buildBatchPlanPrompt({ issues: batchIssues, ...epicOption });
       tracePrompt(session.name, issues[0].number, 'batch-plan', planPrompt);
 
       const planResult = await spawnAgent({
@@ -1483,6 +1488,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     const implementPrompt = resumeNote + buildBatchImplementPrompt({
       issues: batchIssues,
       planContent: allPlans,
+      ...epicOption,
       visionContext: visionContext ?? undefined,
       projectContext: projectContext ?? undefined,
       learningContext: learningContext || undefined,
@@ -1628,6 +1634,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
         const reviewPrompt = buildBatchReviewPrompt({
           issues: batchIssues,
           baseBranch: config.baseBranch,
+          ...epicOption,
           visionContext: loadFileIfExists(join(projectDir, '.alpha-loop', 'vision.md')) ?? undefined,
         });
 
@@ -1668,7 +1675,10 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
       if (attempt < config.maxTestRetries) {
         const findings = formatGateFindings(reviewGate, 'Code Review');
-        const fixPrompt = `The code review for the batch found problems that need to be fixed.\n\n${findings}\n\nInstructions:\n1. Address each finding listed above\n2. Run tests to make sure nothing is broken\n3. Commit your fixes`;
+        const epicFixContext = options.epicContext
+          ? `\n\n${formatEpicPromptContext(options.epicContext)}\n\nUse the parent epic context to keep batch fixes scoped while preserving sibling integration.`
+          : '';
+        const fixPrompt = `The code review for the batch found problems that need to be fixed.\n\n${findings}${epicFixContext}\n\nInstructions:\n1. Address each finding listed above\n2. Run tests to make sure nothing is broken\n3. Commit your fixes`;
 
         tracePrompt(session.name, issues[0].number, `batch-review-fix-${attempt}`, fixPrompt);
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -9,6 +9,7 @@ export type ImplementPromptOptions = {
   body: string;
   comments?: Array<{ author: string; body: string; createdAt: string }>;
   planContent?: string;
+  epicContext?: EpicPromptContext;
   visionContext?: string;
   projectContext?: string;
   previousResult?: string;
@@ -21,7 +22,20 @@ export type ReviewPromptOptions = {
   body: string;
   comments?: Array<{ author: string; body: string; createdAt: string }>;
   baseBranch: string;
+  epicContext?: EpicPromptContext;
   visionContext?: string;
+};
+
+export type EpicPromptContext = {
+  number: number;
+  title: string;
+  bodySummary: string;
+  acceptanceCriteria: string[];
+  subIssues: Array<{
+    issueNum: number;
+    title?: string;
+    checked: boolean;
+  }>;
 };
 
 /** A single issue within a batch. */
@@ -34,11 +48,13 @@ export type BatchIssue = {
 
 export type BatchPlanPromptOptions = {
   issues: BatchIssue[];
+  epicContext?: EpicPromptContext;
 };
 
 export type BatchImplementPromptOptions = {
   issues: BatchIssue[];
   planContent?: string;
+  epicContext?: EpicPromptContext;
   visionContext?: string;
   projectContext?: string;
   learningContext?: string;
@@ -47,7 +63,15 @@ export type BatchImplementPromptOptions = {
 export type BatchReviewPromptOptions = {
   issues: BatchIssue[];
   baseBranch: string;
+  epicContext?: EpicPromptContext;
   visionContext?: string;
+};
+
+export type IssuePlanPromptOptions = {
+  issueNum: number;
+  title: string;
+  body: string;
+  epicContext?: EpicPromptContext;
 };
 
 export type LearnPromptOptions = {
@@ -63,17 +87,127 @@ export type LearnPromptOptions = {
   body?: string;
 };
 
+function normalizeBulletText(text: string): string {
+  return text.trim().replace(/^[-*]\s+/, '').trim();
+}
+
+export function formatEpicPromptContext(context: EpicPromptContext): string {
+  const lines: string[] = [
+    '## Parent Epic Context',
+    '',
+    `Epic #${context.number}: ${context.title}`,
+    '',
+    '### Goal / Body Summary',
+    context.bodySummary.trim() || '(no parent epic body summary available)',
+    '',
+    '### Acceptance Criteria',
+  ];
+
+  if (context.acceptanceCriteria.length > 0) {
+    for (const criterion of context.acceptanceCriteria) {
+      lines.push(`- ${normalizeBulletText(criterion)}`);
+    }
+  } else {
+    lines.push('- (none identified in parent epic body)');
+  }
+
+  lines.push('', '### Ordered Sub-Issue Checklist');
+  if (context.subIssues.length > 0) {
+    context.subIssues.forEach((issue, index) => {
+      const status = issue.checked ? '[x]' : '[ ]';
+      const title = issue.title ? ` ${issue.title}` : '';
+      lines.push(`${index + 1}. ${status} #${issue.issueNum}${title}`);
+    });
+  } else {
+    lines.push('(no sub-issues found)');
+  }
+
+  return lines.join('\n');
+}
+
+function appendEpicContextSection(
+  sections: string[],
+  epicContext: EpicPromptContext | undefined,
+  guidance?: string[],
+): void {
+  if (!epicContext) return;
+  sections.push('', '', formatEpicPromptContext(epicContext));
+  if (guidance && guidance.length > 0) {
+    sections.push('', '### Epic Scope Guidance', ...guidance.map((line) => `- ${line}`));
+  }
+}
+
+/**
+ * Build the planning prompt for a single issue.
+ */
+export function buildIssuePlanPrompt(options: IssuePlanPromptOptions): string {
+  const { issueNum, title, body, epicContext } = options;
+
+  const sections: string[] = [
+    'Analyze this GitHub issue and produce a structured implementation plan.',
+    '',
+    `Issue #${issueNum}: ${title}`,
+    '',
+    body,
+  ];
+
+  appendEpicContextSection(sections, epicContext, [
+    `Plan only the work needed for issue #${issueNum}; use sibling items to understand dependencies and integration boundaries.`,
+  ]);
+
+  sections.push(
+    '',
+    '',
+    `Write a JSON file to: plan-issue-${issueNum}.json`,
+    '',
+    'The file must contain ONLY valid JSON with this exact schema:',
+    '',
+    '{',
+    '  "summary": "One-line description of what needs to be done",',
+    '  "files": ["src/path/to/file.ts", "..."],',
+    '  "implementation": "Concise step-by-step plan. What to create, modify, wire up. No issue restatement.",',
+    '  "testing": {',
+    '    "needed": true,',
+    '    "reason": "Why tests are or aren\'t needed for this change"',
+    '  },',
+    '  "verification": {',
+    '    "needed": false,',
+    '    "method": "playwright",',
+    '    "command": "optional shell command for script/cli/boot/api methods",',
+    '    "instructions": "If needed: specific steps to verify the feature. If not needed: omit this field.",',
+    '    "reason": "Why verification is or isn\'t needed"',
+    '  }',
+    '}',
+    '',
+    'Rules:',
+    '- testing.needed: true if ANY code changes could affect behavior. false only for docs, config, or comments.',
+    '- verification.needed: true if the issue changes behavior that can be validated at runtime.',
+    '- verification.method: "playwright" for UI changes, "script" for validation scripts, "boot" for service startup checks, "cli" for CLI testing, "api" for API endpoint testing.',
+    '- verification.command: required for script/cli/boot/api methods - the shell command to run. Exit code 0 = pass.',
+    '- verification.instructions: for playwright method, list the exact playwright-cli commands to verify.',
+    '- implementation: be concise and actionable. List files to modify and what to change in each.',
+    '- Write ONLY the JSON file. Do not create any other files or make any code changes.',
+  );
+
+  return sections.join('\n');
+}
+
 /**
  * Build the implementation prompt for an AI agent.
  */
 export function buildImplementPrompt(options: ImplementPromptOptions): string {
-  const { issueNum, title, body, comments, planContent, visionContext, projectContext, previousResult, learningContext } = options;
+  const { issueNum, title, body, comments, planContent, epicContext, visionContext, projectContext, previousResult, learningContext } = options;
 
   const sections: string[] = [
     `Implement GitHub issue #${issueNum}: ${title}`,
     '',
     body,
   ];
+
+  appendEpicContextSection(sections, epicContext, [
+    `Keep the implementation narrowly scoped to issue #${issueNum}. Do not implement sibling checklist items unless this issue explicitly requires shared integration work.`,
+    'Preserve contracts that sibling sub-issues depend on, and call out any integration assumptions in your final notes.',
+  ]);
 
   if (comments && comments.length > 0) {
     sections.push('', '', '## Discussion (issue comments)');
@@ -131,7 +265,7 @@ export function buildImplementPrompt(options: ImplementPromptOptions): string {
  * The agent writes one plan JSON per issue.
  */
 export function buildBatchPlanPrompt(options: BatchPlanPromptOptions): string {
-  const { issues } = options;
+  const { issues, epicContext } = options;
 
   const issueList = issues.map((i) => {
     let entry = `### Issue #${i.issueNum}: ${i.title}\n${i.body || '(no description)'}`;
@@ -145,8 +279,11 @@ export function buildBatchPlanPrompt(options: BatchPlanPromptOptions): string {
   }).join('\n\n');
 
   const fileList = issues.map((i) => `plan-issue-${i.issueNum}.json`).join(', ');
+  const epicSection = epicContext
+    ? `\n\n${formatEpicPromptContext(epicContext)}\n\n### Epic Scope Guidance\n- Plan only the listed batch issues. Use unchecked sibling items to identify integration boundaries, not to expand this batch scope.`
+    : '';
 
-  return `Analyze the following GitHub issues and produce a structured implementation plan for EACH one.
+  return `Analyze the following GitHub issues and produce a structured implementation plan for EACH one.${epicSection}
 
 ## Issues to Plan
 
@@ -194,7 +331,7 @@ Each file must contain ONLY valid JSON with this exact schema:
  * Build a batch implementation prompt — implements all issues in a single agent call.
  */
 export function buildBatchImplementPrompt(options: BatchImplementPromptOptions): string {
-  const { issues, planContent, visionContext, projectContext, learningContext } = options;
+  const { issues, planContent, epicContext, visionContext, projectContext, learningContext } = options;
 
   const issueList = issues.map((i) => {
     let entry = `### Issue #${i.issueNum}: ${i.title}\n${i.body || '(no description)'}`;
@@ -216,6 +353,11 @@ export function buildBatchImplementPrompt(options: BatchImplementPromptOptions):
     '',
     issueList,
   ];
+
+  appendEpicContextSection(sections, epicContext, [
+    'Keep this batch limited to the listed issues. Leave other sibling checklist items for their own runs unless a shared integration contract must be preserved.',
+    'When touching shared code, maintain compatibility with sibling work described in the epic checklist.',
+  ]);
 
   if (planContent) {
     sections.push('', '', '## Implementation Plans', planContent);
@@ -263,7 +405,7 @@ export function buildBatchImplementPrompt(options: BatchImplementPromptOptions):
  * Build a batch review prompt — reviews all issues' changes in a single agent call.
  */
 export function buildBatchReviewPrompt(options: BatchReviewPromptOptions): string {
-  const { issues, baseBranch, visionContext } = options;
+  const { issues, baseBranch, epicContext, visionContext } = options;
 
   const issueList = issues.map((i) => {
     let entry = `### Issue #${i.issueNum}: ${i.title}\n${i.body || '(no description)'}`;
@@ -285,6 +427,11 @@ export function buildBatchReviewPrompt(options: BatchReviewPromptOptions): strin
     '',
     issueList,
   ];
+
+  appendEpicContextSection(sections, epicContext, [
+    'Use the epic context to judge integration-sensitive work across siblings.',
+    'Do not block this batch for unrelated sibling checklist items that were intentionally left for separate runs.',
+  ]);
 
   if (visionContext) {
     sections.push('', '', '## Product Vision (guide your review decisions)', visionContext);
@@ -365,7 +512,7 @@ export function buildBatchReviewPrompt(options: BatchReviewPromptOptions): strin
  * Build the code review prompt for an AI agent.
  */
 export function buildReviewPrompt(options: ReviewPromptOptions): string {
-  const { issueNum, title, body, comments, baseBranch, visionContext } = options;
+  const { issueNum, title, body, comments, baseBranch, epicContext, visionContext } = options;
 
   const sections: string[] = [
     `Review the code changes for issue #${issueNum}: ${title}`,
@@ -375,6 +522,11 @@ export function buildReviewPrompt(options: ReviewPromptOptions): string {
     'Original requirements:',
     body,
   ];
+
+  appendEpicContextSection(sections, epicContext, [
+    'Use the epic context to judge whether this child issue preserves integration with sibling work.',
+    `Do not fail issue #${issueNum} for parent checklist items that belong to other sub-issues unless this change breaks their integration contract.`,
+  ]);
 
   if (comments && comments.length > 0) {
     sections.push('', 'Discussion (issue comments):');
@@ -472,6 +624,7 @@ export type SessionReviewPromptOptions = {
     testsPassing: boolean;
   }>;
   includeSecurityScan: boolean;
+  epicContext?: EpicPromptContext;
   visionContext?: string;
 };
 
@@ -481,7 +634,7 @@ export type SessionReviewPromptOptions = {
  * cross-issue integration problems that per-issue reviews miss.
  */
 export function buildSessionReviewPrompt(options: SessionReviewPromptOptions): string {
-  const { sessionName, baseBranch, issuesSummary, includeSecurityScan, visionContext } = options;
+  const { sessionName, baseBranch, issuesSummary, includeSecurityScan, epicContext, visionContext } = options;
 
   const issuesList = issuesSummary.map((i) =>
     `- #${i.issueNum}: ${i.title} — ${i.status}${i.testsPassing ? '' : ' (tests failing)'}`,
@@ -523,6 +676,10 @@ export function buildSessionReviewPrompt(options: SessionReviewPromptOptions): s
     '- Dead code (functions, imports, variables) that no remaining code references',
     '- Missing error handling at integration boundaries',
   ];
+
+  appendEpicContextSection(sections, epicContext, [
+    'Use this parent epic context to catch cross-issue integration problems across the processed sub-issues.',
+  ]);
 
   sections.push(
     '',

--- a/src/lib/verify.ts
+++ b/src/lib/verify.ts
@@ -12,6 +12,7 @@ import { exec } from './shell.js';
 import { log } from './logger.js';
 import { spawnAgent } from './agent.js';
 import type { Config } from './config.js';
+import { formatEpicPromptContext, type EpicPromptContext } from './prompts.js';
 
 export type VerifyResult = {
   passed: boolean;
@@ -104,8 +105,10 @@ export async function runVerify(options: {
   verifyMethod?: VerifyMethod;
   /** Shell command for 'script' method verification. */
   verifyCommand?: string;
+  /** Parent epic context for sub-issue verification. */
+  epicContext?: EpicPromptContext;
 }): Promise<VerifyResult> {
-  const { worktree, logFile, issueNum, title, body, config, sessionDir, verifyInstructions, verifyMethod, verifyCommand } = options;
+  const { worktree, logFile, issueNum, title, body, config, sessionDir, verifyInstructions, verifyMethod, verifyCommand, epicContext } = options;
 
   if (config.skipVerify) {
     log.info('Verification skipped (skipVerify=true)');
@@ -199,6 +202,8 @@ export async function runVerify(options: {
 ## Issue: ${title}
 
 ${body}
+
+${epicContext ? `${formatEpicPromptContext(epicContext)}\n\nUse the parent epic context to verify integration-sensitive behavior while keeping judgment focused on issue #${issueNum}.\n` : ''}
 
 ## What Changed
 ${diffStat.stdout || 'No diff available'}

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -24,10 +24,19 @@ jest.mock('../../src/lib/config', () => ({
 jest.mock('../../src/lib/github', () => ({
   pollIssues: jest.fn(),
   listMilestones: jest.fn().mockReturnValue([]),
+  listEpics: jest.fn().mockReturnValue([]),
+  getEpicSubIssues: jest.fn().mockReturnValue([]),
+  getIssueWithComments: jest.fn(),
+  getMergedPRForIssue: jest.fn(),
+  updateEpicChecklist: jest.fn(),
+  commentIssue: jest.fn(),
+  closeIssue: jest.fn(),
+  labelIssue: jest.fn(),
 }));
 
 jest.mock('../../src/lib/pipeline', () => ({
   processIssue: jest.fn(),
+  processBatch: jest.fn(),
 }));
 
 jest.mock('../../src/lib/session', () => ({
@@ -68,14 +77,17 @@ jest.mock('node:fs', () => ({
 
 import { exec } from '../../src/lib/shell';
 import { loadConfig } from '../../src/lib/config';
-import { pollIssues } from '../../src/lib/github';
-import { processIssue } from '../../src/lib/pipeline';
+import { pollIssues, getIssueWithComments, updateEpicChecklist } from '../../src/lib/github';
+import { processIssue, processBatch } from '../../src/lib/pipeline';
 import { createSession, finalizeSession } from '../../src/lib/session';
 
 const mockExec = exec as jest.MockedFunction<typeof exec>;
 const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
 const mockPollIssues = pollIssues as jest.MockedFunction<typeof pollIssues>;
+const mockGetIssueWithComments = getIssueWithComments as jest.MockedFunction<typeof getIssueWithComments>;
+const mockUpdateEpicChecklist = updateEpicChecklist as jest.MockedFunction<typeof updateEpicChecklist>;
 const mockProcessIssue = processIssue as jest.MockedFunction<typeof processIssue>;
+const mockProcessBatch = processBatch as jest.MockedFunction<typeof processBatch>;
 const mockCreateSession = createSession as jest.MockedFunction<typeof createSession>;
 const mockFinalizeSession = finalizeSession as jest.MockedFunction<typeof finalizeSession>;
 
@@ -136,7 +148,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 
   mockExec.mockReturnValue({ stdout: '/usr/bin/tool', stderr: '', exitCode: 0 });
-  mockLoadConfig.mockReturnValue(makeConfig() as any);
+  mockLoadConfig.mockImplementation((overrides: any = {}) => makeConfig(overrides) as any);
   mockCreateSession.mockReturnValue({
     name: 'session/20260330-143000',
     branch: 'session/20260330-143000',
@@ -146,6 +158,8 @@ beforeEach(() => {
   });
   mockFinalizeSession.mockResolvedValue(null);
   mockPollIssues.mockReturnValue([]);
+  mockGetIssueWithComments.mockReturnValue(null);
+  mockProcessBatch.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -224,5 +238,112 @@ describe('runCommand', () => {
     expect(mockExec).toHaveBeenCalledWith('command -v "gh"');
     expect(mockExec).toHaveBeenCalledWith('command -v "git"');
     expect(mockExec).toHaveBeenCalledWith('command -v "claude"');
+  });
+
+  test('passes compact parent epic context to sub-issue processing for --epic runs', async () => {
+    const epicBody = `## Goal
+Ship the epic as a coordinated set of sub-issues.
+
+## Acceptance Criteria
+- [ ] Parent agents understand the epic
+- [ ] Sibling ordering is visible
+
+## Checklist
+- [x] #188 Add epic issue template during init
+- [ ] #189 Inject parent epic context into sub-issue agents`;
+
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => {
+      if (issueNum === 195) {
+        return { number: 195, title: 'Parent Epic', body: epicBody, labels: ['epic'] };
+      }
+      if (issueNum === 189) {
+        return { number: 189, title: 'Child Issue', body: 'Child body', labels: ['ready'] };
+      }
+      return null;
+    });
+    mockProcessIssue.mockResolvedValue({
+      issueNum: 189,
+      title: 'Child Issue',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    });
+
+    await runCommand({ epic: 195, dryRun: true });
+
+    expect(mockGetIssueWithComments.mock.calls.filter((call) => call[1] === 195)).toHaveLength(1);
+    const options = mockProcessIssue.mock.calls[0][5] as any;
+    expect(options.epicContext).toEqual(expect.objectContaining({
+      number: 195,
+      title: 'Parent Epic',
+      bodySummary: expect.stringContaining('Ship the epic'),
+      acceptanceCriteria: expect.arrayContaining(['- [ ] Parent agents understand the epic']),
+    }));
+    expect(options.epicContext.subIssues).toEqual([
+      { issueNum: 188, title: 'Add epic issue template during init', checked: true },
+      { issueNum: 189, title: 'Inject parent epic context into sub-issue agents', checked: false },
+    ]);
+  });
+
+  test('passes parent epic context to batch processing for --epic batch runs', async () => {
+    const epicBody = `## Goal
+Coordinate batch children.
+
+## Acceptance Criteria
+- [ ] Batch agents understand the epic
+
+## Checklist
+- [ ] #189 First child
+- [ ] #190 Second child`;
+
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => {
+      if (issueNum === 195) {
+        return { number: 195, title: 'Parent Epic', body: epicBody, labels: ['epic'] };
+      }
+      if (issueNum === 189) {
+        return { number: 189, title: 'First child', body: 'First body', labels: ['ready'] };
+      }
+      if (issueNum === 190) {
+        return { number: 190, title: 'Second child', body: 'Second body', labels: ['ready'] };
+      }
+      return null;
+    });
+    mockProcessBatch.mockResolvedValue([
+      { issueNum: 189, title: 'First child', status: 'success', testsPassing: true, verifyPassing: true, verifySkipped: true, duration: 30, filesChanged: 1 },
+      { issueNum: 190, title: 'Second child', status: 'success', testsPassing: true, verifyPassing: true, verifySkipped: true, duration: 30, filesChanged: 1 },
+    ]);
+
+    await runCommand({ epic: 195, dryRun: true, batch: true });
+
+    const options = mockProcessBatch.mock.calls[0][3] as any;
+    expect(options.epicContext).toEqual(expect.objectContaining({
+      number: 195,
+      title: 'Parent Epic',
+      bodySummary: expect.stringContaining('Coordinate batch children'),
+    }));
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+  });
+
+  test('does not pass epic context for flat runs', async () => {
+    mockPollIssues.mockReturnValue([
+      { number: 42, title: 'Test issue', body: 'Body', labels: ['ready'] },
+    ]);
+    mockProcessIssue.mockResolvedValue({
+      issueNum: 42,
+      title: 'Test issue',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    });
+
+    await runCommand({});
+
+    expect(mockProcessIssue.mock.calls[0]).toHaveLength(5);
   });
 });

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -82,11 +82,13 @@ jest.mock('../../src/lib/config', () => ({
 }));
 
 jest.mock('../../src/lib/prompts', () => ({
+  buildIssuePlanPrompt: jest.fn().mockReturnValue('structured implementation plan prompt'),
   buildImplementPrompt: jest.fn().mockReturnValue('implement prompt'),
   buildReviewPrompt: jest.fn().mockReturnValue('review prompt'),
   buildBatchPlanPrompt: jest.fn().mockReturnValue('batch plan prompt'),
   buildBatchImplementPrompt: jest.fn().mockReturnValue('batch implement prompt'),
   buildBatchReviewPrompt: jest.fn().mockReturnValue('batch review prompt'),
+  formatEpicPromptContext: jest.fn().mockReturnValue('## Parent Epic Context\nEpic #195: Parent epic'),
   buildAssumptionsPrompt: jest.fn().mockReturnValue('assumptions prompt'),
 }));
 
@@ -103,8 +105,11 @@ import { spawnAgent } from '../../src/lib/agent';
 import { setupWorktree, cleanupWorktree } from '../../src/lib/worktree';
 import { labelIssue, commentIssue, createPR, mergePR, updateProjectStatus } from '../../src/lib/github';
 import { runTests } from '../../src/lib/testing';
+import { runVerify } from '../../src/lib/verify';
 import { extractLearnings, getLearningContext } from '../../src/lib/learning';
 import { saveResult, getPreviousResult } from '../../src/lib/session';
+import { buildIssuePlanPrompt, buildImplementPrompt, buildReviewPrompt, buildBatchPlanPrompt, buildBatchImplementPrompt, buildBatchReviewPrompt } from '../../src/lib/prompts';
+import { writeTraceToSubdir } from '../../src/lib/traces';
 import type { Config } from '../../src/lib/config';
 
 const mockExec = exec as jest.MockedFunction<typeof exec>;
@@ -114,10 +119,28 @@ const mockCleanupWorktree = cleanupWorktree as jest.MockedFunction<typeof cleanu
 const mockCreatePR = createPR as jest.MockedFunction<typeof createPR>;
 const mockMergePR = mergePR as jest.MockedFunction<typeof mergePR>;
 const mockRunTests = runTests as jest.MockedFunction<typeof runTests>;
+const mockRunVerify = runVerify as jest.MockedFunction<typeof runVerify>;
 const mockExtractLearnings = extractLearnings as jest.MockedFunction<typeof extractLearnings>;
 const mockGetLearningContext = getLearningContext as jest.MockedFunction<typeof getLearningContext>;
 const mockSaveResult = saveResult as jest.MockedFunction<typeof saveResult>;
 const mockGetPreviousResult = getPreviousResult as jest.MockedFunction<typeof getPreviousResult>;
+const mockBuildIssuePlanPrompt = buildIssuePlanPrompt as jest.MockedFunction<typeof buildIssuePlanPrompt>;
+const mockBuildImplementPrompt = buildImplementPrompt as jest.MockedFunction<typeof buildImplementPrompt>;
+const mockBuildReviewPrompt = buildReviewPrompt as jest.MockedFunction<typeof buildReviewPrompt>;
+const mockBuildBatchPlanPrompt = buildBatchPlanPrompt as jest.MockedFunction<typeof buildBatchPlanPrompt>;
+const mockBuildBatchImplementPrompt = buildBatchImplementPrompt as jest.MockedFunction<typeof buildBatchImplementPrompt>;
+const mockBuildBatchReviewPrompt = buildBatchReviewPrompt as jest.MockedFunction<typeof buildBatchReviewPrompt>;
+const mockWriteTraceToSubdir = writeTraceToSubdir as jest.MockedFunction<typeof writeTraceToSubdir>;
+
+const epicContext = {
+  number: 195,
+  title: 'Parent epic',
+  bodySummary: 'Parent body summary',
+  acceptanceCriteria: ['- [ ] Parent AC'],
+  subIssues: [
+    { issueNum: 42, title: 'Test issue', checked: false },
+  ],
+};
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
@@ -188,6 +211,11 @@ function makeSession(): SessionContext {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  const { existsSync, readFileSync } = require('node:fs');
+  (existsSync as jest.Mock).mockReset();
+  (existsSync as jest.Mock).mockReturnValue(false);
+  (readFileSync as jest.Mock).mockReset();
+  (readFileSync as jest.Mock).mockReturnValue('');
 
   // Default: everything succeeds
   mockExec.mockReturnValue({ stdout: '', stderr: '', exitCode: 0 });
@@ -223,6 +251,79 @@ describe('processIssue', () => {
     expect(mockExtractLearnings).toHaveBeenCalled();
     expect(mockSaveResult).toHaveBeenCalled();
     expect(mockCleanupWorktree).toHaveBeenCalled();
+  });
+
+  test('passes epic context into plan, implementation, and review prompt builders', async () => {
+    await processIssue(42, 'Test issue', 'Issue body', makeConfig(), makeSession(), { epicContext });
+
+    expect(mockBuildIssuePlanPrompt).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
+    expect(mockBuildImplementPrompt).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
+    expect(mockBuildReviewPrompt).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
+  });
+
+  test('does not pass epic context when pipeline options are omitted', async () => {
+    await processIssue(42, 'Test issue', 'Issue body', makeConfig(), makeSession());
+
+    expect(mockBuildIssuePlanPrompt.mock.calls[0][0]).not.toHaveProperty('epicContext');
+    expect(mockBuildImplementPrompt.mock.calls[0][0]).not.toHaveProperty('epicContext');
+    expect(mockBuildReviewPrompt.mock.calls[0][0]).not.toHaveProperty('epicContext');
+  });
+
+  test('prompt traces contain epic context only when provided', async () => {
+    mockBuildIssuePlanPrompt.mockImplementationOnce((options: any) =>
+      options.epicContext ? 'plan prompt\n## Parent Epic Context' : 'plan prompt',
+    );
+    mockBuildImplementPrompt.mockImplementationOnce((options: any) =>
+      options.epicContext ? 'implement prompt\n## Parent Epic Context' : 'implement prompt',
+    );
+    mockBuildReviewPrompt.mockImplementationOnce((options: any) =>
+      options.epicContext ? 'review prompt\n## Parent Epic Context' : 'review prompt',
+    );
+
+    await processIssue(42, 'Test issue', 'Issue body', makeConfig(), makeSession(), { epicContext });
+
+    const promptTraceBodies = mockWriteTraceToSubdir.mock.calls
+      .filter((call) => call[1] === 'prompts')
+      .map((call) => String(call[3]));
+
+    expect(promptTraceBodies.some((body) => body.includes('## Parent Epic Context'))).toBe(true);
+
+    jest.clearAllMocks();
+    mockBuildIssuePlanPrompt.mockReturnValue('structured implementation plan prompt');
+    mockBuildImplementPrompt.mockReturnValue('implement prompt');
+    mockBuildReviewPrompt.mockReturnValue('review prompt');
+
+    await processIssue(42, 'Test issue', 'Issue body', makeConfig(), makeSession());
+
+    const nonEpicPromptTraceBodies = mockWriteTraceToSubdir.mock.calls
+      .filter((call) => call[1] === 'prompts')
+      .map((call) => String(call[3]));
+    expect(nonEpicPromptTraceBodies.every((body) => !body.includes('## Parent Epic Context'))).toBe(true);
+  });
+
+  test('passes epic context into runVerify when plan requires verification', async () => {
+    const { existsSync, readFileSync } = require('node:fs');
+    const mockExistsSync = existsSync as jest.MockedFunction<typeof import('node:fs').existsSync>;
+    const mockReadFileSync = readFileSync as jest.MockedFunction<typeof import('node:fs').readFileSync>;
+
+    mockExistsSync.mockImplementation((path: any) => String(path).includes('plan-issue-42.json'));
+    mockReadFileSync.mockImplementation((path: any) => {
+      if (String(path).includes('plan-issue-42.json')) {
+        return JSON.stringify({
+          summary: 'Plan',
+          files: ['src/index.ts'],
+          implementation: 'Implement it',
+          testing: { needed: false, reason: 'Covered by verification' },
+          verification: { needed: true, method: 'playwright', instructions: 'Open app', reason: 'Runtime behavior' },
+        });
+      }
+      return '';
+    });
+    mockRunVerify.mockResolvedValue({ passed: true, skipped: false, output: 'Status: PASS' });
+
+    await processIssue(42, 'Test issue', 'Issue body', makeConfig({ skipVerify: false }), makeSession(), { epicContext });
+
+    expect(mockRunVerify).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
   });
 
   test('returns failure and labels failed when implementation fails', async () => {
@@ -664,6 +765,14 @@ describe('processBatch', () => {
     { number: 10, title: 'Issue 10', body: 'Body 10' },
     { number: 11, title: 'Issue 11', body: 'Body 11' },
   ];
+
+  test('passes epic context into batch plan, implementation, and review prompt builders', async () => {
+    await processBatch(batchIssues, makeConfig({ batch: true }), makeSession(), { epicContext });
+
+    expect(mockBuildBatchPlanPrompt).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
+    expect(mockBuildBatchImplementPrompt).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
+    expect(mockBuildBatchReviewPrompt).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
+  });
 
   test('skips auto-merge when tests are failing', async () => {
     mockRunTests.mockReturnValue({ passed: false, output: 'Tests failed' });

--- a/tests/lib/prompts.test.ts
+++ b/tests/lib/prompts.test.ts
@@ -1,4 +1,68 @@
-import { buildImplementPrompt, buildReviewPrompt, buildLearnPrompt, buildBatchPlanPrompt, buildBatchReviewPrompt, buildSessionReviewPrompt } from '../../src/lib/prompts';
+import {
+  buildImplementPrompt,
+  buildReviewPrompt,
+  buildLearnPrompt,
+  buildIssuePlanPrompt,
+  buildBatchPlanPrompt,
+  buildBatchImplementPrompt,
+  buildBatchReviewPrompt,
+  buildSessionReviewPrompt,
+  formatEpicPromptContext,
+  type EpicPromptContext,
+} from '../../src/lib/prompts';
+
+const epicContext: EpicPromptContext = {
+  number: 195,
+  title: 'Improve epic execution',
+  bodySummary: 'Make sub-issue agents aware of the parent epic goal.',
+  acceptanceCriteria: [
+    '- [ ] Agents receive parent context',
+    '- [ ] Sibling checklist order is preserved',
+  ],
+  subIssues: [
+    { issueNum: 188, title: 'Add epic issue template during init', checked: true },
+    { issueNum: 189, title: 'Inject parent epic context into sub-issue agents', checked: false },
+  ],
+};
+
+describe('formatEpicPromptContext', () => {
+  test('renders parent title, summary, acceptance criteria, and ordered checklist', () => {
+    const prompt = formatEpicPromptContext(epicContext);
+
+    expect(prompt).toContain('## Parent Epic Context');
+    expect(prompt).toContain('Epic #195: Improve epic execution');
+    expect(prompt).toContain('Make sub-issue agents aware of the parent epic goal.');
+    expect(prompt).toContain('- [ ] Agents receive parent context');
+    expect(prompt).toContain('1. [x] #188 Add epic issue template during init');
+    expect(prompt).toContain('2. [ ] #189 Inject parent epic context into sub-issue agents');
+  });
+});
+
+describe('buildIssuePlanPrompt', () => {
+  test('includes parent epic context when provided', () => {
+    const prompt = buildIssuePlanPrompt({
+      issueNum: 189,
+      title: 'Inject parent context',
+      body: 'Child issue body',
+      epicContext,
+    });
+
+    expect(prompt).toContain('Analyze this GitHub issue and produce a structured implementation plan.');
+    expect(prompt).toContain('## Parent Epic Context');
+    expect(prompt).toContain('Epic #195: Improve epic execution');
+    expect(prompt).toContain('Ordered Sub-Issue Checklist');
+  });
+
+  test('omits parent epic context when not provided', () => {
+    const prompt = buildIssuePlanPrompt({
+      issueNum: 42,
+      title: 'Flat issue',
+      body: 'Child issue body',
+    });
+
+    expect(prompt).not.toContain('## Parent Epic Context');
+  });
+});
 
 describe('buildImplementPrompt', () => {
   test('includes issue number, title, and body', () => {
@@ -52,6 +116,20 @@ describe('buildImplementPrompt', () => {
     expect(prompt).toContain('## Before You Start');
     expect(prompt).toContain('## After Implementing');
     expect(prompt).toContain('git commit -m "feat: Add login page (closes #42)"');
+  });
+
+  test('includes parent epic context and narrow scope guidance when provided', () => {
+    const prompt = buildImplementPrompt({
+      issueNum: 189,
+      title: 'Inject parent context',
+      body: 'Child issue body',
+      epicContext,
+    });
+
+    expect(prompt).toContain('## Parent Epic Context');
+    expect(prompt).toContain('Epic #195: Improve epic execution');
+    expect(prompt).toContain('Keep the implementation narrowly scoped to issue #189');
+    expect(prompt).toContain('Preserve contracts that sibling sub-issues depend on');
   });
 });
 
@@ -145,6 +223,19 @@ describe('buildReviewPrompt', () => {
     expect(prompt).toContain('review-issue-42.json');
     expect(prompt).toContain('"passed"');
     expect(prompt).toContain('"findings"');
+  });
+
+  test('includes parent epic context when provided', () => {
+    const prompt = buildReviewPrompt({
+      issueNum: 189,
+      title: 'Inject parent context',
+      body: 'Child issue body',
+      baseBranch: 'master',
+      epicContext,
+    });
+
+    expect(prompt).toContain('## Parent Epic Context');
+    expect(prompt).toContain('judge whether this child issue preserves integration');
   });
 });
 
@@ -242,6 +333,28 @@ describe('buildBatchPlanPrompt', () => {
     });
     expect(prompt).toContain('grep the codebase to verify it exists');
   });
+
+  test('includes parent epic context for epic batches', () => {
+    const prompt = buildBatchPlanPrompt({
+      issues: [{ issueNum: 189, title: 'Test', body: 'Body' }],
+      epicContext,
+    });
+
+    expect(prompt).toContain('## Parent Epic Context');
+    expect(prompt).toContain('Plan only the listed batch issues');
+  });
+});
+
+describe('buildBatchImplementPrompt', () => {
+  test('includes parent epic context and batch scope guidance', () => {
+    const prompt = buildBatchImplementPrompt({
+      issues: [{ issueNum: 189, title: 'Test', body: 'Body' }],
+      epicContext,
+    });
+
+    expect(prompt).toContain('## Parent Epic Context');
+    expect(prompt).toContain('Keep this batch limited to the listed issues');
+  });
 });
 
 describe('buildBatchReviewPrompt', () => {
@@ -260,6 +373,17 @@ describe('buildBatchReviewPrompt', () => {
     });
     expect(prompt).toContain('RED FLAG');
     expect(prompt).toContain('silently hide missing injection');
+  });
+
+  test('includes parent epic context for epic batches', () => {
+    const prompt = buildBatchReviewPrompt({
+      issues: [{ issueNum: 189, title: 'Test', body: 'Body' }],
+      baseBranch: 'master',
+      epicContext,
+    });
+
+    expect(prompt).toContain('## Parent Epic Context');
+    expect(prompt).toContain('integration-sensitive work across siblings');
   });
 });
 

--- a/tests/lib/verify.test.ts
+++ b/tests/lib/verify.test.ts
@@ -290,6 +290,41 @@ describe('runVerify', () => {
     expect(result.skipped).toBe(true);
     expect(result.output).toContain('no command');
   });
+
+  it('includes parent epic context in playwright verification prompts', async () => {
+    exec.mockImplementation((cmd: string) => {
+      if (cmd === 'which playwright-cli') {
+        return { exitCode: 0, stdout: '/usr/bin/playwright-cli', stderr: '' };
+      }
+      if (cmd.includes('git diff --stat')) {
+        return { exitCode: 0, stdout: ' src/app.tsx | 5 +++++\n 1 file changed, 5 insertions(+)', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    spawnAgent.mockResolvedValue({ exitCode: 0, output: '### Status: PASS', duration: 1000 });
+
+    await runVerify({
+      worktree: '/tmp/test',
+      logFile: '/tmp/test.log',
+      issueNum: 189,
+      title: 'test',
+      body: 'test body',
+      config: makeConfig(),
+      sessionDir: '/tmp/session',
+      epicContext: {
+        number: 195,
+        title: 'Parent Epic',
+        bodySummary: 'Coordinate sibling work.',
+        acceptanceCriteria: ['- [ ] Parent AC'],
+        subIssues: [{ issueNum: 189, title: 'Child issue', checked: false }],
+      },
+    });
+
+    expect(spawnAgent).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining('## Parent Epic Context'),
+    }));
+    expect(spawnAgent.mock.calls[0][0].prompt).toContain('Epic #195: Parent Epic');
+  });
 });
 
 describe('runScriptVerify', () => {


### PR DESCRIPTION
Closes #189
Part of #195

## Summary

Automated implementation of **Inject parent epic context into sub-issue agents**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Review passed; epic context is plumbed into epic run prompts without affecting flat or milestone runs.

## Test Requirements
- Unit tests for prompt builders or pipeline prompt traces.
- Run command tests for epic context plumbing.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*