### PR TITLE
feat: Make run target selection respect milestone-scheduled epics (closes #193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ alpha-loop init
 
 # 2. Edit .alpha-loop.yaml if needed (agent, model, test_command, etc.)
 
-# 3. Run the loop — you'll be prompted to pick a milestone
+# 3. Run the loop — you'll be prompted to pick an epic or milestone
 alpha-loop run
 
 # Or target a specific milestone directly
@@ -68,19 +68,24 @@ After all issues are processed, Alpha Loop:
 
 ### Milestone-Based Workflow
 
-When you start the loop interactively, Alpha Loop shows your open milestones and lets you pick which one to work on:
+When you start the loop interactively, Alpha Loop shows open epics above milestones and lets you pick which target to work on:
 
 ```
+  Open Epics
+
+  1  Multi-tenant support #165 (0/7 done · milestone v1.0)
+
   Open Milestones
 
-  0  All issues (no milestone filter)
-  1  v1.0 — MVP (5 open, 3/8 done · due 2026-04-15)
-  2  v1.1 — Polish (10 open, 0/10 done)
+  2  v1.0 — MVP (5 open, 3/8 done · due 2026-04-15 · 1 scheduled epic)
+  3  v1.1 — Polish (10 open, 0/10 done)
 
-  Select milestone [0-2]: 1
+  0  All ready issues (no filter)
+
+  Select [0-3]: 1
 ```
 
-This lets you plan work in GitHub milestones and control exactly how much the loop processes per session. You can also pass `--milestone "v1.0"` to skip the prompt, or set `milestone: v1.0` in your config file.
+This lets you plan work in GitHub milestones and control exactly how much the loop processes per session. You can also pass `--milestone "v1.0"` to skip the prompt, or set `milestone: v1.0` in your config file. If that milestone has exactly one open parent issue labeled `epic`, Alpha Loop processes that epic's checklist; if it has multiple scheduled epics, it exits with their numbers and asks you to choose with `--epic <N>`. Use `--skip-epic --milestone "v1.0"` to force the flat milestone issue flow.
 
 ### Session Branches
 
@@ -304,7 +309,7 @@ Options:
   --once              Process one issue and exit
   --dry-run           Preview without making changes
   --model <model>     AI model override (e.g., opus, sonnet, gpt-5.4, gpt-5.3-codex)
-  --milestone <name>  Only process issues in this milestone (skips interactive prompt)
+  --milestone <name>  Process this milestone's scheduled epic, or flat issues if none
   --skip-tests        Skip test execution
   --skip-review       Skip code review step
   --skip-learn        Skip learning extraction
@@ -313,7 +318,7 @@ Options:
   --batch             Batch mode: process multiple issues per agent call (faster, fewer tokens)
   --batch-size <n>    Issues per batch (default: 5)
   --epic <n>          Process a specific epic by issue number (skips the picker)
-  --skip-epic         Skip the epic picker, use flat/milestone flow
+  --skip-epic         Skip epic discovery, use flat/milestone flow
   --verify-only <n>   Run only the verification pass on an existing epic
 ```
 
@@ -554,7 +559,7 @@ The loop uses these labels. Run `alpha-loop init` to create any that are missing
 
 ### Milestones
 
-Use GitHub milestones to group issues into planned releases or sprints. When you start the loop, you'll be prompted to pick a milestone — only issues in that milestone will be processed.
+Use GitHub milestones to group issues into planned releases or sprints. When you start the loop, you'll be prompted to pick an epic or milestone; milestone rows show scheduled epic counts when parent epics are assigned to them.
 
 Create milestones at `github.com/<owner>/<repo>/milestones/new`. Set due dates to keep yourself on track.
 
@@ -571,11 +576,13 @@ An epic is a GitHub issue with the `epic` label and a task-list body that refere
 
 Run `alpha-loop init` to install the epic issue template at `.github/ISSUE_TEMPLATE/epic.yml`. It applies the `epic` label and prompts for the goal, ordered sub-issues, acceptance criteria, dependencies, sequencing notes, and verification expectations.
 
-When you start the loop, open epics appear above milestones in the picker. You can also target one directly:
+When you start the loop, open epics appear above milestones in the picker and show milestone membership when present. You can also target one directly:
 
 ```bash
 alpha-loop run --epic 165
 ```
+
+`alpha-loop run --milestone "v1.0"` checks for open epics assigned to that milestone before fetching flat issues. One scheduled epic is processed automatically, multiple scheduled epics require `--epic <N>`, and no scheduled epics falls back to ready non-epic issues in that milestone. `--epic` always wins over `--milestone`; `--skip-epic` disables epic discovery and preserves the flat milestone flow.
 
 Sub-issues are processed in checklist order (not issue-number order). Each sub-issue PR gets `Part of #165` appended, and the epic body's checkboxes auto-flip from `- [ ]` to `- [x]` as PRs merge. When every sub-issue has shipped, the loop runs a verification pass against each sub-issue's acceptance criteria — on `pass` the epic is auto-closed, on `partial` or `fail` it stays open with a `needs-human-input` label and a structured comment explaining the gaps.
 

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -60,13 +60,15 @@ The picker lists open epics above milestones:
 
 ```
   Open Epics
-  1  #165 Multi-tenant support (0/7 sub-issues done)
-  2  #170 Billing revamp (2/5 sub-issues done)
+  1  Multi-tenant support #165 (0/7 done · milestone v1.1)
+  2  Billing revamp #170 (2/5 done)
 
   Open Milestones
-  3  v1.1 — Polish (10 open)
+  3  v1.1 — Polish (10 open, 3/13 done · 1 scheduled epic)
 
-  Select [1-3]:
+  0  All ready issues (no filter)
+
+  Select [0-3]:
 ```
 
 ### Forced
@@ -77,13 +79,27 @@ alpha-loop run --epic 165
 
 Processes epic `#165` directly, skipping the picker.
 
+`--epic` is the explicit override. If you also pass `--milestone`, the milestone filter is ignored and the selected epic's checklist is processed.
+
+### Milestone Scheduled
+
+```bash
+alpha-loop run --milestone "v1.1"
+```
+
+When a milestone contains open parent issues labeled `epic`, Alpha Loop applies this rule before fetching flat issues:
+
+1. Exactly one scheduled epic: process that epic's checklist.
+2. Multiple scheduled epics: print their issue numbers and titles, then exit. Re-run with `--epic <N>` to choose one.
+3. No scheduled epics: use the existing flat milestone flow and process ready non-epic issues in that milestone.
+
 ### Excluded
 
 ```bash
-alpha-loop run --skip-epic
+alpha-loop run --skip-epic --milestone "v1.1"
 ```
 
-Skips the epic picker entirely and goes straight to milestones. Useful when you want to work on standalone issues in a repo that has open epics.
+Skips epic discovery entirely and uses the flat milestone issue flow. Useful when you want to work on standalone issues in a milestone that also has scheduled parent epics.
 
 ## Sub-Issue Ordering
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ program
   .option('--skip-tests', 'Skip test execution')
   .option('--skip-review', 'Skip code review')
   .option('--skip-learn', 'Skip learning extraction')
-  .option('--milestone <name>', 'Only process issues in this milestone')
+  .option('--milestone <name>', 'Process the scheduled epic for this milestone, or flat issues if none')
   .option('--auto-merge', 'Auto-merge PRs to session branch')
   .option('--merge-to <branch>', 'Use existing branch instead of creating session branch')
   .option('--once', 'Process one issue and exit')
@@ -39,7 +39,7 @@ program
   .option('--fix', 'Auto-fix validation issues (reorder deps, comment on incomplete issues)')
   .option('--verbose', 'Stream live agent output to terminal')
   .option('--epic <n>', 'Process a specific epic by issue number (skips the picker)', parseInt)
-  .option('--skip-epic', 'Skip the epic picker, use flat/milestone flow')
+  .option('--skip-epic', 'Skip epic discovery, use flat/milestone flow')
   .option('--verify-only <n>', 'Run only the verification pass on an existing epic', parseInt)
   .action(async (options) => {
     const { runCommand } = await import('./commands/run.js');

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -159,6 +159,38 @@ export type PickTargetResult =
   | { type: 'milestone'; title: string }
   | { type: 'all' };
 
+type ResolvedRunTarget = {
+  activeEpic?: number;
+  activeEpicTitle?: string;
+  activeEpicIssue?: Issue;
+  activeMilestone: string;
+};
+
+function hasEpicLabel(issue: Issue): boolean {
+  return issue.labels.some((label) => label.toLowerCase() === 'epic');
+}
+
+export function formatEpicPickerMeta(epic: Issue): string {
+  const summary = buildEpicSummary(epic);
+  const progress = summary.totalCount > 0
+    ? `${summary.doneCount}/${summary.totalCount} done`
+    : 'no sub-issues';
+  const milestone = epic.milestone ? ` · milestone ${epic.milestone}` : '';
+  return `${progress}${milestone}`;
+}
+
+export function formatMilestonePickerMeta(milestone: Milestone, epics: Issue[]): string {
+  const progress = milestone.openIssues + milestone.closedIssues > 0
+    ? `${milestone.closedIssues}/${milestone.openIssues + milestone.closedIssues} done`
+    : 'empty';
+  const due = milestone.dueOn ? ` · due ${milestone.dueOn.split('T')[0]}` : '';
+  const scheduledEpicCount = epics.filter((epic) => epic.milestone === milestone.title).length;
+  const scheduled = scheduledEpicCount > 0
+    ? ` · ${scheduledEpicCount} scheduled epic${scheduledEpicCount === 1 ? '' : 's'}`
+    : '';
+  return `${milestone.openIssues} open, ${progress}${due}${scheduled}`;
+}
+
 /**
  * Show open epics + milestones and let the user pick one, or choose "all in order".
  * Epics are listed first (they're typically what the user actually wants).
@@ -199,11 +231,7 @@ async function pickTarget(
     console.error('');
     for (let i = 0; i < epics.length; i++) {
       const e = epics[i];
-      const summary = buildEpicSummary(e);
-      const progress = summary.totalCount > 0
-        ? `${summary.doneCount}/${summary.totalCount} done`
-        : 'no sub-issues';
-      console.error(`  ${BOLD}${i + 1}${NC}  ${e.title} #${e.number} ${DIM}(${progress})${NC}`);
+      console.error(`  ${BOLD}${i + 1}${NC}  ${e.title} #${e.number} ${DIM}(${formatEpicPickerMeta(e)})${NC}`);
     }
     console.error('');
   }
@@ -213,11 +241,7 @@ async function pickTarget(
     console.error('');
     for (let i = 0; i < milestones.length; i++) {
       const m = milestones[i];
-      const progress = m.openIssues + m.closedIssues > 0
-        ? `${m.closedIssues}/${m.openIssues + m.closedIssues} done`
-        : 'empty';
-      const due = m.dueOn ? ` · due ${m.dueOn.split('T')[0]}` : '';
-      console.error(`  ${BOLD}${epics.length + i + 1}${NC}  ${m.title} ${DIM}(${m.openIssues} open, ${progress}${due})${NC}`);
+      console.error(`  ${BOLD}${epics.length + i + 1}${NC}  ${m.title} ${DIM}(${formatMilestonePickerMeta(m, epics)})${NC}`);
     }
     console.error('');
   }
@@ -243,6 +267,79 @@ async function pickTarget(
   const selected = milestones[milestoneIdx];
   log.success(`Milestone selected: ${selected.title} (${selected.openIssues} open issues)`);
   return { type: 'milestone', title: selected.title };
+}
+
+async function resolveRunTarget(config: Config, options: RunOptions): Promise<ResolvedRunTarget | null> {
+  let activeMilestone = config.milestone;
+
+  // --epic <N> overrides everything except --verify-only
+  if (options.epic !== undefined) {
+    if (typeof options.epic !== 'number' || !Number.isFinite(options.epic) || options.epic <= 0) {
+      log.error('--epic requires a positive integer issue number (e.g. --epic 165)');
+      process.exit(1);
+      return null;
+    }
+    const epic = getIssueWithComments(config.repo, options.epic);
+    if (!epic) {
+      log.error(`Could not fetch epic #${options.epic}`);
+      process.exit(1);
+      return null;
+    }
+    return {
+      activeEpic: epic.number,
+      activeEpicTitle: epic.title,
+      activeEpicIssue: epic,
+      activeMilestone: '',
+    };
+  }
+
+  if (activeMilestone && options.skipEpic !== true) {
+    const scheduledEpics = listEpics(config.repo, { milestone: activeMilestone });
+
+    if (scheduledEpics.length === 1) {
+      const epic = scheduledEpics[0];
+      log.info(`Milestone '${activeMilestone}' has one scheduled epic; processing epic #${epic.number}: ${epic.title}`);
+      return {
+        activeEpic: epic.number,
+        activeEpicTitle: epic.title,
+        activeEpicIssue: epic,
+        activeMilestone: '',
+      };
+    }
+
+    if (scheduledEpics.length > 1) {
+      log.error(`Milestone '${activeMilestone}' has multiple scheduled epics:`);
+      for (const epic of scheduledEpics) {
+        log.error(`  #${epic.number} ${epic.title}`);
+      }
+      log.error(`Use --epic <N> to choose one, or --skip-epic --milestone ${JSON.stringify(activeMilestone)} to process flat issues.`);
+      process.exit(1);
+      return null;
+    }
+
+    log.info(`No open epics scheduled for milestone '${activeMilestone}' — using flat milestone issue flow`);
+  }
+
+  // Interactive picker when TTY and nothing preset
+  if (!activeMilestone && !config.dryRun && process.stdin.isTTY) {
+    const target = await pickTarget(config.repo, {
+      preferEpics: config.preferEpics,
+      hideEpics: options.skipEpic === true,
+    });
+    if (target.type === 'epic') {
+      return {
+        activeEpic: target.epicNum,
+        activeEpicTitle: target.epicTitle,
+        activeEpicIssue: target.epic,
+        activeMilestone: '',
+      };
+    }
+    if (target.type === 'milestone') {
+      activeMilestone = target.title;
+    }
+  }
+
+  return { activeMilestone };
 }
 
 /**
@@ -464,42 +561,12 @@ export async function runCommand(options: RunOptions): Promise<void> {
   }
 
   // --- Target selection (epic or milestone) — must happen before session creation ---
-  let activeEpic: number | undefined;
-  let activeEpicTitle: string | undefined;
-  let activeEpicIssue: Issue | undefined;
-  let activeMilestone = config.milestone;
-
-  // --epic <N> overrides everything except --verify-only
-  if (options.epic !== undefined) {
-    if (typeof options.epic !== 'number' || !Number.isFinite(options.epic) || options.epic <= 0) {
-      log.error('--epic requires a positive integer issue number (e.g. --epic 165)');
-      process.exit(1);
-    }
-    const epic = getIssueWithComments(config.repo, options.epic);
-    if (!epic) {
-      log.error(`Could not fetch epic #${options.epic}`);
-      process.exit(1);
-    }
-    activeEpic = epic.number;
-    activeEpicTitle = epic.title;
-    activeEpicIssue = epic;
-    activeMilestone = '';
-  }
-
-  // Interactive picker when TTY and nothing preset
-  if (activeEpic === undefined && !activeMilestone && !config.dryRun && process.stdin.isTTY) {
-    const target = await pickTarget(config.repo, {
-      preferEpics: config.preferEpics,
-      hideEpics: options.skipEpic === true,
-    });
-    if (target.type === 'epic') {
-      activeEpic = target.epicNum;
-      activeEpicTitle = target.epicTitle;
-      activeEpicIssue = target.epic;
-    } else if (target.type === 'milestone') {
-      activeMilestone = target.title;
-    }
-  }
+  const target = await resolveRunTarget(config, options);
+  if (!target) return;
+  let activeEpic = target.activeEpic;
+  let activeEpicTitle = target.activeEpicTitle;
+  let activeEpicIssue = target.activeEpicIssue;
+  const activeMilestone = target.activeMilestone;
 
   if (activeEpic !== undefined) {
     log.info(`Processing epic #${activeEpic}${activeEpicTitle ? ': ' + activeEpicTitle : ''}`);
@@ -647,7 +714,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
         continue;
       }
       ref.title = ref.title ?? sub.title;
-      if (sub.labels.includes('epic')) {
+      if (hasEpicLabel(sub)) {
         log.warn(`Sub-issue #${sub.number} skipped: is itself an epic (nested epics unsupported in v1)`);
         continue;
       }
@@ -665,7 +732,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
       project: config.project,
       repoOwner: config.repoOwner,
       milestone: activeMilestone || undefined,
-    }).filter((iss) => !iss.labels.includes('epic'));
+    }).filter((iss) => !hasEpicLabel(iss));
   }
 
   // When set mid-loop, skip post-loop epic verification (e.g. checklist body inconsistency).

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -875,9 +875,10 @@ function truncateBody(body: string): string {
 /**
  * List open issues labeled `epic`.
  */
-export function listEpics(repo: string): Issue[] {
+export function listEpics(repo: string, options?: { milestone?: string }): Issue[] {
+  const milestoneFlag = options?.milestone ? ` --milestone ${JSON.stringify(options.milestone)}` : '';
   const result = ghExec(
-    `gh issue list --repo "${repo}" --label "epic" --state open --json number,title,body,labels,milestone --limit 100`,
+    `gh issue list --repo "${repo}" --label "epic" --state open${milestoneFlag} --json number,title,body,labels,milestone --limit 100`,
   );
   if (result.exitCode !== 0) {
     log.warn(`Failed to list epics: ${result.stderr}`);

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -1,4 +1,4 @@
-import { runCommand } from '../../src/commands/run';
+import { formatEpicPickerMeta, formatMilestonePickerMeta, runCommand } from '../../src/commands/run';
 
 jest.mock('../../src/lib/shell', () => ({
   exec: jest.fn(),
@@ -77,13 +77,14 @@ jest.mock('node:fs', () => ({
 
 import { exec } from '../../src/lib/shell';
 import { loadConfig } from '../../src/lib/config';
-import { pollIssues, getIssueWithComments, updateEpicChecklist } from '../../src/lib/github';
+import { pollIssues, listEpics, getIssueWithComments, updateEpicChecklist } from '../../src/lib/github';
 import { processIssue, processBatch } from '../../src/lib/pipeline';
 import { createSession, finalizeSession } from '../../src/lib/session';
 
 const mockExec = exec as jest.MockedFunction<typeof exec>;
 const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
 const mockPollIssues = pollIssues as jest.MockedFunction<typeof pollIssues>;
+const mockListEpics = listEpics as jest.MockedFunction<typeof listEpics>;
 const mockGetIssueWithComments = getIssueWithComments as jest.MockedFunction<typeof getIssueWithComments>;
 const mockUpdateEpicChecklist = updateEpicChecklist as jest.MockedFunction<typeof updateEpicChecklist>;
 const mockProcessIssue = processIssue as jest.MockedFunction<typeof processIssue>;
@@ -137,6 +138,7 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
     agentTimeout: 1800,
     pricing: {},
     pipeline: {},
+    preferEpics: false,
     ...overrides,
   };
 }
@@ -158,6 +160,7 @@ beforeEach(() => {
   });
   mockFinalizeSession.mockResolvedValue(null);
   mockPollIssues.mockReturnValue([]);
+  mockListEpics.mockReturnValue([]);
   mockGetIssueWithComments.mockReturnValue(null);
   mockProcessBatch.mockResolvedValue([]);
 });
@@ -169,6 +172,28 @@ afterEach(() => {
 });
 
 describe('runCommand', () => {
+  test('picker metadata shows epic milestone membership and scheduled epic counts', () => {
+    const epic = {
+      number: 195,
+      title: 'Scheduled Epic',
+      body: '- [x] #1\n- [ ] #2',
+      labels: ['epic'],
+      milestone: 'Sprint 1',
+    };
+    const milestone = {
+      number: 1,
+      title: 'Sprint 1',
+      description: '',
+      openIssues: 3,
+      closedIssues: 2,
+      dueOn: '2026-06-01T00:00:00Z',
+      state: 'open',
+    };
+
+    expect(formatEpicPickerMeta(epic)).toBe('1/2 done · milestone Sprint 1');
+    expect(formatMilestonePickerMeta(milestone, [epic])).toBe('3 open, 2/5 done · due 2026-06-01 · 1 scheduled epic');
+  });
+
   test('processes all matching issues and exits', async () => {
     mockPollIssues.mockReturnValue([
       { number: 42, title: 'Test issue', body: 'Body', labels: ['ready'] },
@@ -192,6 +217,161 @@ describe('runCommand', () => {
       expect.any(Object),
     );
     expect(mockFinalizeSession).toHaveBeenCalled();
+  });
+
+  test('processes a single epic scheduled in the requested milestone', async () => {
+    mockListEpics.mockReturnValue([
+      {
+        number: 195,
+        title: 'Scheduled Epic',
+        body: '- [ ] #201 Build scheduled child',
+        labels: ['epic'],
+        milestone: 'Sprint 1',
+      },
+    ]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => {
+      if (issueNum === 201) {
+        return { number: 201, title: 'Build scheduled child', body: 'Child body', labels: ['ready'] };
+      }
+      return null;
+    });
+    mockProcessIssue.mockResolvedValue({
+      issueNum: 201,
+      title: 'Build scheduled child',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    });
+
+    await runCommand({ milestone: 'Sprint 1', dryRun: true });
+
+    expect(mockListEpics).toHaveBeenCalledWith('owner/repo', { milestone: 'Sprint 1' });
+    expect(mockPollIssues).not.toHaveBeenCalled();
+    expect(mockCreateSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+      epicNum: 195,
+      epicTitle: 'Scheduled Epic',
+      milestone: undefined,
+    }));
+    expect(mockProcessIssue).toHaveBeenCalledWith(
+      201,
+      'Build scheduled child',
+      'Child body',
+      expect.any(Object),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  test('surfaces multiple epics scheduled in a milestone and exits with guidance', async () => {
+    mockListEpics.mockReturnValue([
+      { number: 195, title: 'First Epic', body: '- [ ] #201', labels: ['epic'], milestone: 'Sprint 1' },
+      { number: 196, title: 'Second Epic', body: '- [ ] #202', labels: ['epic'], milestone: 'Sprint 1' },
+    ]);
+
+    await runCommand({ milestone: 'Sprint 1', dryRun: true });
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+  });
+
+  test('falls back to flat milestone flow when no epics are scheduled and filters epic parents', async () => {
+    mockPollIssues.mockReturnValue([
+      { number: 42, title: 'Flat issue', body: 'Body', labels: ['ready'] },
+      { number: 195, title: 'Parent Epic', body: '- [ ] #42', labels: ['ready', 'epic'] },
+    ]);
+    mockProcessIssue.mockResolvedValue({
+      issueNum: 42,
+      title: 'Flat issue',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    });
+
+    await runCommand({ milestone: 'Sprint 1', dryRun: true });
+
+    expect(mockListEpics).toHaveBeenCalledWith('owner/repo', { milestone: 'Sprint 1' });
+    expect(mockPollIssues).toHaveBeenCalledWith('owner/repo', 'ready', 100, expect.objectContaining({
+      milestone: 'Sprint 1',
+    }));
+    expect(mockProcessIssue).toHaveBeenCalledTimes(1);
+    expect(mockProcessIssue).toHaveBeenCalledWith(
+      42,
+      'Flat issue',
+      'Body',
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  test('--skip-epic preserves flat milestone flow without epic discovery', async () => {
+    mockPollIssues.mockReturnValue([
+      { number: 42, title: 'Flat issue', body: 'Body', labels: ['ready'] },
+      { number: 195, title: 'Parent Epic', body: '- [ ] #42', labels: ['ready', 'epic'] },
+    ]);
+    mockProcessIssue.mockResolvedValue({
+      issueNum: 42,
+      title: 'Flat issue',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    });
+
+    await runCommand({ milestone: 'Sprint 1', skipEpic: true, dryRun: true });
+
+    expect(mockListEpics).not.toHaveBeenCalled();
+    expect(mockPollIssues).toHaveBeenCalledWith('owner/repo', 'ready', 100, expect.objectContaining({
+      milestone: 'Sprint 1',
+    }));
+    expect(mockProcessIssue).toHaveBeenCalledTimes(1);
+  });
+
+  test('--epic overrides milestone-targeted epic discovery', async () => {
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => {
+      if (issueNum === 195) {
+        return { number: 195, title: 'Forced Epic', body: '- [ ] #201 Build forced child', labels: ['epic'] };
+      }
+      if (issueNum === 201) {
+        return { number: 201, title: 'Build forced child', body: 'Child body', labels: ['ready'] };
+      }
+      return null;
+    });
+    mockProcessIssue.mockResolvedValue({
+      issueNum: 201,
+      title: 'Build forced child',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    });
+
+    await runCommand({ milestone: 'Sprint 1', epic: 195, dryRun: true });
+
+    expect(mockListEpics).not.toHaveBeenCalled();
+    expect(mockPollIssues).not.toHaveBeenCalled();
+    expect(mockCreateSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+      epicNum: 195,
+      milestone: undefined,
+    }));
+    expect(mockProcessIssue).toHaveBeenCalledWith(
+      201,
+      'Build forced child',
+      'Child body',
+      expect.any(Object),
+      expect.any(Object),
+      expect.any(Object),
+    );
   });
 
   test('exits cleanly when no issues found', async () => {

--- a/tests/lib/github.test.ts
+++ b/tests/lib/github.test.ts
@@ -3,7 +3,7 @@ import {
   createIssue, updateIssue, closeIssue, createMilestone,
   setIssueMilestone, listOpenIssues, addIssueToProject,
   getIssueBody, updateEpicIssueBody, commentChildEpicBacklink,
-  listRoadmapEpics,
+  listRoadmapEpics, listEpics,
 } from '../../src/lib/github';
 
 jest.mock('../../src/lib/shell', () => ({
@@ -385,6 +385,38 @@ describe('updateIssue', () => {
 });
 
 describe('epic issue helpers', () => {
+  test('listEpics can filter open epics by milestone and normalizes milestone titles', () => {
+    mockExec.mockReturnValue({
+      stdout: JSON.stringify([
+        {
+          number: 195,
+          title: 'Scheduled epic',
+          body: '- [ ] #201',
+          labels: [{ name: 'epic' }],
+          milestone: { title: 'Sprint 1' },
+        },
+      ]),
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const epics = listEpics('owner/repo', { milestone: 'Sprint 1' });
+
+    expect(epics).toEqual([{
+      number: 195,
+      title: 'Scheduled epic',
+      body: '- [ ] #201',
+      labels: ['epic'],
+      milestone: 'Sprint 1',
+    }]);
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining('--milestone "Sprint 1"'),
+    );
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining('--json number,title,body,labels,milestone'),
+    );
+  });
+
   test('listRoadmapEpics returns open epic child counts and summaries from known issues', () => {
     mockExec.mockReturnValue({
       stdout: JSON.stringify([


### PR DESCRIPTION
Closes #193
Part of #195

## Summary

Automated implementation of **Make run target selection respect milestone-scheduled epics**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Review passed after fixing milestone flat-flow label filtering and roadmap milestone context wiring.

- **CRITICAL** [FIXED] `src/lib/github.ts`: Flat milestone issue polling dropped the ready-label filter when a milestone was specified, so --milestone with no scheduled epic and --skip-epic --milestone could process non-ready ordinary issues.
- **WARNING** [FIXED] `src/lib/github.ts`: Roadmap prompt construction read issue.milestone from listOpenIssues results, but listOpenIssues did not request or populate milestone data from GitHub.

## Test Requirements
- Run command tests with open epics assigned to milestones.
- Regression tests that flat issue processing still filters out `epic`-labeled parent issues.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*