### PR TITLE
feat: Orchestrator deadlocks after verify-fix-1 success — RESULT emitted but push/PR step never starts (closes #187)

### DIFF
--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -33,21 +33,40 @@ type StrandedBranch = {
   filesChanged: string[];
 };
 
+function normalizeGitBranchLine(line: string): string {
+  return line.trim().replace(/^[*+]\s*/, '');
+}
+
+function listAgentIssueBranches(): string[] {
+  const branches = new Set<string>();
+
+  const listResult = exec('git branch --list "agent/issue-*"');
+  if (listResult.exitCode === 0) {
+    for (const line of listResult.stdout.split('\n')) {
+      const branch = normalizeGitBranchLine(line);
+      if (branch) branches.add(branch);
+    }
+  }
+
+  const worktreeResult = exec('git worktree list --porcelain');
+  if (worktreeResult.exitCode === 0) {
+    for (const line of worktreeResult.stdout.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('branch refs/heads/')) continue;
+      const branch = trimmed.slice('branch refs/heads/'.length);
+      if (branch.startsWith('agent/issue-')) branches.add(branch);
+    }
+  }
+
+  return Array.from(branches).sort();
+}
+
 /**
  * Find local branches matching agent/issue-* that have no open PR and have
  * commits ahead of the remote base branch.
  */
-function findStrandedBranches(baseBranch: string, filterIssue?: number): StrandedBranch[] {
-  const listResult = exec('git branch --list "agent/issue-*"');
-  if (listResult.exitCode !== 0 || !listResult.stdout.trim()) {
-    return [];
-  }
-
-  const branches = listResult.stdout
-    .split('\n')
-    .map((b) => b.trim().replace(/^\*\s*/, ''))
-    .filter(Boolean);
-
+export function findStrandedBranches(baseBranch: string, filterIssue?: number): StrandedBranch[] {
+  const branches = listAgentIssueBranches();
   const stranded: StrandedBranch[] = [];
 
   for (const branch of branches) {

--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -30,6 +30,10 @@ export type AgentResult = {
   toolCalls?: number;
   /** Number of tool_result blocks with is_error === true. */
   toolErrors?: number;
+  /** Claude stream-json result subtype, when present. */
+  resultSubtype?: string;
+  /** Whether the Claude stream-json result reported an error. */
+  resultIsError?: boolean;
 };
 
 /**
@@ -90,6 +94,10 @@ function formatStreamJsonLine(line: string): string | null {
 
 /** Default agent timeout: 30 minutes */
 const DEFAULT_AGENT_TIMEOUT_MS = 30 * 60 * 1000;
+/** Grace period after a Claude stream-json result before treating the run as done. */
+const DEFAULT_RESULT_GRACE_MS = 60 * 1000;
+/** Time to wait for SIGTERM before forcing a stuck child down. */
+const FORCE_KILL_GRACE_MS = 5 * 1000;
 
 export type AgentOptions = {
   agent: AgentType;
@@ -100,6 +108,11 @@ export type AgentOptions = {
   verbose?: boolean;
   /** Timeout in milliseconds. Defaults to 30 minutes. */
   timeout?: number;
+  /**
+   * Grace period after a Claude stream-json `result` event before resolving if
+   * the child process never closes. Set to 0 to disable result-based recovery.
+   */
+  resultGraceMs?: number;
   /** Max conversation turns for the agent. Only supported by claude. */
   maxTurns?: number;
   /** Resume the most recent agent session in the CWD instead of starting fresh. */
@@ -252,7 +265,7 @@ function defaultLocalEnv(agent: AgentType, model: string): Record<string, string
  */
 export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
   const { command, args } = buildAgentArgs(options);
-  const useStreamJson = options.agent === 'claude';
+  const useStreamJson = command === 'claude' && args.includes('stream-json');
 
   log.info(`Agent: ${options.agent} | Model: ${options.model} | CWD: ${options.cwd}`);
 
@@ -289,6 +302,14 @@ export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
     let parsedCostUsd: number | undefined;
     let parsedInputTokens: number | undefined;
     let parsedOutputTokens: number | undefined;
+    let parsedResultSubtype: string | undefined;
+    let parsedResultIsError = false;
+    let sawStreamResult = false;
+    let agentTimeoutTimer: NodeJS.Timeout | undefined;
+    let resultGraceTimer: NodeJS.Timeout | undefined;
+    let forceKillTimer: NodeJS.Timeout | undefined;
+    let pendingTerminationExitCode: number | undefined;
+    let pendingTerminationOutput: string | undefined;
     // Tool-use telemetry (per-stage metrics aggregation).
     let toolUseCount = 0;
     let toolErrorCount = 0;
@@ -318,6 +339,90 @@ export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
       writeToLog(stream, data.toString());
     };
 
+    function terminateChild(
+      reason: string,
+      exitCode: number,
+      output: string,
+      signal: NodeJS.Signals = 'SIGTERM',
+    ) {
+      if (resolved) return;
+      pendingTerminationExitCode = exitCode;
+      pendingTerminationOutput = output;
+      log.warn(reason);
+      try { child.kill(signal); } catch { /* ignore */ }
+      forceKillTimer = setTimeout(() => {
+        try { child.kill('SIGKILL'); } catch { /* ignore */ }
+        finish(exitCode, output);
+      }, FORCE_KILL_GRACE_MS);
+    }
+
+    function resultExitCode() {
+      return parsedResultIsError ? 1 : 0;
+    }
+
+    function startResultGraceTimer() {
+      const resultGraceMs = options.resultGraceMs ?? DEFAULT_RESULT_GRACE_MS;
+      if (resultGraceMs <= 0 || resolved) return;
+      if (resultGraceTimer) clearTimeout(resultGraceTimer);
+      resultGraceTimer = setTimeout(() => {
+        terminateChild(
+          `Agent emitted a stream-json result but did not close after ${Math.round(resultGraceMs / 1000)}s; terminating stuck process...`,
+          resultExitCode(),
+          getOutput(),
+        );
+      }, resultGraceMs);
+    }
+
+    function processStreamJsonLine(stream: typeof child.stdout, line: string) {
+      if (!line) return;
+
+      // Extract the final result text and cost/token data for the return value
+      try {
+        const obj = JSON.parse(line) as Record<string, unknown>;
+        if (obj.type === 'result') {
+          sawStreamResult = true;
+          finalResultText = typeof obj.result === 'string' ? obj.result : '';
+          parsedResultSubtype = typeof obj.subtype === 'string' ? obj.subtype : undefined;
+          parsedResultIsError = obj.is_error === true || parsedResultSubtype?.startsWith('error') === true;
+          // Capture structured error info so transient/permanent classification
+          // still has something useful when Claude reports an empty error result.
+          if (parsedResultIsError) {
+            finalResultText = finalResultText || JSON.stringify(obj);
+          }
+          // Parse cost from result block
+          if (typeof obj.total_cost_usd === 'number') {
+            parsedCostUsd = obj.total_cost_usd;
+          }
+          // Parse token usage from result block
+          const usage = obj.usage as Record<string, unknown> | undefined;
+          if (usage) {
+            if (typeof usage.input_tokens === 'number') parsedInputTokens = usage.input_tokens;
+            if (typeof usage.output_tokens === 'number') parsedOutputTokens = usage.output_tokens;
+          }
+          startResultGraceTimer();
+        } else if (obj.type === 'assistant') {
+          const msg = obj.message as Record<string, unknown> | undefined;
+          const content = (msg?.content ?? []) as Array<Record<string, unknown>>;
+          for (const block of content) {
+            if (block.type === 'tool_use') toolUseCount++;
+          }
+        } else if (obj.type === 'user') {
+          const msg = obj.message as Record<string, unknown> | undefined;
+          const content = (msg?.content ?? []) as Array<Record<string, unknown>>;
+          for (const block of content) {
+            if (block.type === 'tool_result' && block.is_error === true) toolErrorCount++;
+          }
+        }
+      } catch { /* not valid JSON, ignore */ }
+
+      const formatted = formatStreamJsonLine(line);
+      if (formatted) {
+        const logLine = formatted + '\n';
+        if (options.verbose) process.stderr.write(logLine);
+        writeToLog(stream, logLine);
+      }
+    }
+
     /**
      * Handle stream-json data for Claude — parse JSON lines into readable output.
      */
@@ -330,49 +435,7 @@ export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
       while ((newlineIdx = lineBuffer.indexOf('\n')) !== -1) {
         const line = lineBuffer.slice(0, newlineIdx).trim();
         lineBuffer = lineBuffer.slice(newlineIdx + 1);
-
-        if (!line) continue;
-
-        // Extract the final result text and cost/token data for the return value
-        try {
-          const obj = JSON.parse(line) as Record<string, unknown>;
-          if (obj.type === 'result') {
-            finalResultText = typeof obj.result === 'string' ? obj.result : '';
-            // Capture error info so transient error detection works
-            if (obj.is_error || obj.subtype === 'error') {
-              finalResultText = finalResultText || JSON.stringify(obj);
-            }
-            // Parse cost from result block
-            if (typeof obj.total_cost_usd === 'number') {
-              parsedCostUsd = obj.total_cost_usd;
-            }
-            // Parse token usage from result block
-            const usage = obj.usage as Record<string, unknown> | undefined;
-            if (usage) {
-              if (typeof usage.input_tokens === 'number') parsedInputTokens = usage.input_tokens;
-              if (typeof usage.output_tokens === 'number') parsedOutputTokens = usage.output_tokens;
-            }
-          } else if (obj.type === 'assistant') {
-            const msg = obj.message as Record<string, unknown> | undefined;
-            const content = (msg?.content ?? []) as Array<Record<string, unknown>>;
-            for (const block of content) {
-              if (block.type === 'tool_use') toolUseCount++;
-            }
-          } else if (obj.type === 'user') {
-            const msg = obj.message as Record<string, unknown> | undefined;
-            const content = (msg?.content ?? []) as Array<Record<string, unknown>>;
-            for (const block of content) {
-              if (block.type === 'tool_result' && block.is_error === true) toolErrorCount++;
-            }
-          }
-        } catch { /* not valid JSON, ignore */ }
-
-        const formatted = formatStreamJsonLine(line);
-        if (formatted) {
-          const logLine = formatted + '\n';
-          if (options.verbose) process.stderr.write(logLine);
-          writeToLog(stream, logLine);
-        }
+        processStreamJsonLine(stream, line);
       }
     };
 
@@ -389,27 +452,34 @@ export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
     child.stdout.on('error', () => {});
     child.stderr.on('error', () => {});
 
-    const getOutput = () => {
+    function getOutput() {
       if (useStreamJson) {
         // Return the parsed result text, not raw JSON
         return finalResultText || Buffer.concat(chunks).toString();
       }
       return Buffer.concat(chunks).toString();
-    };
+    }
 
-    const finish = (exitCode: number, output: string) => {
+    function finish(exitCode: number, output?: string) {
       if (resolved) return;
       resolved = true;
-      clearTimeout(timer);
+      if (agentTimeoutTimer) clearTimeout(agentTimeoutTimer);
+      if (resultGraceTimer) clearTimeout(resultGraceTimer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+      if (useStreamJson && !sawStreamResult && lineBuffer.trim()) {
+        processStreamJsonLine(child.stdout, lineBuffer.trim());
+        lineBuffer = '';
+      }
+      const finalOutput = output ?? getOutput();
       const duration = Date.now() - startTime;
       // Fall back to output-string classification when we didn't see structured
       // tool_result error blocks (e.g. non-stream-json agents like codex).
       const toolErrorsFinal = toolErrorCount > 0
         ? toolErrorCount
-        : classifyToolErrors(output).length;
+        : classifyToolErrors(finalOutput).length;
       const result: AgentResult = {
         exitCode,
-        output,
+        output: finalOutput,
         duration,
         model: options.model || undefined,
         costUsd: parsedCostUsd,
@@ -418,6 +488,8 @@ export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
         toolCalls: toolUseCount,
         toolErrors: toolErrorsFinal,
       };
+      if (parsedResultSubtype !== undefined) result.resultSubtype = parsedResultSubtype;
+      if (parsedResultIsError) result.resultIsError = true;
       if (logStream) {
         logStream.end(() => {
           resolve(result);
@@ -425,22 +497,24 @@ export async function spawnAgent(options: AgentOptions): Promise<AgentResult> {
       } else {
         resolve(result);
       }
-    };
+    }
 
     // Kill the agent if it exceeds the timeout
-    const timer = setTimeout(() => {
+    agentTimeoutTimer = setTimeout(() => {
       if (!resolved) {
-        log.warn(`Agent timed out after ${Math.round(timeoutMs / 1000)}s, killing process...`);
-        try { child.kill('SIGTERM'); } catch { /* ignore */ }
-        setTimeout(() => {
-          try { child.kill('SIGKILL'); } catch { /* ignore */ }
-        }, 5000);
-        finish(1, getOutput() + '\n[TIMEOUT] Agent killed after exceeding time limit.');
+        terminateChild(
+          `Agent timed out after ${Math.round(timeoutMs / 1000)}s, killing process...`,
+          1,
+          getOutput() + '\n[TIMEOUT] Agent killed after exceeding time limit.',
+        );
       }
     }, timeoutMs);
 
     child.on('close', (code) => {
-      finish(code ?? 1, getOutput());
+      finish(
+        pendingTerminationExitCode ?? code ?? (sawStreamResult ? resultExitCode() : 1),
+        pendingTerminationOutput,
+      );
     });
 
     child.on('error', (err) => {

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -147,6 +147,9 @@ const TRANSIENT_ERROR_PATTERNS = [
 /** Sentinel appended by agent.ts when the process is killed for exceeding the timeout. */
 const TIMEOUT_SENTINEL = '[TIMEOUT]';
 
+/** Watchdog after Claude stream-json result events for resumed fix stages. */
+const RESUMED_FIX_RESULT_GRACE_MS = 60 * 1000;
+
 /**
  * Check if agent output indicates a transient error (usage limits, rate limits).
  * These issues should be re-queued, not marked as permanently failed.
@@ -823,6 +826,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           logFile: join(session.logsDir, `issue-${issueNum}-fix-${attempt}.log`),
           verbose: config.verbose,
           timeout: config.agentTimeout * 1000,
+          resultGraceMs: RESUMED_FIX_RESULT_GRACE_MS,
         }, config, fixCtx);
 
         // Trace fix output and costs
@@ -934,6 +938,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           logFile: join(session.logsDir, `issue-${issueNum}-review-fix-${attempt}.log`),
           verbose: config.verbose,
           timeout: config.agentTimeout * 1000,
+          resultGraceMs: RESUMED_FIX_RESULT_GRACE_MS,
         }, config, reviewFixCtx);
 
         // Trace review-fix output and costs
@@ -1046,6 +1051,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
             logFile: join(session.logsDir, `issue-${issueNum}-verify-fix-${attempt}.log`),
             verbose: config.verbose,
             timeout: config.agentTimeout * 1000,
+            resultGraceMs: RESUMED_FIX_RESULT_GRACE_MS,
           }, config, verifyFixCtx);
 
           // Trace verify-fix output and costs
@@ -1597,6 +1603,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           logFile: join(session.logsDir, `batch-fix-${attempt}.log`),
           verbose: config.verbose,
           timeout: config.agentTimeout * 1000,
+          resultGraceMs: RESUMED_FIX_RESULT_GRACE_MS,
         });
 
         traceOutput(session.name, issues[0].number, `batch-fix-${attempt}`, fixResult.output);
@@ -1691,6 +1698,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
           logFile: join(session.logsDir, `batch-review-fix-${attempt}.log`),
           verbose: config.verbose,
           timeout: config.agentTimeout * 1000,
+          resultGraceMs: RESUMED_FIX_RESULT_GRACE_MS,
         });
 
         traceOutput(session.name, issues[0].number, `batch-review-fix-${attempt}`, reviewFixResult.output);

--- a/tests/commands/resume.test.ts
+++ b/tests/commands/resume.test.ts
@@ -1,0 +1,76 @@
+jest.mock('../../src/lib/shell', () => ({
+  exec: jest.fn(),
+}));
+
+import { findStrandedBranches } from '../../src/commands/resume';
+import { exec } from '../../src/lib/shell';
+
+const mockExec = exec as jest.MockedFunction<typeof exec>;
+
+const ok = (stdout = '') => ({ stdout, stderr: '', exitCode: 0 });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('findStrandedBranches', () => {
+  test('normalizes + prefixed branches checked out in another worktree', () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd === 'git branch --list "agent/issue-*"') {
+        return ok('  agent/issue-462\n+ agent/issue-466\n');
+      }
+      if (cmd === 'git worktree list --porcelain') return ok('');
+      if (cmd === 'git log "origin/master..agent/issue-462" --oneline') return ok('');
+      if (cmd === 'git log "origin/master..agent/issue-466" --oneline') {
+        return ok('a3f214b fix(#466): address verification findings\n');
+      }
+      if (cmd === 'git diff --name-only "origin/master...agent/issue-466"') {
+        return ok('src/lib/agent.ts\n');
+      }
+      return ok('');
+    });
+
+    expect(findStrandedBranches('master')).toEqual([
+      {
+        branch: 'agent/issue-466',
+        issueNum: 466,
+        commits: ['a3f214b fix(#466): address verification findings'],
+        filesChanged: ['src/lib/agent.ts'],
+      },
+    ]);
+  });
+
+  test('detects agent issue branches from git worktree porcelain output', () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd === 'git branch --list "agent/issue-*"') return ok('');
+      if (cmd === 'git worktree list --porcelain') {
+        return ok([
+          'worktree /repo',
+          'HEAD abc123',
+          'branch refs/heads/master',
+          '',
+          'worktree /repo/.worktrees/issue-187',
+          'HEAD def456',
+          'branch refs/heads/agent/issue-187',
+          '',
+        ].join('\n'));
+      }
+      if (cmd === 'git log "origin/master..agent/issue-187" --oneline') {
+        return ok('def456 fix(#187): recover after result\n');
+      }
+      if (cmd === 'git diff --name-only "origin/master...agent/issue-187"') {
+        return ok('src/commands/resume.ts\n');
+      }
+      return ok('');
+    });
+
+    expect(findStrandedBranches('master', 187)).toEqual([
+      {
+        branch: 'agent/issue-187',
+        issueNum: 187,
+        commits: ['def456 fix(#187): recover after result'],
+        filesChanged: ['src/commands/resume.ts'],
+      },
+    ]);
+  });
+});

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -18,6 +18,7 @@ const mockChild = {
   stdout: mockStdout,
   stderr: mockStderr,
   on: jest.fn(),
+  kill: jest.fn(),
 };
 
 jest.mock('node:child_process', () => ({
@@ -40,6 +41,7 @@ beforeEach(() => {
   mockStdout.on.mockReset();
   mockStderr.on.mockReset();
   mockChild.on.mockReset();
+  mockChild.kill.mockReset();
 });
 
 describe('buildAgentArgs', () => {
@@ -342,6 +344,108 @@ describe('spawnAgent', () => {
     expect(result.costUsd).toBe(1.234);
     expect(result.inputTokens).toBe(50000);
     expect(result.outputTokens).toBe(12000);
+  });
+
+  test('resolves from Claude stream-json result when the child never closes', async () => {
+    jest.useFakeTimers();
+    try {
+      let stdoutHandler: Function;
+      mockStdout.on.mockImplementation((event: string, cb: Function) => {
+        if (event === 'data') stdoutHandler = cb;
+      });
+      mockChild.on.mockImplementation(() => {
+        // Reproduce the deadlock: no close event after the result line.
+      });
+
+      const resultPromise = spawnAgent({
+        ...baseOptions,
+        resultGraceMs: 10,
+      });
+
+      stdoutHandler!(Buffer.from(JSON.stringify({
+        type: 'result',
+        result: 'Done.',
+        total_cost_usd: 0.25,
+        usage: { input_tokens: 100, output_tokens: 20 },
+      }) + '\n'));
+
+      await jest.advanceTimersByTimeAsync(10);
+      expect(mockChild.kill).toHaveBeenCalledWith('SIGTERM');
+
+      await jest.advanceTimersByTimeAsync(5000);
+      const result = await resultPromise;
+
+      expect(mockChild.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(result.exitCode).toBe(0);
+      expect(result.output).toBe('Done.');
+      expect(result.costUsd).toBe(0.25);
+      expect(result.inputTokens).toBe(100);
+      expect(result.outputTokens).toBe(20);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('returns only the final result text when assistant text duplicates the result payload', async () => {
+    let stdoutHandler: Function;
+    mockStdout.on.mockImplementation((event: string, cb: Function) => {
+      if (event === 'data') stdoutHandler = cb;
+    });
+    mockChild.on.mockImplementation((event: string, cb: Function) => {
+      if (event === 'close') {
+        setTimeout(() => {
+          stdoutHandler(Buffer.from([
+            JSON.stringify({
+              type: 'assistant',
+              message: { content: [{ type: 'text', text: 'Done.' }] },
+            }),
+            JSON.stringify({ type: 'result', result: 'Done.' }),
+            '',
+          ].join('\n')));
+          cb(0);
+        }, 10);
+      }
+    });
+
+    const result = await spawnAgent(baseOptions);
+    expect(result.output).toBe('Done.');
+  });
+
+  test('preserves Claude result error metadata when recovering after result grace', async () => {
+    jest.useFakeTimers();
+    try {
+      let stdoutHandler: Function;
+      mockStdout.on.mockImplementation((event: string, cb: Function) => {
+        if (event === 'data') stdoutHandler = cb;
+      });
+      mockChild.on.mockImplementation(() => {
+        // No close event.
+      });
+
+      const resultPromise = spawnAgent({
+        ...baseOptions,
+        resultGraceMs: 10,
+      });
+
+      stdoutHandler!(Buffer.from(JSON.stringify({
+        type: 'result',
+        subtype: 'error_max_turns',
+        is_error: true,
+        result: '',
+        total_cost_usd: 0.5,
+      }) + '\n'));
+
+      await jest.advanceTimersByTimeAsync(5010);
+      const result = await resultPromise;
+
+      expect(result.exitCode).toBe(1);
+      expect(result.resultSubtype).toBe('error_max_turns');
+      expect(result.resultIsError).toBe(true);
+      expect(result.output).toContain('"subtype":"error_max_turns"');
+      expect(result.costUsd).toBe(0.5);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   test('cost fields are undefined when not provided', async () => {

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -326,6 +326,53 @@ describe('processIssue', () => {
     expect(mockRunVerify).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
   });
 
+  test('continues from verify-fix into PR creation when verification passes on retry', async () => {
+    const { existsSync, readFileSync } = require('node:fs');
+    const mockExistsSync = existsSync as jest.MockedFunction<typeof import('node:fs').existsSync>;
+    const mockReadFileSync = readFileSync as jest.MockedFunction<typeof import('node:fs').readFileSync>;
+
+    mockExistsSync.mockImplementation((path: any) => String(path).includes('plan-issue-42.json'));
+    mockReadFileSync.mockImplementation((path: any) => {
+      if (String(path).includes('plan-issue-42.json')) {
+        return JSON.stringify({
+          summary: 'Plan with live verification',
+          files: ['src/index.ts'],
+          implementation: 'Implement it',
+          testing: { needed: false, reason: 'Verified live' },
+          verification: { needed: true, method: 'playwright', instructions: 'Open app', reason: 'Runtime behavior' },
+        });
+      }
+      return '';
+    });
+
+    let verifyAttempt = 0;
+    mockRunVerify.mockImplementation(async () => {
+      verifyAttempt++;
+      if (verifyAttempt === 1) {
+        return { passed: false, skipped: false, output: 'Verification failed' };
+      }
+      return { passed: true, skipped: false, output: 'Verification passed' };
+    });
+
+    const result = await processIssue(42, 'Test issue', 'Issue body', makeConfig({ skipVerify: false }), makeSession());
+
+    expect(result.status).toBe('success');
+    expect(mockRunVerify).toHaveBeenCalledTimes(2);
+    expect(mockCreatePR).toHaveBeenCalled();
+
+    const verifyFixCallIndex = (mockSpawnAgent as jest.Mock).mock.calls.findIndex(
+      (call: any[]) => (call[0] as any).prompt?.includes('Live verification failed for issue #42'),
+    );
+    expect(verifyFixCallIndex).toBeGreaterThanOrEqual(0);
+    const verifyFixOptions = (mockSpawnAgent as jest.Mock).mock.calls[verifyFixCallIndex][0] as any;
+    expect(verifyFixOptions.resume).toBe(true);
+    expect(verifyFixOptions.resultGraceMs).toBe(60_000);
+
+    expect(mockCreatePR.mock.invocationCallOrder[0]).toBeGreaterThan(
+      (mockSpawnAgent as jest.Mock).mock.invocationCallOrder[verifyFixCallIndex],
+    );
+  });
+
   test('returns failure and labels failed when implementation fails', async () => {
     mockSpawnAgent.mockImplementation(async (options) => {
       // Plan succeeds, implement fails


### PR DESCRIPTION
Closes #187
Part of #206

## Summary

Automated implementation of **Orchestrator deadlocks after verify-fix-1 success — RESULT emitted but push/PR step never starts**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Review passed; the verify-fix result watchdog is wired into resumed fix stages and covered by tests.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*