### PR TITLE
feat: fix: parseSubIssues regex rejects markdown-emphasised issue numbers (epics with bold/linked refs silently parse as empty) (closes #186)

### DIFF
--- a/src/lib/epics.ts
+++ b/src/lib/epics.ts
@@ -10,13 +10,23 @@
  */
 import type { Issue } from './github.js';
 
-const SUB_ISSUE_LINE_RE = /^(\s*)- \[([ xX])\] #(\d+)\b/;
+const SUB_ISSUE_LINE_RE = /^(\s*)- \[([ xX])\]\s+[*_~`\[]*#(\d+)(?=$|[^A-Za-z0-9])/;
+const CHECKLIST_ITEM_RE = /^\s*- \[[ xX]\]/;
+const CHECKLIST_BOX_RE = /^(\s*)- \[[ xX]\]/;
+const LOCAL_ISSUE_REF_RE = /(^|[^A-Za-z0-9_./-])#\d+(?=$|[^A-Za-z0-9])/;
 const EPIC_HEURISTIC_MIN_ITEMS = 3;
 
 export type SubIssueRef = {
   number: number;
   checked: boolean;
   /** Zero-indexed line position in the split body — used for surgical replacement. */
+  lineIndex: number;
+};
+
+export type UnparsedSubIssueChecklistLine = {
+  /** Original line text from the epic body. */
+  line: string;
+  /** Zero-indexed line position in the split body. */
   lineIndex: number;
 };
 
@@ -51,8 +61,9 @@ function formatChildChecklist(issueNumbers: number[]): string[] {
 /**
  * Parse task-list sub-issue references from an issue body.
  *
- * Matches lines like `- [ ] #42` or `- [x] #42` (with optional leading
- * whitespace to allow nested markdown lists). Cross-repo refs like
+ * Matches lines like `- [ ] #42`, `- [x] **#42**`, or
+ * `- [ ] [#42](https://...)` (with optional leading whitespace to allow
+ * nested markdown lists). Cross-repo refs like
  * `- [ ] owner/repo#42` are silently skipped — see the v1 non-goals.
  *
  * Returns refs in document order.
@@ -71,6 +82,24 @@ export function parseSubIssues(body: string): SubIssueRef[] {
     });
   }
   return refs;
+}
+
+/**
+ * Find checklist lines that contain a local-looking issue ref but do not match
+ * the supported sub-issue syntax. Cross-repo refs like `owner/repo#42` and
+ * numeric-only refs are intentionally ignored.
+ */
+export function findUnparsedSubIssueChecklistLines(body: string): UnparsedSubIssueChecklistLine[] {
+  const lines = body.split('\n');
+  const unparsed: UnparsedSubIssueChecklistLine[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!CHECKLIST_ITEM_RE.test(line)) continue;
+    if (SUB_ISSUE_LINE_RE.test(line)) continue;
+    if (!LOCAL_ISSUE_REF_RE.test(line)) continue;
+    unparsed.push({ line, lineIndex: i });
+  }
+  return unparsed;
 }
 
 /**
@@ -139,7 +168,7 @@ export function flipChecklistItem(body: string, subIssueNum: number, checked: bo
     if (!m) continue;
     if (parseInt(m[3], 10) !== subIssueNum) continue;
     const newBox = checked ? 'x' : ' ';
-    lines[i] = lines[i].replace(SUB_ISSUE_LINE_RE, `${m[1]}- [${newBox}] #${m[3]}`);
+    lines[i] = lines[i].replace(CHECKLIST_BOX_RE, `${m[1]}- [${newBox}]`);
     return lines.join('\n');
   }
   return body;

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -7,7 +7,12 @@ import { tmpdir } from 'node:os';
 import { exec } from './shell.js';
 import { ghExec, getProjectCache, setProjectCache } from './rate-limit.js';
 import { log } from './logger.js';
-import { flipChecklistItem, parseSubIssues, type SubIssueRef } from './epics.js';
+import {
+  findUnparsedSubIssueChecklistLines,
+  flipChecklistItem,
+  parseSubIssues,
+  type SubIssueRef,
+} from './epics.js';
 
 /** Max PR body length. GitHub supports 65536 but we leave room for metadata. */
 const MAX_PR_BODY_CHARS = 60_000;
@@ -688,6 +693,18 @@ function summarizeEpicBody(body: string, maxChars: number): string {
   return summarizeBody(text, maxChars);
 }
 
+function warnForUnparsedSubIssueChecklistLines(epicNum: number, body: string): void {
+  const unparsedLines = findUnparsedSubIssueChecklistLines(body);
+  for (const { line, lineIndex } of unparsedLines) {
+    log.warn(
+      [
+        `Checklist line did not parse in epic #${epicNum} at line ${lineIndex + 1}: ${line}`,
+        "Hint: expected '- [ ] #N - title' format, with #N immediately after the checkbox; common markdown wrappers around #N are supported.",
+      ].join('\n'),
+    );
+  }
+}
+
 /**
  * List open epics with ordered child issue summaries for roadmap planning.
  * Known open issues are used first; missing child issue details are fetched
@@ -917,6 +934,7 @@ export function listEpics(repo: string, options?: { milestone?: string }): Issue
 export function getEpicSubIssues(repo: string, epicNum: number): SubIssueRef[] {
   const epic = getIssueWithComments(repo, epicNum);
   if (!epic) return [];
+  warnForUnparsedSubIssueChecklistLines(epicNum, epic.body);
   return parseSubIssues(epic.body);
 }
 

--- a/tests/lib/epics.test.ts
+++ b/tests/lib/epics.test.ts
@@ -1,5 +1,6 @@
 import {
   parseSubIssues,
+  findUnparsedSubIssueChecklistLines,
   buildEpicIssueBody,
   mergeEpicChecklist,
   flipChecklistItem,
@@ -45,6 +46,18 @@ describe('parseSubIssues', () => {
     expect(refs[0]).toMatchObject({ number: 42, checked: false, lineIndex: 0 });
   });
 
+  test.each([
+    ['bare issue ref', '- [ ] #211 - feat: skills loader'],
+    ['bold issue ref', '- [ ] **#211** - feat: skills loader'],
+    ['italic issue ref', '- [ ] _#211_ - feat: skills loader'],
+    ['markdown link issue ref', '- [ ] [#211](https://github.com/owner/repo/issues/211) - feat: skills loader'],
+    ['inline code issue ref', '- [ ] `#211` - feat: skills loader'],
+  ])('parses %s', (_label, line) => {
+    const refs = parseSubIssues(line);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ number: 211, checked: false, lineIndex: 0 });
+  });
+
   test('parses mixed checked and unchecked items and preserves document order', () => {
     const body = [
       '- [x] #10',
@@ -86,6 +99,26 @@ describe('parseSubIssues', () => {
     expect(refs).toHaveLength(2);
     expect(refs[0].lineIndex).toBe(4);
     expect(refs[1].lineIndex).toBe(5);
+  });
+});
+
+describe('findUnparsedSubIssueChecklistLines', () => {
+  test('returns checklist lines with local issue refs that were not parsed', () => {
+    const body = [
+      '- [ ] #10',
+      '- [ ] (#11)',
+      '- [ ] Work before #12',
+      '- [ ] owner/repo#13',
+      '- [ ] 14 - numeric-only refs are out of scope',
+      '- [ ] Task without an issue ref',
+    ].join('\n');
+
+    const lines = findUnparsedSubIssueChecklistLines(body);
+
+    expect(lines).toEqual([
+      { line: '- [ ] (#11)', lineIndex: 1 },
+      { line: '- [ ] Work before #12', lineIndex: 2 },
+    ]);
   });
 });
 
@@ -178,6 +211,12 @@ describe('flipChecklistItem', () => {
     // Only the checkbox line should change
     const expected = body.replace('- [ ] #7', '- [x] #7');
     expect(result).toBe(expected);
+  });
+
+  test('preserves markdown wrapping around the issue ref when flipping', () => {
+    const body = '- [ ] **#42** - feat: skills loader\n- [ ] _#99_';
+    const result = flipChecklistItem(body, 42, true);
+    expect(result).toBe('- [x] **#42** - feat: skills loader\n- [ ] _#99_');
   });
 
   test('returns body unchanged when target sub-issue is not present', () => {

--- a/tests/lib/github.test.ts
+++ b/tests/lib/github.test.ts
@@ -3,7 +3,7 @@ import {
   createIssue, updateIssue, closeIssue, createMilestone,
   setIssueMilestone, listOpenIssues, addIssueToProject,
   getIssueBody, updateEpicIssueBody, commentChildEpicBacklink,
-  listRoadmapEpics, listEpics,
+  listRoadmapEpics, listEpics, getEpicSubIssues,
 } from '../../src/lib/github';
 
 jest.mock('../../src/lib/shell', () => ({
@@ -512,6 +512,41 @@ describe('epic issue helpers', () => {
     });
     expect(mockExec).toHaveBeenCalledWith(
       'gh issue view 7 --repo "owner/repo" --json number,title,body,labels,comments',
+    );
+  });
+
+  test('getEpicSubIssues warns when an issue-like checklist line is not parsed', () => {
+    mockExec.mockReturnValue({
+      stdout: JSON.stringify({
+        number: 214,
+        title: 'Epic: Parser regression',
+        body: [
+          '- [ ] **#10** - parsed bold ref',
+          '- [ ] [#11](https://github.com/owner/repo/issues/11) - parsed link ref',
+          '- [ ] (#12) - unsupported wrapper',
+          '- [ ] owner/repo#13 - cross-repo refs are out of scope',
+          '- [ ] 14 - numeric-only refs are out of scope',
+        ].join('\n'),
+        labels: [{ name: 'epic' }],
+        comments: [],
+      }),
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const { log: mockLog } = require('../../src/lib/logger');
+    const refs = getEpicSubIssues('owner/repo', 214);
+
+    expect(refs).toEqual([
+      { number: 10, checked: false, lineIndex: 0 },
+      { number: 11, checked: false, lineIndex: 1 },
+    ]);
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Checklist line did not parse in epic #214 at line 3: - [ ] (#12) - unsupported wrapper'),
+    );
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Hint: expected '- [ ] #N - title' format"),
     );
   });
 


### PR DESCRIPTION
Closes #186
Part of #206

## Summary

Automated implementation of **fix: parseSubIssues regex rejects markdown-emphasised issue numbers (epics with bold/linked refs silently parse as empty)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Review passed: parseSubIssues handles markdown-emphasized issue refs, warning coverage is wired, and tests/build pass.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*