### PR TITLE
Session: session/epic-217-epic-multi-epic-execution-queues-and-pr-coordination — 5/5 succeeded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,8 @@ alpha-loop resume        # Resume stranded work from crashed sessions
 alpha-loop resume --issue 34     # Resume a specific issue
 alpha-loop review        # Analyze learnings, propose agent/skill improvements
 alpha-loop review --apply        # Apply improvements and create draft PR
-alpha-loop history       # View session history
+alpha-loop history       # View session and queue history
+alpha-loop history queue-<timestamp> # Inspect a multi-epic queue manifest
 alpha-loop history <name> --qa    # Show QA checklist for session
 alpha-loop history --clean        # Remove old session data
 pnpm test               # Run all tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ alpha-loop run           # Run the loop continuously
 alpha-loop run --once    # Process one issue and exit
 alpha-loop run --dry-run # Dry run (preview, no changes)
 alpha-loop run --epic <N>        # Process an epic (sub-issues in checklist order, auto-verify on completion)
+alpha-loop run --epics <ids>     # Process multiple epics in order, one session PR per epic
 alpha-loop run --verify-only <N> # Run just the epic verification pass
 alpha-loop scan          # Generate/refresh project context
 alpha-loop plan          # Generate project scope (milestones + issues) from seed inputs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ alpha-loop plan          # Generate project scope (milestones + issues) from see
 alpha-loop add           # Create a new issue from a free-form description using AI
 alpha-loop triage        # Analyze and improve existing issues
 alpha-loop roadmap       # Organize open issues into milestones
+alpha-loop roadmap --queue       # Recommend the next ordered epic run queue
 alpha-loop vision        # (deprecated) Use "alpha-loop plan" instead
 alpha-loop auth          # Save authenticated browser state
 alpha-loop resume        # Resume stranded work from crashed sessions

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop run --dry-run` | Preview without making changes |
 | `alpha-loop run --epic <N>` | Process an epic — its sub-issues in checklist order, auto-verify on completion (see [docs/epics.md](docs/epics.md)) |
 | `alpha-loop run --epics <ids>` | Process an ordered comma-separated queue of epics, one session branch and PR per epic |
+| `alpha-loop run --epics <ids> --queue-branch-mode independent` | Run queued epics without stacking later session branches on earlier ones |
 | `alpha-loop run --verify-only <N>` | Run just the epic verification pass — evaluates merged PRs against acceptance criteria |
 | `alpha-loop scan` | Generate/refresh project context and instructions file |
 | `alpha-loop vision` | **(deprecated)** Use `alpha-loop plan` instead |
@@ -332,6 +333,7 @@ Options:
   --batch-size <n>    Issues per batch (default: 5)
   --epic <n>          Process a specific epic by issue number (skips the picker)
   --epics <ids>       Process multiple epics in order (comma-separated)
+  --queue-branch-mode <mode>  Branch mode for --epics: stacked or independent
   --skip-epic         Skip epic discovery, use flat/milestone flow
   --verify-only <n>   Run only the verification pass on an existing epic
 ```
@@ -604,7 +606,7 @@ To run several epics unattended while keeping review scope separate, pass an exp
 alpha-loop run --epics 205,166,214
 ```
 
-The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `--dry-run` prints the validated queue without mutating GitHub or git state.
+The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. By default, queue sessions use `stacked` ancestry: later epic session branches start from the previous successful session branch while their PRs still target the configured base branch. Use `--queue-branch-mode independent` for unrelated epics that should all branch from the base branch. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `--dry-run` prints the validated queue without mutating GitHub or git state.
 
 Sub-issues are processed in checklist order (not issue-number order). Each sub-issue PR gets `Part of #165` appended, and the epic body's checkboxes auto-flip from `- [ ]` to `- [x]` as PRs merge. When every sub-issue has shipped, the loop runs a verification pass against each sub-issue's acceptance criteria — on `pass` the epic is auto-closed, on `partial` or `fail` it stays open with a `needs-human-input` label and a structured comment explaining the gaps.
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ For planned feature work, use epics as the unit you schedule and ship:
 1. `alpha-loop triage` reviews open issues, proposes cleanup, and groups related ready issues into parent epics with ordered child checklists.
 2. `alpha-loop roadmap` schedules parent epic issues into milestones, while still scheduling standalone issues that are not part of an epic.
 3. `alpha-loop run --epic <N>` ships the epic's child issues in checklist order. Agents working on each child issue receive the parent epic goal, acceptance criteria, and sibling checklist as context.
-4. `alpha-loop run --epics <A,B,C>` runs several parent epics back-to-back in that exact order, with a separate session branch and PR for each epic.
-5. `alpha-loop run --verify-only <N>` re-runs the epic verification pass when you need to re-check shipped child issues against the parent acceptance criteria.
+4. `alpha-loop roadmap --queue` recommends the next ordered epic queue, explains blockers and risks, and prints the exact `alpha-loop run --epics ...` command.
+5. `alpha-loop run --epics <A,B,C>` runs several parent epics back-to-back in that exact order, with a separate session branch and PR for each epic.
+6. `alpha-loop run --verify-only <N>` re-runs the epic verification pass when you need to re-check shipped child issues against the parent acceptance criteria.
 
 Milestones answer "when should this epic ship?" The epic checklist answers "what child issues ship, and in what order?"
 
@@ -311,6 +312,8 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop triage --dry-run` | Display cleanup findings and epic proposals without making changes |
 | `alpha-loop triage --yes` | Non-interactive mode: apply AI-selected cleanup actions and epic proposals |
 | `alpha-loop roadmap` | Schedule parent epics and standalone issues into milestones using AI analysis |
+| `alpha-loop roadmap --queue` | Recommend the next ordered epic run queue without making changes |
+| `alpha-loop roadmap --queue --milestone <name>` | Recommend an epic run queue within a release or sprint milestone |
 | `alpha-loop roadmap --dry-run` | Display proposed epic/standalone milestone assignments without making changes |
 | `alpha-loop roadmap --yes` | Non-interactive mode: apply all AI-recommended epic and standalone assignments |
 
@@ -599,6 +602,15 @@ alpha-loop run --epic 165
 ```
 
 `alpha-loop run --milestone "v1.0"` checks for open epics assigned to that milestone before fetching flat issues. One scheduled epic is processed automatically, multiple scheduled epics require `--epic <N>`, and no scheduled epics falls back to ready non-epic issues in that milestone. `--epic` always wins over `--milestone`; `--skip-epic` disables epic discovery and preserves the flat milestone flow.
+
+To ask Alpha Loop what to run next, use queue planning:
+
+```bash
+alpha-loop roadmap --queue
+alpha-loop roadmap --queue --milestone "v1.0"
+```
+
+Queue planning is read-only. It inspects open `epic` issues, milestone assignments, checklist progress, child readiness labels, dependency phrases such as `depends on #N`, and likely file overlap. When a runnable queue exists, it prints an executable command like `alpha-loop run --epics 205,166,214`; blocked epics stay out of the command and are listed with their blockers.
 
 To run several epics unattended while keeping review scope separate, pass an explicit queue:
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,9 @@ If the loop hangs or crashes mid-session, work can be stranded on local branches
 1. Scans for local `agent/issue-*` branches with commits but no open PR
 2. Pushes each branch to origin
 3. Runs code review
-4. Creates PRs and updates issue status
+4. Creates WIP PRs, marks issues `In Review`, and updates the session PR with a verification caveat
+
+Recovered PRs are not marked complete. `resume` does not rerun the project test suite or final smoke tests, so verify recovered work before merging.
 
 Use `--issue <N>` to resume a specific issue.
 
@@ -285,7 +287,7 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop history --clean` | Remove old session data |
 | `alpha-loop report routing` | Aggregate per-stage telemetry + cost-per-issue across sessions |
 | `alpha-loop sync` | Sync templates to configured harnesses (Claude, Codex, Cursor, etc.) |
-| `alpha-loop resume` | Resume stranded work — push branches, review, open PRs |
+| `alpha-loop resume` | Resume stranded work — push branches, review, open WIP PRs |
 | `alpha-loop resume --issue <N>` | Resume a specific issue |
 | `alpha-loop review` | Analyze learnings and propose self-improvements |
 | `alpha-loop review --apply` | Apply proposed improvements and create a draft PR |

--- a/README.md
+++ b/README.md
@@ -277,8 +277,9 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop scan` | Generate/refresh project context and instructions file |
 | `alpha-loop vision` | **(deprecated)** Use `alpha-loop plan` instead |
 | `alpha-loop auth` | Save authenticated browser state for verification |
-| `alpha-loop history` | View session history |
+| `alpha-loop history` | View session and queue history |
 | `alpha-loop history <name>` | View a specific session |
+| `alpha-loop history queue-<timestamp>` | Inspect a multi-epic queue manifest, including stopped/pending epics |
 | `alpha-loop history <name> --qa` | Show QA checklist for session |
 | `alpha-loop history <name> --telemetry` | Show per-stage telemetry table (see [docs/telemetry.md](docs/telemetry.md)) |
 | `alpha-loop history --clean` | Remove old session data |
@@ -618,7 +619,7 @@ To run several epics unattended while keeping review scope separate, pass an exp
 alpha-loop run --epics 205,166,214
 ```
 
-The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. By default, queue sessions use `stacked` ancestry: later epic session branches start from the previous successful session branch while their PRs still target the configured base branch. Use `--queue-branch-mode independent` for unrelated epics that should all branch from the base branch. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `--dry-run` prints the validated queue without mutating GitHub or git state.
+The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. By default, queue sessions use `stacked` ancestry: later epic session branches start from the previous successful session branch while their PRs still target the configured base branch. Use `--queue-branch-mode independent` for unrelated epics that should all branch from the base branch. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `alpha-loop history` lists those manifests and `alpha-loop history queue-<timestamp>` prints stopped/pending epics, session PRs, and rebase notes. `--dry-run` prints the validated queue without mutating GitHub or git state.
 
 Sub-issues are processed in checklist order (not issue-number order). Each sub-issue PR gets `Part of #165` appended, and the epic body's checkboxes auto-flip from `- [ ]` to `- [x]` as PRs merge. When every sub-issue has shipped, the loop runs a verification pass against each sub-issue's acceptance criteria — on `pass` the epic is auto-closed, on `partial` or `fail` it stays open with a `needs-human-input` label and a structured comment explaining the gaps.
 
@@ -664,6 +665,7 @@ What needs to be done.
 | `.alpha-loop/evals/` | Yes | Eval cases (YAML) and score history (`scores.jsonl`) |
 | `.alpha-loop/traces/` | No (gitignored) | Meta-Harness style execution traces per session |
 | `.alpha-loop/sessions/` | No (gitignored) | Local session logs, results JSON, screenshots |
+| `.alpha-loop/sessions/queue-<timestamp>/queue.json` | No (gitignored) | Multi-epic queue manifest with status, session PRs, merge order, and stop reason |
 | `.alpha-loop/auth/` | No (gitignored) | Saved browser auth state for verification |
 | `.worktrees/` | No (gitignored) | Temporary git worktrees during processing |
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ For planned feature work, use epics as the unit you schedule and ship:
 1. `alpha-loop triage` reviews open issues, proposes cleanup, and groups related ready issues into parent epics with ordered child checklists.
 2. `alpha-loop roadmap` schedules parent epic issues into milestones, while still scheduling standalone issues that are not part of an epic.
 3. `alpha-loop run --epic <N>` ships the epic's child issues in checklist order. Agents working on each child issue receive the parent epic goal, acceptance criteria, and sibling checklist as context.
-4. `alpha-loop run --verify-only <N>` re-runs the epic verification pass when you need to re-check shipped child issues against the parent acceptance criteria.
+4. `alpha-loop run --epics <A,B,C>` runs several parent epics back-to-back in that exact order, with a separate session branch and PR for each epic.
+5. `alpha-loop run --verify-only <N>` re-runs the epic verification pass when you need to re-check shipped child issues against the parent acceptance criteria.
 
 Milestones answer "when should this epic ship?" The epic checklist answers "what child issues ship, and in what order?"
 
@@ -269,6 +270,7 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop run` | Fetch matching issues, process them all, then exit |
 | `alpha-loop run --dry-run` | Preview without making changes |
 | `alpha-loop run --epic <N>` | Process an epic — its sub-issues in checklist order, auto-verify on completion (see [docs/epics.md](docs/epics.md)) |
+| `alpha-loop run --epics <ids>` | Process an ordered comma-separated queue of epics, one session branch and PR per epic |
 | `alpha-loop run --verify-only <N>` | Run just the epic verification pass — evaluates merged PRs against acceptance criteria |
 | `alpha-loop scan` | Generate/refresh project context and instructions file |
 | `alpha-loop vision` | **(deprecated)** Use `alpha-loop plan` instead |
@@ -329,6 +331,7 @@ Options:
   --batch             Batch mode: process multiple issues per agent call (faster, fewer tokens)
   --batch-size <n>    Issues per batch (default: 5)
   --epic <n>          Process a specific epic by issue number (skips the picker)
+  --epics <ids>       Process multiple epics in order (comma-separated)
   --skip-epic         Skip epic discovery, use flat/milestone flow
   --verify-only <n>   Run only the verification pass on an existing epic
 ```
@@ -594,6 +597,14 @@ alpha-loop run --epic 165
 ```
 
 `alpha-loop run --milestone "v1.0"` checks for open epics assigned to that milestone before fetching flat issues. One scheduled epic is processed automatically, multiple scheduled epics require `--epic <N>`, and no scheduled epics falls back to ready non-epic issues in that milestone. `--epic` always wins over `--milestone`; `--skip-epic` disables epic discovery and preserves the flat milestone flow.
+
+To run several epics unattended while keeping review scope separate, pass an explicit queue:
+
+```bash
+alpha-loop run --epics 205,166,214
+```
+
+The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `--dry-run` prints the validated queue without mutating GitHub or git state.
 
 Sub-issues are processed in checklist order (not issue-number order). Each sub-issue PR gets `Part of #165` appended, and the epic body's checkboxes auto-flip from `- [ ]` to `- [x]` as PRs merge. When every sub-issue has shipped, the loop runs a verification pass against each sub-issue's acceptance criteria — on `pass` the epic is auto-closed, on `partial` or `fail` it stays open with a `needs-human-input` label and a structured comment explaining the gaps.
 

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -121,6 +121,58 @@ alpha-loop run --skip-epic --milestone "v1.1"
 
 Skips epic discovery entirely and uses the flat milestone issue flow. Useful when you want to work on standalone issues in a milestone that also has scheduled parent epics.
 
+## Multi-Epic Queues
+
+Use one epic when the work has one integrated goal, one parent acceptance-criteria set, and one verification pass. Use a multi-epic queue when you want a long unattended run across several parent epics while keeping review scope separate. Each epic in the queue still produces its own session branch and session PR.
+
+There are two ways to build a queue:
+
+```bash
+alpha-loop roadmap --queue
+alpha-loop roadmap --queue --milestone "v1.1"
+```
+
+`roadmap --queue` is read-only. It inspects open epics, milestone order, child readiness, dependency phrases such as `depends on #N`, and likely file overlap. When at least one epic is runnable, it prints a command like:
+
+```bash
+alpha-loop run --epics 205,166,214
+```
+
+You can also provide the queue explicitly:
+
+```bash
+alpha-loop run --epics 205,166,214
+```
+
+Explicit queues are processed exactly in the order provided. Before any session starts, Alpha Loop validates that each issue exists, is labeled `epic`, is not duplicated, and is open unless already closed as completed. `--dry-run` performs the same validation and prints the queue without creating branches, PRs, GitHub comments, or queue manifests.
+
+### Execution Model
+
+For a non-dry-run queue, Alpha Loop writes:
+
+```text
+.alpha-loop/sessions/queue-<timestamp>/queue.json
+```
+
+The manifest records queue status, epic order, branch ancestry mode, per-epic session branch/PR URLs, dependency and overlap notes, failures, and the stop reason if the queue halts. `alpha-loop history` lists queue manifests alongside sessions, and `alpha-loop history queue-<timestamp>` prints the manifest details. If a queue stops, inspect that detail view to find the failed epic and the still-pending epics.
+
+Queue execution is fail-stop by default. Alpha Loop stops at the first epic that fails, remains incomplete after eligible children run, hits an epic checklist consistency error, fails verification, or encounters a transient agent/rate-limit stop. Earlier successful epic PRs stay available for review. Pending epics remain `pending` in `queue.json`; rerun them with a new explicit queue once the failure is resolved.
+
+If the process crashes inside a child issue before its branch has a PR, run `alpha-loop resume` to recover stranded `agent/issue-*` branches. Then inspect the queue manifest and continue with the remaining epic IDs.
+
+### Branch Ancestry Modes
+
+Queued epics always create separate session PRs that target the configured base branch. The branch ancestry controls where later session branches start.
+
+| Mode | Command | Branch behavior | When to use |
+|------|---------|-----------------|-------------|
+| `stacked` | `alpha-loop run --epics 205,166,214` | The first session branch starts from the base branch. Each later session branch starts from the previous successful session branch. | Related epics where later work may build on earlier queue changes. This is the default. |
+| `independent` | `alpha-loop run --epics 205,166,214 --queue-branch-mode independent` | Every session branch starts from the base branch. | Unrelated epics that only need queue order for scheduling or review coordination. |
+
+Stacked queue PRs include merge and rebase guidance. Merge the first session PR first. After it lands on the base branch, rebase the next stacked session branch onto the base branch before final review/merge, then repeat for the rest of the queue. Independent queue PRs should still be reviewed in queue order, but they can merge independently once ready because no branch ancestry dependency was created.
+
+Session PR bodies include an `Execution Queue` section with the queue ID, position, parent epic, previous/next epic, branch ancestry mode, dependency PR link, and risk notes. Dependency notes come from queued epic references such as `depends on #205`; overlap notes come from likely shared file paths mentioned in epic context.
+
 ## Sub-Issue Ordering
 
 Sub-issues are processed in the order they appear in the epic's task-list — **not** by issue number. To reorder, edit the epic body and rearrange the `- [ ] #N` lines.

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -158,7 +158,7 @@ The manifest records queue status, epic order, branch ancestry mode, per-epic se
 
 Queue execution is fail-stop by default. Alpha Loop stops at the first epic that fails, remains incomplete after eligible children run, hits an epic checklist consistency error, fails verification, or encounters a transient agent/rate-limit stop. Earlier successful epic PRs stay available for review. Pending epics remain `pending` in `queue.json`; rerun them with a new explicit queue once the failure is resolved.
 
-If the process crashes inside a child issue before its branch has a PR, run `alpha-loop resume` to recover stranded `agent/issue-*` branches. Then inspect the queue manifest and continue with the remaining epic IDs.
+If the process crashes inside a child issue before its branch has a PR, run `alpha-loop resume` to recover stranded `agent/issue-*` branches as WIP PRs. Recovered PRs are not marked complete; run the project tests and final verification before merging, then inspect the queue manifest and continue with the remaining epic IDs.
 
 ### Branch Ancestry Modes
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,7 +4,7 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>'],
   testMatch: ['**/*.test.ts', '**/*.test.tsx'],
-  testPathIgnorePatterns: ['/node_modules/'],
+  testPathIgnorePatterns: ['/node_modules/', '/.worktrees/'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,7 @@ program
   .option('--verbose', 'Stream live agent output to terminal')
   .option('--epic <n>', 'Process a specific epic by issue number (skips the picker)', parseInt)
   .option('--epics <ids>', 'Process multiple epics in order (comma-separated issue numbers)')
+  .option('--queue-branch-mode <mode>', 'Branch mode for --epics: stacked or independent')
   .option('--skip-epic', 'Skip epic discovery, use flat/milestone flow')
   .option('--verify-only <n>', 'Run only the verification pass on an existing epic', parseInt)
   .action(async (options) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ program
   .option('--fix', 'Auto-fix validation issues (reorder deps, comment on incomplete issues)')
   .option('--verbose', 'Stream live agent output to terminal')
   .option('--epic <n>', 'Process a specific epic by issue number (skips the picker)', parseInt)
+  .option('--epics <ids>', 'Process multiple epics in order (comma-separated issue numbers)')
   .option('--skip-epic', 'Skip epic discovery, use flat/milestone flow')
   .option('--verify-only <n>', 'Run only the verification pass on an existing epic', parseInt)
   .action(async (options) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,7 +143,7 @@ program
 
 program
   .command('resume')
-  .description('Resume stranded work — push branches, run review, open PRs')
+  .description('Resume stranded work — push branches, run review, open WIP PRs')
   .option('--issue <num>', 'Only resume a specific issue number')
   .option('--session <name>', 'Resume from a specific session directory')
   .action(async (options) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ program
 
 program
   .command('history [session]')
-  .description('View session history')
+  .description('View session and queue history')
   .option('--qa', 'Show QA checklist for session')
   .option('--clean', 'Remove old session data')
   .option('--telemetry', 'Show per-stage telemetry for a session')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -132,6 +132,8 @@ program
 program
   .command('roadmap')
   .description('Schedule parent epics and standalone issues into milestones using AI analysis')
+  .option('--queue', 'Recommend the next ordered epic run queue without making changes')
+  .option('--milestone <name>', 'Limit queue recommendations to epics in a milestone')
   .option('--dry-run', 'Display proposed epic/standalone milestone assignments without making changes')
   .option('-y, --yes', 'Skip interactive prompts, accept all AI recommendations')
   .action(async (options) => {

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -5,13 +5,22 @@ import { readStageTelemetry } from '../lib/telemetry.js';
 import type { StageTelemetry } from '../lib/telemetry.js';
 import type { PipelineResult } from '../lib/pipeline.js';
 import type { EscalationEvent } from '../lib/escalation.js';
+import type { EpicQueueManifest, QueueSessionContext } from '../lib/epic-queue.js';
 
 type SessionManifest = {
   name: string;
   branch: string;
   completed: string;
   results: PipelineResult[];
+  queue?: QueueSessionContext;
   stages?: StageTelemetry[];
+};
+
+type QueueManifestRef = {
+  dir: string;
+  name: string;
+  timestamp: string;
+  manifest: EpicQueueManifest;
 };
 
 function formatDuration(seconds: number | undefined): string {
@@ -71,6 +80,55 @@ function findSessionDirs(sessionsRoot: string): Array<{ dir: string; name: strin
   return sessions;
 }
 
+function loadQueueManifest(filePath: string): EpicQueueManifest | null {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as EpicQueueManifest;
+    if (!manifest.queueId || !Array.isArray(manifest.epics)) return null;
+    return manifest;
+  } catch {
+    return null;
+  }
+}
+
+function queueTimestamp(queueId: string): string {
+  return queueId.startsWith('queue-') ? queueId.slice('queue-'.length) : queueId;
+}
+
+/**
+ * Find multi-epic queue manifests under .alpha-loop/sessions/queue-<timestamp>/queue.json.
+ */
+function findQueueManifests(sessionsRoot: string): QueueManifestRef[] {
+  if (!fs.existsSync(sessionsRoot)) return [];
+
+  const queues: QueueManifestRef[] = [];
+  for (const entry of fs.readdirSync(sessionsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith('queue-')) continue;
+    const dir = path.join(sessionsRoot, entry.name);
+    const manifest = loadQueueManifest(path.join(dir, 'queue.json'));
+    if (!manifest) continue;
+    const name = manifest.queueId || entry.name;
+    queues.push({
+      dir,
+      name,
+      timestamp: queueTimestamp(name),
+      manifest,
+    });
+  }
+
+  queues.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return queues;
+}
+
+function findQueueManifest(sessionsRoot: string, name: string): QueueManifestRef | undefined {
+  const wanted = name.trim();
+  if (!wanted) return undefined;
+  return findQueueManifests(sessionsRoot).find((queue) => (
+    queue.name === wanted ||
+    queue.timestamp === wanted ||
+    queue.name.endsWith(wanted)
+  ));
+}
+
 /**
  * Load session manifests from the learnings directory (checked into git, shared with team).
  * These are created during session finalization.
@@ -96,6 +154,7 @@ function loadManifests(projectDir?: string): Map<string, SessionManifest> {
 export function historyList(sessionsDir: string, projectDir?: string): void {
   const localSessions = findSessionDirs(sessionsDir);
   const manifests = loadManifests(projectDir);
+  const queues = findQueueManifests(sessionsDir);
 
   // Build a unified list: local sessions + manifests not covered by local data
   const seenNames = new Set(localSessions.map((s) => s.name));
@@ -129,42 +188,130 @@ export function historyList(sessionsDir: string, projectDir?: string): void {
   // Sort newest first
   entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 
-  if (entries.length === 0) {
+  if (entries.length === 0 && queues.length === 0) {
     console.log('No sessions found.');
     return;
   }
 
-  console.log('Sessions:');
-  console.log('');
+  if (entries.length > 0) {
+    console.log('Sessions:');
+    console.log('');
 
-  for (const entry of entries) {
-    const issueCount = entry.results.length;
-    const successCount = entry.results.filter((r) => r.status === 'success').length;
-    const failedCount = issueCount - successCount;
-    const totalDuration = entry.results.reduce((sum, r) => sum + r.duration, 0);
-    const durStr = formatDuration(totalDuration);
+    for (const entry of entries) {
+      const issueCount = entry.results.length;
+      const successCount = entry.results.filter((r) => r.status === 'success').length;
+      const failedCount = issueCount - successCount;
+      const totalDuration = entry.results.reduce((sum, r) => sum + r.duration, 0);
+      const durStr = formatDuration(totalDuration);
 
-    // Parse date from timestamp (YYYYMMDD-HHMMSS)
-    const ts = entry.timestamp;
-    const date = ts.length >= 8
-      ? `${ts.slice(0, 4)}-${ts.slice(4, 6)}-${ts.slice(6, 8)}`
-      : ts;
+      // Parse date from timestamp (YYYYMMDD-HHMMSS)
+      const ts = entry.timestamp;
+      const date = ts.length >= 8
+        ? `${ts.slice(0, 4)}-${ts.slice(4, 6)}-${ts.slice(6, 8)}`
+        : ts;
 
-    const issueWord = issueCount === 1 ? 'issue' : 'issues';
-    let statusParts = '';
-    if (successCount > 0) statusParts += `${successCount} \u2713`;
-    if (failedCount > 0) statusParts += ` ${failedCount} \u2717`;
-    if (issueCount === 0) statusParts = '(empty)';
+      const issueWord = issueCount === 1 ? 'issue' : 'issues';
+      let statusParts = '';
+      if (successCount > 0) statusParts += `${successCount} \u2713`;
+      if (failedCount > 0) statusParts += ` ${failedCount} \u2717`;
+      if (issueCount === 0) statusParts = '(empty)';
 
-    console.log(
-      `  ${entry.name.padEnd(30)} ${date}  ${String(issueCount).padStart(2)} ${issueWord.padEnd(7)} ${statusParts.padEnd(10)} ${durStr}`,
-    );
+      console.log(
+        `  ${entry.name.padEnd(30)} ${date}  ${String(issueCount).padStart(2)} ${issueWord.padEnd(7)} ${statusParts.padEnd(10)} ${durStr}`,
+      );
+    }
+  }
+
+  if (queues.length > 0) {
+    if (entries.length > 0) console.log('');
+    console.log('Queues:');
+    console.log('');
+    for (const queue of queues) {
+      const manifest = queue.manifest;
+      const epicCount = manifest.epics.length;
+      const successCount = manifest.epics.filter((entry) => entry.status === 'success').length;
+      const failedCount = manifest.epics.filter((entry) => entry.status === 'failure').length;
+      const pendingCount = manifest.epics.filter((entry) => entry.status === 'pending' || entry.status === 'running').length;
+      const startedAt = manifest.startedAt ?? '';
+      const date = startedAt.length >= 10 ? startedAt.slice(0, 10) : queue.timestamp;
+      const epicWord = epicCount === 1 ? 'epic' : 'epics';
+      const status = `${manifest.status}${manifest.stopReason ? `: ${manifest.stopReason}` : ''}`;
+      console.log(
+        `  ${queue.name.padEnd(30)} ${date}  ${String(epicCount).padStart(2)} ${epicWord.padEnd(6)} ${successCount} ok, ${failedCount} failed, ${pendingCount} pending  ${status}`,
+      );
+    }
   }
 }
 
-export function historyDetail(sessionsDir: string, sessionName: string): void {
+function formatQueueEpicStatus(status: string): string {
+  if (status === 'success') return 'success';
+  if (status === 'failure') return 'failed';
+  if (status === 'skipped') return 'skipped';
+  if (status === 'running') return 'running';
+  return 'pending';
+}
+
+function printQueueManifestDetail(queue: QueueManifestRef, projectDir?: string): void {
+  const root = projectDir ?? process.cwd();
+  const manifest = queue.manifest;
+  const manifestPath = path.relative(root, path.join(queue.dir, 'queue.json'));
+
+  console.log(`Queue:       ${manifest.queueId}`);
+  console.log(`Status:      ${manifest.status}`);
+  console.log(`Branch mode: ${manifest.branchAncestryMode}`);
+  console.log(`Started:     ${manifest.startedAt}`);
+  if (manifest.endedAt) console.log(`Ended:       ${manifest.endedAt}`);
+  if (manifest.stopReason) console.log(`Stop reason: ${manifest.stopReason}`);
+  console.log(`Manifest:    ${manifestPath}`);
+  console.log('');
+
+  console.log('Epics:');
+  for (const entry of manifest.epics) {
+    console.log(`  ${entry.queueIndex}/${entry.queueTotal} #${entry.epicNumber} ${entry.title} — ${formatQueueEpicStatus(entry.status)}`);
+    if (entry.sessionName) console.log(`           Session: ${entry.sessionName}`);
+    if (entry.sessionBranch) console.log(`           Branch:  ${entry.sessionBranch}`);
+    if (entry.sessionPrUrl) console.log(`           PR:      ${entry.sessionPrUrl}`);
+    if (entry.branchedFromBranch) console.log(`           From:    ${entry.branchedFromBranch}`);
+    if (entry.dependsOnSessionBranch) {
+      const pr = entry.dependsOnSessionPrUrl ? ` (${entry.dependsOnSessionPrUrl})` : '';
+      console.log(`           Depends: ${entry.dependsOnSessionBranch}${pr}`);
+    }
+    if (entry.rebaseOntoBranch) console.log(`           Rebase:  ${entry.sessionBranch ?? 'this branch'} onto ${entry.rebaseOntoBranch} after the dependency PR lands`);
+    for (const warning of entry.dependencyWarnings ?? []) console.log(`           Dependency: ${warning}`);
+    for (const warning of entry.overlapWarnings ?? []) console.log(`           File overlap: ${warning}`);
+    for (const failure of entry.failures ?? []) console.log(`           Failure: ${failure.code} — ${failure.message}`);
+  }
+}
+
+function printSessionQueueSummary(queue: QueueSessionContext): void {
+  console.log('');
+  console.log('Queue:');
+  console.log(`  ID:        ${queue.queueId}`);
+  console.log(`  Position:  ${queue.queueIndex} of ${queue.queueTotal}`);
+  console.log(`  Epic:      #${queue.currentEpic.number} ${queue.currentEpic.title}`);
+  console.log(`  Mode:      ${queue.branchAncestryMode}`);
+  console.log(`  From:      ${queue.branchedFromBranch}`);
+  if (queue.dependsOnSessionBranch) {
+    const pr = queue.dependsOnSessionPrUrl ? ` (${queue.dependsOnSessionPrUrl})` : '';
+    console.log(`  Depends:   ${queue.dependsOnSessionBranch}${pr}`);
+  }
+  if (queue.rebaseOntoBranch) {
+    console.log(`  Rebase:    onto ${queue.rebaseOntoBranch} after the dependency PR lands`);
+  }
+}
+
+export function historyDetail(sessionsDir: string, sessionName: string, projectDir?: string): void {
+  const queue = findQueueManifest(sessionsDir, sessionName);
+  if (queue) {
+    printQueueManifestDetail(queue, projectDir);
+    return;
+  }
+
   let results: PipelineResult[] = [];
   let sessionDir: string | undefined;
+  let manifest: SessionManifest | undefined;
+  const root = projectDir ?? process.cwd();
+  const manifests = loadManifests(root);
 
   // Try local session directories first
   const localDir = path.join(sessionsDir, sessionName);
@@ -182,14 +329,16 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
 
   // Fall back to manifest from learnings (checked-in data from teammates)
   if (results.length === 0) {
-    const manifests = loadManifests();
-    const manifest = manifests.get(sessionName)
+    manifest = manifests.get(sessionName)
       ?? [...manifests.values()].find((m) => m.name.endsWith(sessionName));
     if (manifest) {
       results = manifest.results;
       sessionName = manifest.name;
     }
   }
+
+  manifest ??= manifests.get(sessionName)
+    ?? [...manifests.values()].find((m) => m.name === sessionName || m.name.endsWith(sessionName));
 
   if (results.length === 0) {
     log.error(`Session not found: ${sessionName}`);
@@ -204,6 +353,11 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
   console.log(`Issues:   ${results.length} (${successCount} succeeded, ${results.length - successCount} failed)`);
   console.log(`Duration: ${formatDuration(totalDuration)}`);
   console.log('');
+
+  if (manifest?.queue) {
+    printSessionQueueSummary(manifest.queue);
+    console.log('');
+  }
 
   // Stage-revert banner: if any issue in this session has an active revert event, flag it.
   const activeReverts = new Set<string>();
@@ -284,7 +438,7 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
   }
 
   // Check for session summary in learnings
-  const learningsDir = path.join(process.cwd(), '.alpha-loop', 'learnings');
+  const learningsDir = path.join(root, '.alpha-loop', 'learnings');
   const summaryName = `session-summary-${sessionName.replace(/\//g, '-')}.md`;
   const summaryPath = path.join(learningsDir, summaryName);
   if (fs.existsSync(summaryPath)) {

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -226,6 +226,7 @@ export function historyList(sessionsDir: string, projectDir?: string): void {
     if (entries.length > 0) console.log('');
     console.log('Queues:');
     console.log('');
+
     for (const queue of queues) {
       const manifest = queue.manifest;
       const epicCount = manifest.epics.length;
@@ -236,6 +237,7 @@ export function historyList(sessionsDir: string, projectDir?: string): void {
       const date = startedAt.length >= 10 ? startedAt.slice(0, 10) : queue.timestamp;
       const epicWord = epicCount === 1 ? 'epic' : 'epics';
       const status = `${manifest.status}${manifest.stopReason ? `: ${manifest.stopReason}` : ''}`;
+
       console.log(
         `  ${queue.name.padEnd(30)} ${date}  ${String(epicCount).padStart(2)} ${epicWord.padEnd(6)} ${successCount} ok, ${failedCount} failed, ${pendingCount} pending  ${status}`,
       );
@@ -267,7 +269,7 @@ function printQueueManifestDetail(queue: QueueManifestRef, projectDir?: string):
 
   console.log('Epics:');
   for (const entry of manifest.epics) {
-    console.log(`  ${entry.queueIndex}/${entry.queueTotal} #${entry.epicNumber} ${entry.title} — ${formatQueueEpicStatus(entry.status)}`);
+    console.log(`  ${entry.queueIndex}/${entry.queueTotal} #${entry.epicNumber} ${entry.title} - ${formatQueueEpicStatus(entry.status)}`);
     if (entry.sessionName) console.log(`           Session: ${entry.sessionName}`);
     if (entry.sessionBranch) console.log(`           Branch:  ${entry.sessionBranch}`);
     if (entry.sessionPrUrl) console.log(`           PR:      ${entry.sessionPrUrl}`);
@@ -276,10 +278,12 @@ function printQueueManifestDetail(queue: QueueManifestRef, projectDir?: string):
       const pr = entry.dependsOnSessionPrUrl ? ` (${entry.dependsOnSessionPrUrl})` : '';
       console.log(`           Depends: ${entry.dependsOnSessionBranch}${pr}`);
     }
-    if (entry.rebaseOntoBranch) console.log(`           Rebase:  ${entry.sessionBranch ?? 'this branch'} onto ${entry.rebaseOntoBranch} after the dependency PR lands`);
+    if (entry.rebaseOntoBranch) {
+      console.log(`           Rebase:  ${entry.sessionBranch ?? 'this branch'} onto ${entry.rebaseOntoBranch} after the dependency PR lands`);
+    }
     for (const warning of entry.dependencyWarnings ?? []) console.log(`           Dependency: ${warning}`);
     for (const warning of entry.overlapWarnings ?? []) console.log(`           File overlap: ${warning}`);
-    for (const failure of entry.failures ?? []) console.log(`           Failure: ${failure.code} — ${failure.message}`);
+    for (const failure of entry.failures ?? []) console.log(`           Failure: ${failure.code} - ${failure.message}`);
   }
 }
 
@@ -442,7 +446,7 @@ export function historyDetail(sessionsDir: string, sessionName: string, projectD
   const summaryName = `session-summary-${sessionName.replace(/\//g, '-')}.md`;
   const summaryPath = path.join(learningsDir, summaryName);
   if (fs.existsSync(summaryPath)) {
-    console.log(`Summary:      ${path.relative(process.cwd(), summaryPath)}`);
+    console.log(`Summary:      ${path.relative(root, summaryPath)}`);
   }
 }
 

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -5,7 +5,8 @@
  * origin/<baseBranch> but no corresponding open PR, then pushes, reviews,
  * and opens a PR for each one. Also updates the session PR if one exists.
  */
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadConfig, resolveStepConfig } from '../lib/config.js';
 import { log } from '../lib/logger.js';
@@ -400,11 +401,10 @@ This PR collects all changes from this session for final review before merging t
   ghExec(`gh pr edit ${prNumber} --repo "${repo}" --title ${JSON.stringify(title)}`, undefined, true);
 
   // Use --body-file to avoid escaping issues
-  const { tmpdir } = require('node:os') as typeof import('node:os');
   const bodyFile = join(tmpdir(), `alpha-loop-session-pr-${Date.now()}`);
   writeFileSync(bodyFile, body, 'utf-8');
   ghExec(`gh pr edit ${prNumber} --repo "${repo}" --body-file "${bodyFile}"`, undefined, true);
-  try { require('node:fs').unlinkSync(bodyFile); } catch { /* cleanup */ }
+  try { unlinkSync(bodyFile); } catch { /* cleanup */ }
 
   log.success(`Session PR updated: ${prUrl}`);
 }

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -179,7 +179,7 @@ function printStrandedSummary(item: StrandedBranch): void {
 async function resumeBranch(
   item: StrandedBranch,
   config: ReturnType<typeof loadConfig>,
-): Promise<{ issueNum: number; prUrl: string; title: string } | null> {
+): Promise<{ issueNum: number; prUrl: string; title: string; filesChanged: number } | null> {
   const { branch, issueNum } = item;
   const repo = config.repo;
   const baseBranch = config.baseBranch;
@@ -244,10 +244,15 @@ async function resumeBranch(
     }
   }
 
-  // Build PR body
+  // Build PR body. Resume recovers stranded work; it does not prove the issue
+  // is complete, so every recovered PR carries an explicit verification caveat.
+  const resumeCaveat = `## Resume Caveat
+
+This PR was recovered by \`alpha-loop resume\`. Resume creates the PR and runs best-effort review only; it does not rerun the project test suite or final verification smoke tests. Treat this PR as WIP until those checks pass.`;
+
   const prBody = reviewOutput
-    ? `## Code Review\n\n${reviewOutput}`
-    : `Resumes stranded work for issue #${issueNum}.`;
+    ? `${resumeCaveat}\n\n## Code Review\n\n${reviewOutput}`
+    : `${resumeCaveat}\n\nResumes stranded work for issue #${issueNum}.`;
 
   // Create PR (createPR handles push internally as well; that is idempotent)
   log.step(`Creating PR for #${issueNum}...`);
@@ -270,19 +275,19 @@ async function resumeBranch(
   // Update issue labels: add in-review, remove in-progress
   labelIssue(repo, issueNum, 'in-review', 'in-progress');
 
-  // Update project board status to Done
+  // Recovered PRs still need review and verification; do not mark them Done.
   if (config.project && config.project > 0) {
-    updateProjectStatus(repo, config.project, config.repoOwner, issueNum, 'Done');
+    updateProjectStatus(repo, config.project, config.repoOwner, issueNum, 'In Review');
   }
 
   // Comment on the issue with the PR link
   commentIssue(
     repo,
     issueNum,
-    `Resumed by alpha-loop. PR ready for review: ${prUrl}`,
+    `Resumed by alpha-loop. PR opened for review: ${prUrl}\n\nFinal tests and verification were not run by resume; treat the PR as WIP until they pass.`,
   );
 
-  return { issueNum, prUrl, title };
+  return { issueNum, prUrl, title, filesChanged: item.filesChanged.length };
 }
 
 /**
@@ -330,6 +335,15 @@ function saveResumedResult(
   const filePath = join(sessionDir, `result-${result.issueNum}.json`);
   writeFileSync(filePath, JSON.stringify(result, null, 2) + '\n');
   log.info(`Session result saved: ${filePath}`);
+}
+
+function isRecoveredUnverified(result: PipelineResult): boolean {
+  return Boolean(result.prUrl) && result.verifySkipped && !result.verifyPassing;
+}
+
+function formatSessionIssueStatus(result: PipelineResult): string {
+  if (isRecoveredUnverified(result)) return 'RECOVERED - VERIFY SKIPPED';
+  return result.status === 'success' ? 'SUCCESS' : 'FAILURE';
 }
 
 /**
@@ -381,6 +395,14 @@ function updateSessionPR(
 
   const successCount = results.filter((r) => r.status === 'success').length;
   const totalDuration = results.reduce((sum, r) => sum + r.duration, 0);
+  const recoveredUnverifiedCount = results.filter(isRecoveredUnverified).length;
+  const resumeCaveat = recoveredUnverifiedCount > 0
+    ? `
+### Resume Caveat
+
+${recoveredUnverifiedCount} recovered PR(s) were not counted as succeeded because \`alpha-loop resume\` does not rerun tests or final verification smoke tests.
+`
+    : '';
 
   const title = `Session: ${sessionName} — ${successCount}/${results.length} succeeded`;
   const body = `## Session Summary
@@ -389,9 +411,10 @@ function updateSessionPR(
 **Issues processed:** ${results.length} (${successCount} succeeded, ${results.length - successCount} failed)
 **Total duration:** ${Math.round(totalDuration / 60)} minutes
 **Updated:** ${new Date().toISOString()}
+${resumeCaveat}
 
 ### Issues
-${results.map((r) => `- #${r.issueNum}: ${r.title} — ${r.status === 'success' ? 'SUCCESS' : 'FAILURE'}${r.prUrl ? ` ([PR](${r.prUrl}))` : ''}`).join('\n')}
+${results.map((r) => `- #${r.issueNum}: ${r.title} — ${formatSessionIssueStatus(r)}${r.prUrl ? ` ([PR](${r.prUrl}))` : ''}`).join('\n')}
 
 ---
 This PR collects all changes from this session for final review before merging to ${baseBranch}.
@@ -450,7 +473,7 @@ export async function resumeCommand(options: ResumeOptions): Promise<void> {
   }
 
   // Process each stranded branch
-  const results: Array<{ issueNum: number; prUrl: string; title: string }> = [];
+  const results: Array<{ issueNum: number; prUrl: string; title: string; filesChanged: number }> = [];
   const failed: number[] = [];
 
   for (const item of withoutPR) {
@@ -469,13 +492,14 @@ export async function resumeCommand(options: ResumeOptions): Promise<void> {
       const pipelineResult: PipelineResult = {
         issueNum: r.issueNum,
         title: r.title,
-        status: 'success',
+        status: 'failure',
+        failureReason: 'transient',
         prUrl: r.prUrl,
-        testsPassing: true,
+        testsPassing: false,
         verifyPassing: false, // verification was skipped/crashed
         verifySkipped: true,
         duration: 0,
-        filesChanged: 0,
+        filesChanged: r.filesChanged,
       };
       saveResumedResult(session.sessionDir, pipelineResult);
       updateSessionPR(config.repo, session.sessionName, session.sessionDir, config.baseBranch);

--- a/src/commands/roadmap.ts
+++ b/src/commands/roadmap.ts
@@ -14,8 +14,10 @@ import { exec } from '../lib/shell.js';
 import { log } from '../lib/logger.js';
 import {
   extractJsonFromResponse,
+  formatEpicQueuePlan,
   formatRoadmapTable,
   normalizeRoadmapPlan,
+  planEpicQueue,
   buildPlanningContext,
   type RoadmapPlan,
 } from '../lib/planning.js';
@@ -31,19 +33,28 @@ import {
 export type RoadmapOptions = {
   dryRun?: boolean;
   yes?: boolean;
+  queue?: boolean;
+  milestone?: string;
 };
 
 /** Truncate issue bodies to stay within agent context limits. */
 const MAX_BODY_CHARS = 500;
 
 export async function roadmapCommand(options: RoadmapOptions): Promise<void> {
-  const config = loadConfig({ dryRun: options.dryRun });
+  const configOverrides: NonNullable<Parameters<typeof loadConfig>[0]> = {};
+  if (options.queue) {
+    configOverrides.dryRun = true;
+    if (options.milestone) configOverrides.milestone = options.milestone;
+  } else if (options.dryRun !== undefined) {
+    configOverrides.dryRun = options.dryRun;
+  }
+  const config = loadConfig(configOverrides);
 
   // ── Fetch open issues ──────────────────────────────────────────────────────
   log.step('Fetching open issues...');
-  const issues = listOpenIssues(config.repo);
+  const issues = options.queue ? listOpenIssues(config.repo, 1000) : listOpenIssues(config.repo);
 
-  if (issues.length === 0) {
+  if (issues.length === 0 && !options.queue) {
     log.info('No open issues found. Nothing to organize.');
     return;
   }
@@ -58,6 +69,20 @@ export async function roadmapCommand(options: RoadmapOptions): Promise<void> {
   log.step('Fetching existing milestones...');
   const existingMilestones = listMilestones(config.repo);
   log.info(`Found ${existingMilestones.length} existing milestone(s)`);
+
+  if (options.queue) {
+    const plan = planEpicQueue(epics, {
+      labelReady: config.labelReady,
+      milestone: options.milestone ?? null,
+      openIssues: issues,
+      milestones: existingMilestones,
+    });
+    console.log('');
+    console.log(formatEpicQueuePlan(plan));
+    console.log('');
+    log.dry('Queue planning only — no changes will be made.');
+    return;
+  }
 
   const epicIssueNums = new Set(epics.map((epic) => epic.issueNum));
   const epicChildIssueNums = new Set(epics.flatMap((epic) => epic.children.map((child) => child.issueNum)));

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -55,6 +55,53 @@ export type RunOptions = {
   verifyOnly?: number;
 };
 
+export type EpicExecutionFailureCode =
+  | 'invalid-epic-number'
+  | 'epic-not-found'
+  | 'missing-epic-label'
+  | 'no-eligible-child-issues'
+  | 'checklist-update-failed'
+  | 'issue-processing-error'
+  | 'batch-processing-error'
+  | 'pipeline-failure'
+  | 'epic-verification-failed';
+
+export type EpicExecutionFailure = {
+  code: EpicExecutionFailureCode;
+  message: string;
+  issueNum?: number;
+  exitCode?: number;
+};
+
+export type EpicExecutionResult = {
+  epicNumber: number;
+  sessionName: string | null;
+  sessionBranch: string | null;
+  sessionPrUrl: string | null;
+  status: 'success' | 'failure';
+  failures: EpicExecutionFailure[];
+  verificationClosedEpic: boolean;
+};
+
+type EpicVerificationFlowResult = {
+  epicNumber: number;
+  status: 'pass' | 'needs-human-input' | 'skipped' | 'failure';
+  closedEpic: boolean;
+  verdict?: string;
+  failure?: EpicExecutionFailure;
+};
+
+type SessionExecutionTarget =
+  | { type: 'epic'; epicNum: number; epicTitle?: string; epicIssue: Issue }
+  | { type: 'flat'; activeMilestone: string };
+
+type SessionExecutionResult = {
+  session: SessionContext;
+  sessionPrUrl: string | null;
+  failures: EpicExecutionFailure[];
+  verificationClosedEpic: boolean;
+};
+
 /**
  * Check that required CLI tools are installed.
  * Also warns about optional tools (playwright-cli) that improve the pipeline.
@@ -276,32 +323,6 @@ async function pickTarget(
 async function resolveRunTarget(config: Config, options: RunOptions): Promise<ResolvedRunTarget | null> {
   let activeMilestone = config.milestone;
 
-  // --epic <N> overrides everything except --verify-only
-  if (options.epic !== undefined) {
-    if (typeof options.epic !== 'number' || !Number.isFinite(options.epic) || options.epic <= 0) {
-      log.error('--epic requires a positive integer issue number (e.g. --epic 165)');
-      process.exit(1);
-      return null;
-    }
-    const epic = getIssueWithComments(config.repo, options.epic);
-    if (!epic) {
-      log.error(`Could not fetch epic #${options.epic}`);
-      process.exit(1);
-      return null;
-    }
-    if (!hasEpicLabel(epic)) {
-      log.error(`Issue #${options.epic} is not labeled 'epic'. Add the epic label before running --epic.`);
-      process.exit(1);
-      return null;
-    }
-    return {
-      activeEpic: epic.number,
-      activeEpicTitle: epic.title,
-      activeEpicIssue: epic,
-      activeMilestone: '',
-    };
-  }
-
   if (activeMilestone && options.skipEpic !== true) {
     const scheduledEpics = listEpics(config.repo, { milestone: activeMilestone });
 
@@ -362,21 +383,32 @@ async function runEpicVerificationFlow(
   epicNum: number,
   config: Config,
   session: SessionContext | null,
-): Promise<void> {
+): Promise<EpicVerificationFlowResult> {
   const epic = getIssueWithComments(config.repo, epicNum);
   if (!epic) {
-    log.error(`Could not fetch epic #${epicNum}`);
-    return;
+    const message = `Could not fetch epic #${epicNum}`;
+    log.error(message);
+    return {
+      epicNumber: epicNum,
+      status: 'failure',
+      closedEpic: false,
+      failure: { code: 'epic-not-found', message },
+    };
   }
   if (!hasEpicLabel(epic)) {
-    log.error(`Issue #${epicNum} is not labeled 'epic'. Add the epic label before running epic verification.`);
-    process.exit(1);
-    return;
+    const message = `Issue #${epicNum} is not labeled 'epic'. Add the epic label before running epic verification.`;
+    log.error(message);
+    return {
+      epicNumber: epicNum,
+      status: 'failure',
+      closedEpic: false,
+      failure: { code: 'missing-epic-label', message, issueNum: epicNum, exitCode: 1 },
+    };
   }
   const refs = getEpicSubIssues(config.repo, epicNum);
   if (refs.length === 0) {
     log.warn(`Epic #${epicNum} has no sub-issues in its checklist — nothing to verify`);
-    return;
+    return { epicNumber: epicNum, status: 'skipped', closedEpic: false };
   }
 
   const subIssues: Issue[] = [];
@@ -401,16 +433,33 @@ async function runEpicVerificationFlow(
   if (config.dryRun) {
     log.dry(`[verify-only] Would post comment on #${epicNum} (verdict=${result.verdict})`);
     console.error(result.comment);
-    return;
+    return {
+      epicNumber: epicNum,
+      status: result.verdict === 'pass' ? 'pass' : 'needs-human-input',
+      closedEpic: false,
+      verdict: result.verdict,
+    };
   }
 
   commentIssue(config.repo, epicNum, result.comment);
   if (result.verdict === 'pass') {
     closeIssue(config.repo, epicNum, 'completed');
     log.success(`Epic #${epicNum} verified and closed`);
+    return {
+      epicNumber: epicNum,
+      status: 'pass',
+      closedEpic: true,
+      verdict: result.verdict,
+    };
   } else {
     labelIssue(config.repo, epicNum, 'needs-human-input');
     log.warn(`Epic #${epicNum} needs human review: verdict=${result.verdict}`);
+    return {
+      epicNumber: epicNum,
+      status: 'needs-human-input',
+      closedEpic: false,
+      verdict: result.verdict,
+    };
   }
 }
 
@@ -538,49 +587,17 @@ function markEpicChecklistItem(
   if (contextItem) contextItem.checked = checked;
 }
 
-/**
- * Run the main loop: poll for issues, process them, finalize session.
- */
-export async function runCommand(options: RunOptions): Promise<void> {
-  // Build config from YAML + env + CLI flags
-  const overrides: Partial<Config> = {};
-  if (options.dryRun) overrides.dryRun = true;
-  if (options.model) overrides.model = options.model;
-  if (options.skipTests) overrides.skipTests = true;
-  if (options.skipReview) overrides.skipReview = true;
-  if (options.skipLearn) overrides.skipLearn = true;
-  if (options.milestone) overrides.milestone = options.milestone;
-  if (options.autoMerge) overrides.autoMerge = true;
-  if (options.mergeTo) overrides.mergeTo = options.mergeTo;
-  if (options.batch) overrides.batch = true;
-  if (options.batchSize) overrides.batchSize = options.batchSize;
-  if (options.verbose) overrides.verbose = true;
-
-  const config = loadConfig(overrides);
-
-  if (!config.repo) {
-    log.error('No repository configured. Run "alpha-loop init" or set repo in .alpha-loop.yaml');
-    process.exit(1);
-  }
-
-  // --- Verify-only path: bypass the normal loop entirely ---
-  if (options.verifyOnly !== undefined) {
-    if (!Number.isFinite(options.verifyOnly) || options.verifyOnly <= 0) {
-      log.error('--verify-only requires a positive integer issue number (e.g. --verify-only 165)');
-      process.exit(1);
-    }
-    log.step(`Running verify-only pass for epic #${options.verifyOnly}`);
-    await runEpicVerificationFlow(options.verifyOnly, config, null);
-    return;
-  }
-
-  // --- Target selection (epic or milestone) — must happen before session creation ---
-  const target = await resolveRunTarget(config, options);
-  if (!target) return;
-  let activeEpic = target.activeEpic;
-  let activeEpicTitle = target.activeEpicTitle;
-  let activeEpicIssue = target.activeEpicIssue;
-  const activeMilestone = target.activeMilestone;
+async function runIssueSession(
+  config: Config,
+  options: RunOptions,
+  target: SessionExecutionTarget,
+): Promise<SessionExecutionResult> {
+  const activeEpic = target.type === 'epic' ? target.epicNum : undefined;
+  const activeEpicTitle = target.type === 'epic' ? target.epicTitle : undefined;
+  const activeEpicIssue = target.type === 'epic' ? target.epicIssue : undefined;
+  const activeMilestone = target.type === 'flat' ? target.activeMilestone : '';
+  const failures: EpicExecutionFailure[] = [];
+  let verificationClosedEpic = false;
 
   if (activeEpic !== undefined) {
     log.info(`Processing epic #${activeEpic}${activeEpicTitle ? ': ' + activeEpicTitle : ''}`);
@@ -708,37 +725,34 @@ export async function runCommand(options: RunOptions): Promise<void> {
   let epicPromptContext: EpicPromptContext | undefined;
   if (activeEpic !== undefined) {
     log.info(`Fetching sub-issues of epic #${activeEpic} in checklist order...`);
-    if (!activeEpicIssue) {
-      const epic = getIssueWithComments(config.repo, activeEpic);
-      if (!epic) {
-        log.error(`Could not fetch epic #${activeEpic}`);
-        process.exit(1);
+    const epicIssue = activeEpicIssue;
+    if (!epicIssue) {
+      const message = `Could not fetch epic #${activeEpic}`;
+      failures.push({ code: 'epic-not-found', message, issueNum: activeEpic, exitCode: 1 });
+      issues = [];
+    } else {
+      epicChecklist = parseEpicChecklistForPrompt(epicIssue.body);
+      issues = [];
+      for (const ref of epicChecklist) {
+        if (ref.checked) continue; // already done
+        const sub = getIssueWithComments(config.repo, ref.issueNum);
+        if (!sub) {
+          log.warn(`Sub-issue #${ref.issueNum} skipped: could not fetch`);
+          continue;
+        }
+        ref.title = ref.title ?? sub.title;
+        if (hasEpicLabel(sub)) {
+          log.warn(`Sub-issue #${sub.number} skipped: is itself an epic (nested epics unsupported in v1)`);
+          continue;
+        }
+        if (!sub.labels.includes(config.labelReady)) {
+          log.warn(`Sub-issue #${sub.number} skipped: not labeled '${config.labelReady}'`);
+          continue;
+        }
+        issues.push(sub);
       }
-      activeEpicIssue = epic;
-      activeEpicTitle = epic.title;
+      epicPromptContext = buildEpicPromptContextFromIssue(epicIssue, epicChecklist);
     }
-
-    epicChecklist = parseEpicChecklistForPrompt(activeEpicIssue.body);
-    issues = [];
-    for (const ref of epicChecklist) {
-      if (ref.checked) continue; // already done
-      const sub = getIssueWithComments(config.repo, ref.issueNum);
-      if (!sub) {
-        log.warn(`Sub-issue #${ref.issueNum} skipped: could not fetch`);
-        continue;
-      }
-      ref.title = ref.title ?? sub.title;
-      if (hasEpicLabel(sub)) {
-        log.warn(`Sub-issue #${sub.number} skipped: is itself an epic (nested epics unsupported in v1)`);
-        continue;
-      }
-      if (!sub.labels.includes(config.labelReady)) {
-        log.warn(`Sub-issue #${sub.number} skipped: not labeled '${config.labelReady}'`);
-        continue;
-      }
-      issues.push(sub);
-    }
-    epicPromptContext = buildEpicPromptContextFromIssue(activeEpicIssue, epicChecklist);
   } else {
     const milestoneMsg = activeMilestone ? ` in milestone '${activeMilestone}'` : '';
     log.info(`Fetching issues${milestoneMsg}...`);
@@ -754,6 +768,14 @@ export async function runCommand(options: RunOptions): Promise<void> {
 
   if (issues.length === 0) {
     log.info('No issues found. Nothing to do.');
+    const uncheckedEpicItems = epicChecklist.filter((item) => !item.checked).length;
+    if (activeEpic !== undefined && (epicChecklist.length === 0 || uncheckedEpicItems > 0)) {
+      failures.push({
+        code: 'no-eligible-child-issues',
+        message: `Epic #${activeEpic} has no eligible child issues to process`,
+        issueNum: activeEpic,
+      });
+    }
   } else {
     const issueLimit = config.maxIssues > 0 ? Math.min(issues.length, config.maxIssues) : issues.length;
     let issuesToProcess = issues.slice(0, issueLimit);
@@ -845,7 +867,9 @@ export async function runCommand(options: RunOptions): Promise<void> {
                 updateEpicChecklist(config.repo, activeEpic, r.issueNum, true);
                 markEpicChecklistItem(epicChecklist, epicPromptContext, r.issueNum, true);
               } catch (err) {
-                log.error(`Epic #${activeEpic} checklist update failed for sub-issue #${r.issueNum}: ${err instanceof Error ? err.message : err}`);
+                const message = `Epic #${activeEpic} checklist update failed for sub-issue #${r.issueNum}: ${err instanceof Error ? err.message : err}`;
+                log.error(message);
+                failures.push({ code: 'checklist-update-failed', message, issueNum: r.issueNum });
                 // One-agent-per-epic contract — halt further processing on body inconsistency
                 epicAbort = true;
                 checklistError = true;
@@ -870,7 +894,9 @@ export async function runCommand(options: RunOptions): Promise<void> {
             break;
           }
         } catch (err) {
-          log.error(`Failed to process batch ${batchIdx + 1}: ${err}`);
+          const message = `Failed to process batch ${batchIdx + 1}: ${err}`;
+          log.error(message);
+          failures.push({ code: 'batch-processing-error', message });
         }
 
         activeIssueNum = null;
@@ -920,7 +946,9 @@ export async function runCommand(options: RunOptions): Promise<void> {
               updateEpicChecklist(config.repo, activeEpic, issue.number, true);
               markEpicChecklistItem(epicChecklist, epicPromptContext, issue.number, true);
             } catch (err) {
-              log.error(`Epic #${activeEpic} checklist update failed for sub-issue #${issue.number}: ${err instanceof Error ? err.message : err}`);
+              const message = `Epic #${activeEpic} checklist update failed for sub-issue #${issue.number}: ${err instanceof Error ? err.message : err}`;
+              log.error(message);
+              failures.push({ code: 'checklist-update-failed', message, issueNum: issue.number });
               // One-agent-per-epic contract — halt further processing on body inconsistency
               epicAbort = true;
               activeIssueNum = null;
@@ -936,7 +964,9 @@ export async function runCommand(options: RunOptions): Promise<void> {
             break;
           }
         } catch (err) {
-          log.error(`Failed to process issue #${issue.number}: ${err}`);
+          const message = `Failed to process issue #${issue.number}: ${err}`;
+          log.error(message);
+          failures.push({ code: 'issue-processing-error', message, issueNum: issue.number });
         }
 
         activeIssueNum = null;
@@ -950,12 +980,34 @@ export async function runCommand(options: RunOptions): Promise<void> {
       const remaining = epicChecklist.filter((r) => !r.checked);
       if (remaining.length === 0) {
         log.step(`All sub-issues of epic #${activeEpic} are complete — running verification pass`);
-        await runEpicVerificationFlow(activeEpic, config, session);
+        const verification = await runEpicVerificationFlow(activeEpic, config, session);
+        verificationClosedEpic = verification.closedEpic;
+        if (verification.failure) {
+          failures.push(verification.failure);
+        } else if (verification.status === 'needs-human-input') {
+          failures.push({
+            code: 'epic-verification-failed',
+            message: `Epic #${activeEpic} verification needs human review: verdict=${verification.verdict ?? 'unknown'}`,
+            issueNum: activeEpic,
+          });
+        }
       } else {
         log.info(`Epic #${activeEpic}: ${remaining.length} sub-issue(s) still open — verification deferred`);
       }
     } catch (err) {
-      log.warn(`Epic completion check failed: ${err instanceof Error ? err.message : err}`);
+      const message = `Epic completion check failed: ${err instanceof Error ? err.message : err}`;
+      log.warn(message);
+      failures.push({ code: 'epic-verification-failed', message, issueNum: activeEpic });
+    }
+  }
+
+  for (const result of session.results) {
+    if (result.status === 'failure') {
+      failures.push({
+        code: 'pipeline-failure',
+        message: `Issue #${result.issueNum} failed during processing`,
+        issueNum: result.issueNum,
+      });
     }
   }
 
@@ -1132,8 +1184,164 @@ export async function runCommand(options: RunOptions): Promise<void> {
   }
 
   // Finalize session
-  await finalizeSession(session, config);
+  const finalizedPrUrl = await finalizeSession(session, config);
+  const sessionPrUrl = finalizedPrUrl ?? session.sessionPrUrl ?? null;
 
   const successCount = session.results.filter((r) => r.status === 'success').length;
   log.info(`Session complete: ${successCount}/${session.results.length} issues succeeded`);
+
+  return {
+    session,
+    sessionPrUrl,
+    failures,
+    verificationClosedEpic,
+  };
+}
+
+function buildEpicFailureResult(epicNumber: number, failure: EpicExecutionFailure): EpicExecutionResult {
+  return {
+    epicNumber,
+    sessionName: null,
+    sessionBranch: null,
+    sessionPrUrl: null,
+    status: 'failure',
+    failures: [failure],
+    verificationClosedEpic: false,
+  };
+}
+
+export async function runSingleEpicExecution(args: {
+  config: Config;
+  epicNumber: number;
+  epicIssue?: Issue;
+  options?: RunOptions;
+}): Promise<EpicExecutionResult> {
+  const { config, epicNumber } = args;
+  const options = args.options ?? {};
+
+  if (typeof epicNumber !== 'number' || !Number.isFinite(epicNumber) || epicNumber <= 0) {
+    return buildEpicFailureResult(epicNumber, {
+      code: 'invalid-epic-number',
+      message: '--epic requires a positive integer issue number (e.g. --epic 165)',
+      exitCode: 1,
+    });
+  }
+
+  const epic = args.epicIssue ?? getIssueWithComments(config.repo, epicNumber);
+  if (!epic) {
+    return buildEpicFailureResult(epicNumber, {
+      code: 'epic-not-found',
+      message: `Could not fetch epic #${epicNumber}`,
+      issueNum: epicNumber,
+      exitCode: 1,
+    });
+  }
+
+  if (!hasEpicLabel(epic)) {
+    return buildEpicFailureResult(epicNumber, {
+      code: 'missing-epic-label',
+      message: `Issue #${epicNumber} is not labeled 'epic'. Add the epic label before running --epic.`,
+      issueNum: epicNumber,
+      exitCode: 1,
+    });
+  }
+
+  const sessionResult = await runIssueSession(config, options, {
+    type: 'epic',
+    epicNum: epic.number,
+    epicTitle: epic.title,
+    epicIssue: epic,
+  });
+
+  return {
+    epicNumber: epic.number,
+    sessionName: sessionResult.session.name,
+    sessionBranch: sessionResult.session.branch,
+    sessionPrUrl: sessionResult.sessionPrUrl,
+    status: sessionResult.failures.length > 0 ? 'failure' : 'success',
+    failures: sessionResult.failures,
+    verificationClosedEpic: sessionResult.verificationClosedEpic,
+  };
+}
+
+function exitForCliEpicValidationFailure(result: EpicExecutionResult): void {
+  const failure = result.failures.find((entry) => entry.exitCode !== undefined);
+  if (!failure) return;
+  log.error(failure.message);
+  process.exit(failure.exitCode ?? 1);
+}
+
+function buildConfigOverrides(options: RunOptions): Partial<Config> {
+  const overrides: Partial<Config> = {};
+  if (options.dryRun) overrides.dryRun = true;
+  if (options.model) overrides.model = options.model;
+  if (options.skipTests) overrides.skipTests = true;
+  if (options.skipReview) overrides.skipReview = true;
+  if (options.skipLearn) overrides.skipLearn = true;
+  if (options.milestone) overrides.milestone = options.milestone;
+  if (options.autoMerge) overrides.autoMerge = true;
+  if (options.mergeTo) overrides.mergeTo = options.mergeTo;
+  if (options.batch) overrides.batch = true;
+  if (options.batchSize) overrides.batchSize = options.batchSize;
+  if (options.verbose) overrides.verbose = true;
+  return overrides;
+}
+
+/**
+ * Run the main loop: poll issues, process them, finalize session.
+ */
+export async function runCommand(options: RunOptions): Promise<void> {
+  const config = loadConfig(buildConfigOverrides(options));
+
+  if (!config.repo) {
+    log.error('No repository configured. Run "alpha-loop init" or set repo in .alpha-loop.yaml');
+    process.exit(1);
+    return;
+  }
+
+  // --- Verify-only path: bypass the normal loop entirely ---
+  if (options.verifyOnly !== undefined) {
+    if (!Number.isFinite(options.verifyOnly) || options.verifyOnly <= 0) {
+      log.error('--verify-only requires a positive integer issue number (e.g. --verify-only 165)');
+      process.exit(1);
+      return;
+    }
+    log.step(`Running verify-only pass for epic #${options.verifyOnly}`);
+    const verification = await runEpicVerificationFlow(options.verifyOnly, config, null);
+    if (verification.failure?.exitCode !== undefined) {
+      process.exit(verification.failure.exitCode);
+    }
+    return;
+  }
+
+  // --epic <N> overrides everything except --verify-only.
+  if (options.epic !== undefined) {
+    const result = await runSingleEpicExecution({
+      config,
+      epicNumber: options.epic,
+      options,
+    });
+    exitForCliEpicValidationFailure(result);
+    return;
+  }
+
+  // --- Target selection (epic or milestone) — must happen before session creation ---
+  const target = await resolveRunTarget(config, options);
+  if (!target) return;
+
+  if (target.activeEpic !== undefined) {
+    const result = await runSingleEpicExecution({
+      config,
+      epicNumber: target.activeEpic,
+      epicIssue: target.activeEpicIssue,
+      options,
+    });
+    exitForCliEpicValidationFailure(result);
+    return;
+  }
+
+  await runIssueSession(config, options, {
+    type: 'flat',
+    activeMilestone: target.activeMilestone,
+  });
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -32,6 +32,15 @@ import { buildSessionReviewPrompt, type EpicPromptContext } from '../lib/prompts
 import { writeTraceToSubdir } from '../lib/traces.js';
 import { readFileSync, existsSync, renameSync, unlinkSync } from 'node:fs';
 import { validateIssueQueue, printValidationReport, commentOnIncompleteIssues, type ValidationReport } from '../lib/validation.js';
+import {
+  createEpicQueueManifest,
+  createEpicQueueValidationFailureManifest,
+  parseEpicQueue,
+  validateEpicQueue,
+  writeQueueManifest,
+  type EpicQueueManifest,
+  type EpicQueueManifestFailure,
+} from '../lib/epic-queue.js';
 
 export type RunOptions = {
   dryRun?: boolean;
@@ -49,10 +58,14 @@ export type RunOptions = {
   fix?: boolean;
   /** Force a specific epic by number, skip picker. */
   epic?: number;
+  /** Process multiple epics in the provided comma-separated order. */
+  epics?: string;
   /** Skip the epic picker entirely, use flat/milestone flow. */
   skipEpic?: boolean;
   /** Run only the verification pass on an existing epic. */
   verifyOnly?: number;
+  /** Internal queue mode: treat an unfinished epic as a queue-stopping failure. */
+  stopOnPartialEpic?: boolean;
 };
 
 export type EpicExecutionFailureCode =
@@ -64,7 +77,10 @@ export type EpicExecutionFailureCode =
   | 'issue-processing-error'
   | 'batch-processing-error'
   | 'pipeline-failure'
-  | 'epic-verification-failed';
+  | 'transient-stop'
+  | 'epic-verification-failed'
+  | 'epic-incomplete'
+  | 'epic-run-error';
 
 export type EpicExecutionFailure = {
   code: EpicExecutionFailureCode;
@@ -654,8 +670,10 @@ async function runIssueSession(
     process.exit(0);
   };
 
-  process.on('SIGINT', () => { void cleanup(); });
-  process.on('SIGTERM', () => { void cleanup(); });
+  const handleSigint = () => { void cleanup(); };
+  const handleSigterm = () => { void cleanup(); };
+  process.on('SIGINT', handleSigint);
+  process.on('SIGTERM', handleSigterm);
 
   // Sync agent assets to all configured harnesses before starting the loop
   const syncResult = syncAgentAssets(resolveHarnesses(config.harnesses, config.agent));
@@ -992,7 +1010,16 @@ async function runIssueSession(
           });
         }
       } else {
-        log.info(`Epic #${activeEpic}: ${remaining.length} sub-issue(s) still open — verification deferred`);
+        const message = `Epic #${activeEpic}: ${remaining.length} sub-issue(s) still open — verification deferred`;
+        log.info(message);
+        const hasFailedIssueResult = session.results.some((result) => result.status === 'failure');
+        if (options.stopOnPartialEpic && !hasFailedIssueResult) {
+          failures.push({
+            code: 'epic-incomplete',
+            message,
+            issueNum: activeEpic,
+          });
+        }
       }
     } catch (err) {
       const message = `Epic completion check failed: ${err instanceof Error ? err.message : err}`;
@@ -1003,9 +1030,12 @@ async function runIssueSession(
 
   for (const result of session.results) {
     if (result.status === 'failure') {
+      const transient = result.failureReason === 'transient';
       failures.push({
-        code: 'pipeline-failure',
-        message: `Issue #${result.issueNum} failed during processing`,
+        code: transient ? 'transient-stop' : 'pipeline-failure',
+        message: transient
+          ? `Issue #${result.issueNum} stopped due to a transient agent or rate-limit failure`
+          : `Issue #${result.issueNum} failed during processing`,
         issueNum: result.issueNum,
       });
     }
@@ -1189,6 +1219,8 @@ async function runIssueSession(
 
   const successCount = session.results.filter((r) => r.status === 'success').length;
   log.info(`Session complete: ${successCount}/${session.results.length} issues succeeded`);
+  process.off('SIGINT', handleSigint);
+  process.off('SIGTERM', handleSigterm);
 
   return {
     session,
@@ -1287,6 +1319,165 @@ function buildConfigOverrides(options: RunOptions): Partial<Config> {
   return overrides;
 }
 
+function rejectIncompatibleEpicQueueOptions(options: RunOptions): boolean {
+  const incompatible: string[] = [];
+  if (options.epic !== undefined) incompatible.push('--epic');
+  if (options.verifyOnly !== undefined) incompatible.push('--verify-only');
+  if (options.milestone) incompatible.push('--milestone');
+  if (options.skipEpic) incompatible.push('--skip-epic');
+  if (options.mergeTo) incompatible.push('--merge-to');
+
+  if (incompatible.length === 0) return false;
+
+  log.error(`--epics cannot be combined with ${incompatible.join(', ')}`);
+  process.exit(1);
+  return true;
+}
+
+function printDryRunEpicQueue(entries: ReturnType<typeof validateEpicQueue>['entries']): void {
+  log.dry(`Validated epic queue (${entries.length} epic${entries.length === 1 ? '' : 's'}):`);
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index];
+    const suffixes = [
+      entry.status === 'already-complete' ? 'already complete; will skip' : '',
+      entry.validationWarning ? `warning: ${entry.validationWarning}` : '',
+    ].filter(Boolean);
+    const suffix = suffixes.length > 0 ? ` (${suffixes.join('; ')})` : '';
+    log.dry(`  ${index + 1}. #${entry.epicNumber} ${entry.title}${suffix}`);
+  }
+}
+
+function toManifestFailures(failures: EpicExecutionFailure[]): EpicQueueManifestFailure[] {
+  return failures.map((failure) => ({
+    code: failure.code,
+    message: failure.message,
+    ...(failure.issueNum !== undefined ? { issueNum: failure.issueNum } : {}),
+    ...(failure.exitCode !== undefined ? { exitCode: failure.exitCode } : {}),
+  }));
+}
+
+function stopReasonForEpicResult(result: EpicExecutionResult): string {
+  const firstFailure = result.failures[0];
+  if (!firstFailure) return `Epic #${result.epicNumber} stopped without a reported failure`;
+
+  const reasonByCode: Partial<Record<EpicExecutionFailureCode, string>> = {
+    'checklist-update-failed': 'checklist-consistency-error',
+    'epic-verification-failed': 'epic-verification-failed',
+    'epic-incomplete': 'epic-incomplete',
+    'transient-stop': 'transient-agent-stop',
+  };
+  const reason = reasonByCode[firstFailure.code] ?? firstFailure.code;
+  return `Epic #${result.epicNumber} stopped: ${reason}`;
+}
+
+function writeQueueManifestUpdate(manifest: EpicQueueManifest): void {
+  const manifestPath = writeQueueManifest(process.cwd(), manifest);
+  log.info(`Queue manifest saved: ${manifestPath}`);
+}
+
+async function runEpicQueue(config: Config, options: RunOptions): Promise<void> {
+  if (rejectIncompatibleEpicQueueOptions(options)) return;
+
+  let epicNumbers: number[];
+  try {
+    epicNumbers = parseEpicQueue(options.epics ?? '');
+  } catch (err) {
+    log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+    return;
+  }
+
+  const validation = validateEpicQueue(config.repo, epicNumbers, undefined, {
+    allowMissingEpicLabel: config.dryRun,
+  });
+  if (validation.errors.length > 0) {
+    for (const error of validation.errors) {
+      log.error(error.message);
+    }
+    if (!config.dryRun) {
+      writeQueueManifestUpdate(createEpicQueueValidationFailureManifest(epicNumbers, validation.errors));
+    }
+    process.exit(1);
+    return;
+  }
+
+  if (config.dryRun) {
+    printDryRunEpicQueue(validation.entries);
+    return;
+  }
+
+  const manifest = createEpicQueueManifest(validation.entries);
+  writeQueueManifestUpdate(manifest);
+
+  const queueConfig: Config = {
+    ...config,
+    autoMerge: true,
+    mergeTo: '',
+  };
+  const queueOptions: RunOptions = {
+    ...options,
+    autoMerge: true,
+    mergeTo: undefined,
+    epics: undefined,
+    stopOnPartialEpic: true,
+  };
+
+  for (const validatedEntry of validation.entries) {
+    const manifestEntry = manifest.epics.find((entry) => entry.epicNumber === validatedEntry.epicNumber);
+    if (!manifestEntry) continue;
+
+    if (manifestEntry.status === 'skipped') {
+      log.info(`Skipping epic #${validatedEntry.epicNumber}: ${manifestEntry.skipReason}`);
+      continue;
+    }
+
+    manifestEntry.status = 'running';
+    manifestEntry.startedAt = new Date().toISOString();
+    writeQueueManifestUpdate(manifest);
+
+    const result = await (async (): Promise<EpicExecutionResult> => {
+      try {
+        return await runSingleEpicExecution({
+          config: queueConfig,
+          epicNumber: validatedEntry.epicNumber,
+          epicIssue: validatedEntry.issue,
+          options: queueOptions,
+        });
+      } catch (err) {
+        return buildEpicFailureResult(validatedEntry.epicNumber, {
+          code: 'epic-run-error',
+          message: `Epic #${validatedEntry.epicNumber} failed with an unhandled error: ${err instanceof Error ? err.message : err}`,
+          issueNum: validatedEntry.epicNumber,
+        });
+      }
+    })();
+
+    manifestEntry.sessionName = result.sessionName;
+    manifestEntry.sessionBranch = result.sessionBranch;
+    manifestEntry.sessionPrUrl = result.sessionPrUrl;
+    manifestEntry.failures = toManifestFailures(result.failures);
+    manifestEntry.endedAt = new Date().toISOString();
+    manifestEntry.status = result.status === 'success' ? 'success' : 'failure';
+
+    if (result.status === 'failure') {
+      manifest.status = 'stopped';
+      manifest.stopReason = stopReasonForEpicResult(result);
+      manifest.endedAt = manifestEntry.endedAt;
+      writeQueueManifestUpdate(manifest);
+      log.error(manifest.stopReason);
+      process.exit(1);
+      return;
+    }
+
+    writeQueueManifestUpdate(manifest);
+  }
+
+  manifest.status = 'success';
+  manifest.endedAt = new Date().toISOString();
+  writeQueueManifestUpdate(manifest);
+  log.success(`Epic queue complete: ${manifest.epics.length} epic${manifest.epics.length === 1 ? '' : 's'}`);
+}
+
 /**
  * Run the main loop: poll issues, process them, finalize session.
  */
@@ -1296,6 +1487,11 @@ export async function runCommand(options: RunOptions): Promise<void> {
   if (!config.repo) {
     log.error('No repository configured. Run "alpha-loop init" or set repo in .alpha-loop.yaml');
     process.exit(1);
+    return;
+  }
+
+  if (options.epics !== undefined) {
+    await runEpicQueue(config, options);
     return;
   }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -31,15 +31,20 @@ import { spawnAgent } from '../lib/agent.js';
 import { buildSessionReviewPrompt, type EpicPromptContext } from '../lib/prompts.js';
 import { writeTraceToSubdir } from '../lib/traces.js';
 import { readFileSync, existsSync, renameSync, unlinkSync } from 'node:fs';
-import { validateIssueQueue, printValidationReport, commentOnIncompleteIssues, type ValidationReport } from '../lib/validation.js';
+import { validateIssueQueue, printValidationReport, commentOnIncompleteIssues, parseDependencies, type ValidationReport } from '../lib/validation.js';
 import {
   createEpicQueueManifest,
   createEpicQueueValidationFailureManifest,
   parseEpicQueue,
   validateEpicQueue,
   writeQueueManifest,
+  type BranchAncestryMode,
   type EpicQueueManifest,
+  type EpicQueueManifestEntry,
   type EpicQueueManifestFailure,
+  type QueueEpicLink,
+  type QueueSessionContext,
+  type ValidatedEpicQueueEntry,
 } from '../lib/epic-queue.js';
 
 export type RunOptions = {
@@ -60,6 +65,8 @@ export type RunOptions = {
   epic?: number;
   /** Process multiple epics in the provided comma-separated order. */
   epics?: string;
+  /** Branch ancestry mode for multi-epic queues. */
+  queueBranchMode?: BranchAncestryMode;
   /** Skip the epic picker entirely, use flat/milestone flow. */
   skipEpic?: boolean;
   /** Run only the verification pass on an existing epic. */
@@ -108,7 +115,7 @@ type EpicVerificationFlowResult = {
 };
 
 type SessionExecutionTarget =
-  | { type: 'epic'; epicNum: number; epicTitle?: string; epicIssue: Issue }
+  | { type: 'epic'; epicNum: number; epicTitle?: string; epicIssue: Issue; queue?: QueueSessionContext }
   | { type: 'flat'; activeMilestone: string };
 
 type SessionExecutionResult = {
@@ -611,6 +618,7 @@ async function runIssueSession(
   const activeEpic = target.type === 'epic' ? target.epicNum : undefined;
   const activeEpicTitle = target.type === 'epic' ? target.epicTitle : undefined;
   const activeEpicIssue = target.type === 'epic' ? target.epicIssue : undefined;
+  const queueContext = target.type === 'epic' ? target.queue : undefined;
   const activeMilestone = target.type === 'flat' ? target.activeMilestone : '';
   const failures: EpicExecutionFailure[] = [];
   let verificationClosedEpic = false;
@@ -626,6 +634,7 @@ async function runIssueSession(
     milestone: activeMilestone || undefined,
     epicNum: activeEpic,
     epicTitle: activeEpicTitle,
+    queue: queueContext,
   });
 
   // Print startup banner
@@ -1247,6 +1256,7 @@ export async function runSingleEpicExecution(args: {
   epicNumber: number;
   epicIssue?: Issue;
   options?: RunOptions;
+  queue?: QueueSessionContext;
 }): Promise<EpicExecutionResult> {
   const { config, epicNumber } = args;
   const options = args.options ?? {};
@@ -1283,6 +1293,7 @@ export async function runSingleEpicExecution(args: {
     epicNum: epic.number,
     epicTitle: epic.title,
     epicIssue: epic,
+    queue: args.queue,
   });
 
   return {
@@ -1347,6 +1358,12 @@ function printDryRunEpicQueue(entries: ReturnType<typeof validateEpicQueue>['ent
   }
 }
 
+function normalizeQueueBranchMode(value: BranchAncestryMode | undefined): BranchAncestryMode {
+  if (value === undefined) return 'stacked';
+  if (value === 'stacked' || value === 'independent') return value;
+  throw new Error(`Invalid queue branch mode: ${value}. Expected "stacked" or "independent".`);
+}
+
 function toManifestFailures(failures: EpicExecutionFailure[]): EpicQueueManifestFailure[] {
   return failures.map((failure) => ({
     code: failure.code,
@@ -1370,6 +1387,129 @@ function stopReasonForEpicResult(result: EpicExecutionResult): string {
   return `Epic #${result.epicNumber} stopped: ${reason}`;
 }
 
+type QueueRiskMap = Map<number, { dependencyWarnings: string[]; overlapWarnings: string[] }>;
+
+function queueEpicLink(entry: ValidatedEpicQueueEntry | EpicQueueManifestEntry | undefined): QueueEpicLink | null {
+  if (!entry) return null;
+  const link: QueueEpicLink = {
+    number: entry.epicNumber,
+    title: entry.title,
+  };
+  if ('sessionBranch' in entry) link.sessionBranch = entry.sessionBranch;
+  if ('sessionPrUrl' in entry) link.sessionPrUrl = entry.sessionPrUrl;
+  return link;
+}
+
+function addQueueDependencyNote(risks: QueueRiskMap, epicNumber: number, note: string): void {
+  const entry = risks.get(epicNumber);
+  if (!entry || entry.dependencyWarnings.includes(note)) return;
+  entry.dependencyWarnings.push(note);
+}
+
+function addQueueOverlapNote(risks: QueueRiskMap, epicNumber: number, note: string): void {
+  const entry = risks.get(epicNumber);
+  if (!entry || entry.overlapWarnings.includes(note)) return;
+  entry.overlapWarnings.push(note);
+}
+
+function buildQueueRiskMap(entries: ValidatedEpicQueueEntry[]): QueueRiskMap {
+  const risks: QueueRiskMap = new Map(entries.map((entry) => [
+    entry.epicNumber,
+    { dependencyWarnings: [], overlapWarnings: [] },
+  ]));
+  const queuedEpicNumbers = new Set(entries.map((entry) => entry.epicNumber));
+
+  for (const entry of entries) {
+    for (const dep of parseDependencies(entry.issue.body).filter((num) => queuedEpicNumbers.has(num))) {
+      addQueueDependencyNote(
+        risks,
+        entry.epicNumber,
+        `Epic #${entry.epicNumber} declares a dependency on queued epic #${dep}.`,
+      );
+      addQueueDependencyNote(
+        risks,
+        dep,
+        `Later queued epic #${entry.epicNumber} declares a dependency on this epic.`,
+      );
+    }
+  }
+
+  const report = validateIssueQueue(
+    entries.map((entry) => ({ number: entry.epicNumber, title: entry.title, body: entry.issue.body })),
+    0,
+  );
+  for (const warning of report.dependencyWarnings) {
+    const note = `Queue order warning: ${warning.reason}.`;
+    addQueueDependencyNote(risks, warning.issueNum, note);
+    addQueueDependencyNote(risks, warning.dependsOn, note);
+  }
+  for (const warning of report.overlapWarnings) {
+    const note = `Epics #${warning.issueA} and #${warning.issueB} both mention ${warning.sharedFiles.join(', ')}.`;
+    addQueueOverlapNote(risks, warning.issueA, note);
+    addQueueOverlapNote(risks, warning.issueB, note);
+  }
+
+  return risks;
+}
+
+function buildQueueSessionContext(args: {
+  manifest: EpicQueueManifest;
+  entries: ValidatedEpicQueueEntry[];
+  currentIndex: number;
+  branchAncestryMode: BranchAncestryMode;
+  baseBranch: string;
+  previousSessionBranch: string | null;
+  previousSessionPrUrl: string | null;
+  risks: QueueRiskMap;
+}): QueueSessionContext {
+  const currentEntry = args.entries[args.currentIndex];
+  const manifestEntry = args.manifest.epics.find((entry) => entry.epicNumber === currentEntry.epicNumber);
+  const previousManifestEntry = args.currentIndex > 0 ? args.manifest.epics[args.currentIndex - 1] : undefined;
+  const nextManifestEntry = args.currentIndex < args.manifest.epics.length - 1
+    ? args.manifest.epics[args.currentIndex + 1]
+    : undefined;
+  const dependsOnSessionBranch = args.branchAncestryMode === 'stacked' ? args.previousSessionBranch : null;
+  const dependsOnSessionPrUrl = dependsOnSessionBranch ? args.previousSessionPrUrl : null;
+  const risk = args.risks.get(currentEntry.epicNumber) ?? { dependencyWarnings: [], overlapWarnings: [] };
+
+  return {
+    queueId: args.manifest.queueId,
+    queueIndex: args.currentIndex + 1,
+    queueTotal: args.entries.length,
+    currentEpic: {
+      number: currentEntry.epicNumber,
+      title: currentEntry.title,
+      sessionBranch: manifestEntry?.sessionBranch ?? null,
+      sessionPrUrl: manifestEntry?.sessionPrUrl ?? null,
+    },
+    previousEpic: queueEpicLink(previousManifestEntry),
+    nextEpic: queueEpicLink(nextManifestEntry),
+    previousSessionBranch: args.previousSessionBranch,
+    previousSessionPrUrl: args.previousSessionPrUrl,
+    branchAncestryMode: args.branchAncestryMode,
+    branchedFromBranch: dependsOnSessionBranch ?? args.baseBranch,
+    dependsOnSessionBranch,
+    dependsOnSessionPrUrl,
+    rebaseOntoBranch: dependsOnSessionBranch ? args.baseBranch : null,
+    dependencyWarnings: risk.dependencyWarnings,
+    overlapWarnings: risk.overlapWarnings,
+  };
+}
+
+function applyQueueContextToManifestEntry(entry: EpicQueueManifestEntry, queue: QueueSessionContext): void {
+  entry.queueIndex = queue.queueIndex;
+  entry.queueTotal = queue.queueTotal;
+  entry.previousEpic = queue.previousEpic;
+  entry.nextEpic = queue.nextEpic;
+  entry.branchAncestryMode = queue.branchAncestryMode;
+  entry.branchedFromBranch = queue.branchedFromBranch;
+  entry.dependsOnSessionBranch = queue.dependsOnSessionBranch;
+  entry.dependsOnSessionPrUrl = queue.dependsOnSessionPrUrl;
+  entry.rebaseOntoBranch = queue.rebaseOntoBranch;
+  entry.dependencyWarnings = queue.dependencyWarnings;
+  entry.overlapWarnings = queue.overlapWarnings;
+}
+
 function writeQueueManifestUpdate(manifest: EpicQueueManifest): void {
   const manifestPath = writeQueueManifest(process.cwd(), manifest);
   log.info(`Queue manifest saved: ${manifestPath}`);
@@ -1387,6 +1527,15 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     return;
   }
 
+  let branchAncestryMode: BranchAncestryMode;
+  try {
+    branchAncestryMode = normalizeQueueBranchMode(options.queueBranchMode);
+  } catch (err) {
+    log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+    return;
+  }
+
   const validation = validateEpicQueue(config.repo, epicNumbers, undefined, {
     allowMissingEpicLabel: config.dryRun,
   });
@@ -1395,7 +1544,7 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
       log.error(error.message);
     }
     if (!config.dryRun) {
-      writeQueueManifestUpdate(createEpicQueueValidationFailureManifest(epicNumbers, validation.errors));
+      writeQueueManifestUpdate(createEpicQueueValidationFailureManifest(epicNumbers, validation.errors, new Date(), branchAncestryMode));
     }
     process.exit(1);
     return;
@@ -1406,7 +1555,8 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     return;
   }
 
-  const manifest = createEpicQueueManifest(validation.entries);
+  const manifest = createEpicQueueManifest(validation.entries, new Date(), branchAncestryMode);
+  const queueRisks = buildQueueRiskMap(validation.entries);
   writeQueueManifestUpdate(manifest);
 
   const queueConfig: Config = {
@@ -1422,7 +1572,12 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     stopOnPartialEpic: true,
   };
 
-  for (const validatedEntry of validation.entries) {
+  let previousSessionBranch: string | null = null;
+  let previousSessionPrUrl: string | null = null;
+  let previousSessionManifestEntry: EpicQueueManifestEntry | null = null;
+
+  for (let index = 0; index < validation.entries.length; index++) {
+    const validatedEntry = validation.entries[index];
     const manifestEntry = manifest.epics.find((entry) => entry.epicNumber === validatedEntry.epicNumber);
     if (!manifestEntry) continue;
 
@@ -1431,6 +1586,17 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
       continue;
     }
 
+    const queueContext = buildQueueSessionContext({
+      manifest,
+      entries: validation.entries,
+      currentIndex: index,
+      branchAncestryMode,
+      baseBranch: config.baseBranch,
+      previousSessionBranch,
+      previousSessionPrUrl,
+      risks: queueRisks,
+    });
+    applyQueueContextToManifestEntry(manifestEntry, queueContext);
     manifestEntry.status = 'running';
     manifestEntry.startedAt = new Date().toISOString();
     writeQueueManifestUpdate(manifest);
@@ -1442,6 +1608,7 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
           epicNumber: validatedEntry.epicNumber,
           epicIssue: validatedEntry.issue,
           options: queueOptions,
+          queue: queueContext,
         });
       } catch (err) {
         return buildEpicFailureResult(validatedEntry.epicNumber, {
@@ -1470,6 +1637,13 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     }
 
     writeQueueManifestUpdate(manifest);
+    if (previousSessionManifestEntry) {
+      previousSessionManifestEntry.nextSessionBranch = result.sessionBranch;
+      previousSessionManifestEntry.nextSessionPrUrl = result.sessionPrUrl;
+    }
+    previousSessionBranch = result.sessionBranch;
+    previousSessionPrUrl = result.sessionPrUrl;
+    previousSessionManifestEntry = manifestEntry;
   }
 
   manifest.status = 'success';

--- a/src/lib/epic-queue.ts
+++ b/src/lib/epic-queue.ts
@@ -1,0 +1,276 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getIssueWithComments, type Issue } from './github.js';
+
+export type EpicQueueValidationErrorCode =
+  | 'duplicate-epic'
+  | 'epic-not-found'
+  | 'missing-epic-label'
+  | 'closed-incomplete-epic';
+
+export type EpicQueueValidationError = {
+  code: EpicQueueValidationErrorCode;
+  epicNumber: number;
+  message: string;
+};
+
+export type EpicQueueEntryStatus = 'pending' | 'already-complete';
+
+export type ValidatedEpicQueueEntry = {
+  epicNumber: number;
+  title: string;
+  issue: Issue;
+  status: EpicQueueEntryStatus;
+  skipReason?: string;
+  validationWarning?: string;
+};
+
+export type EpicQueueValidationResult = {
+  entries: ValidatedEpicQueueEntry[];
+  errors: EpicQueueValidationError[];
+};
+
+export type EpicQueueValidationOptions = {
+  allowMissingEpicLabel?: boolean;
+};
+
+export type EpicQueueManifestStatus = 'running' | 'success' | 'stopped';
+export type EpicQueueManifestEntryStatus = 'pending' | 'running' | 'success' | 'failure' | 'skipped';
+
+export type EpicQueueManifestFailure = {
+  code: string;
+  message: string;
+  issueNum?: number;
+  exitCode?: number;
+};
+
+export type EpicQueueManifestEntry = {
+  epicNumber: number;
+  title: string;
+  status: EpicQueueManifestEntryStatus;
+  sessionName: string | null;
+  sessionBranch: string | null;
+  sessionPrUrl: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  skipReason?: string;
+  failures: EpicQueueManifestFailure[];
+};
+
+export type EpicQueueManifest = {
+  queueId: string;
+  epicIds: number[];
+  status: EpicQueueManifestStatus;
+  startedAt: string;
+  endedAt: string | null;
+  stopReason: string | null;
+  epics: EpicQueueManifestEntry[];
+};
+
+export type FetchIssue = (repo: string, issueNum: number) => Issue | null;
+
+function formatQueueTimestamp(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function normalizeIssueState(value: string | undefined): string {
+  return (value ?? 'OPEN').toLowerCase();
+}
+
+function normalizeIssueStateReason(value: string | null | undefined): string {
+  return (value ?? '').toLowerCase().replace(/_/g, '-');
+}
+
+function hasEpicLabel(issue: Issue): boolean {
+  return issue.labels.some((label) => label.toLowerCase() === 'epic');
+}
+
+function isClosed(issue: Issue): boolean {
+  return normalizeIssueState(issue.state) === 'closed';
+}
+
+function isCompleted(issue: Issue): boolean {
+  return isClosed(issue) && normalizeIssueStateReason(issue.stateReason) === 'completed';
+}
+
+export function parseEpicQueue(raw: string): number[] {
+  if (raw.trim() === '') {
+    throw new Error('--epics requires a comma-separated list of epic issue numbers');
+  }
+
+  return raw.split(',').map((part, index) => {
+    const token = part.trim();
+    if (!/^[1-9]\d*$/.test(token)) {
+      throw new Error(`Invalid epic issue number at position ${index + 1}: ${token || '(empty)'}`);
+    }
+    const epicNumber = Number(token);
+    if (!Number.isSafeInteger(epicNumber)) {
+      throw new Error(`Epic issue number at position ${index + 1} is too large: ${token}`);
+    }
+    return epicNumber;
+  });
+}
+
+export function findDuplicateEpicIds(epicNumbers: number[]): number[] {
+  const seen = new Set<number>();
+  const duplicates: number[] = [];
+  const duplicateSet = new Set<number>();
+
+  for (const epicNumber of epicNumbers) {
+    if (seen.has(epicNumber) && !duplicateSet.has(epicNumber)) {
+      duplicates.push(epicNumber);
+      duplicateSet.add(epicNumber);
+    }
+    seen.add(epicNumber);
+  }
+
+  return duplicates;
+}
+
+export function validateEpicQueue(
+  repo: string,
+  epicNumbers: number[],
+  fetchIssue: FetchIssue = getIssueWithComments,
+  options: EpicQueueValidationOptions = {},
+): EpicQueueValidationResult {
+  const entries: ValidatedEpicQueueEntry[] = [];
+  const errors: EpicQueueValidationError[] = [];
+  const duplicateIds = findDuplicateEpicIds(epicNumbers);
+  const duplicateSet = new Set(duplicateIds);
+
+  for (const epicNumber of duplicateIds) {
+    errors.push({
+      code: 'duplicate-epic',
+      epicNumber,
+      message: `Epic #${epicNumber} appears more than once in the queue`,
+    });
+  }
+
+  for (const epicNumber of epicNumbers) {
+    if (duplicateSet.has(epicNumber)) continue;
+
+    const issue = fetchIssue(repo, epicNumber);
+    if (!issue) {
+      errors.push({
+        code: 'epic-not-found',
+        epicNumber,
+        message: `Could not fetch queued epic #${epicNumber}`,
+      });
+      continue;
+    }
+
+    const missingEpicLabel = !hasEpicLabel(issue);
+    if (missingEpicLabel && !options.allowMissingEpicLabel) {
+      errors.push({
+        code: 'missing-epic-label',
+        epicNumber,
+        message: `Issue #${epicNumber} is not labeled 'epic'`,
+      });
+      continue;
+    }
+
+    const validationWarning = missingEpicLabel
+      ? `Issue #${epicNumber} is not labeled 'epic'; non-dry-run queue execution will reject it`
+      : undefined;
+
+    if (isClosed(issue) && !isCompleted(issue)) {
+      errors.push({
+        code: 'closed-incomplete-epic',
+        epicNumber,
+        message: `Issue #${epicNumber} is closed but not marked completed`,
+      });
+      continue;
+    }
+
+    if (isCompleted(issue)) {
+      entries.push({
+        epicNumber,
+        title: issue.title,
+        issue,
+        status: 'already-complete',
+        skipReason: 'Epic is already closed as completed',
+        validationWarning,
+      });
+      continue;
+    }
+
+    entries.push({
+      epicNumber,
+      title: issue.title,
+      issue,
+      status: 'pending',
+      validationWarning,
+    });
+  }
+
+  return { entries, errors };
+}
+
+export function createEpicQueueManifest(
+  entries: ValidatedEpicQueueEntry[],
+  now: Date = new Date(),
+): EpicQueueManifest {
+  const startedAt = now.toISOString();
+
+  return {
+    queueId: `queue-${formatQueueTimestamp(now)}`,
+    epicIds: entries.map((entry) => entry.epicNumber),
+    status: 'running',
+    startedAt,
+    endedAt: null,
+    stopReason: null,
+    epics: entries.map((entry) => ({
+      epicNumber: entry.epicNumber,
+      title: entry.title,
+      status: entry.status === 'already-complete' ? 'skipped' : 'pending',
+      sessionName: null,
+      sessionBranch: null,
+      sessionPrUrl: null,
+      startedAt: null,
+      endedAt: entry.status === 'already-complete' ? startedAt : null,
+      skipReason: entry.skipReason,
+      failures: [],
+    })),
+  };
+}
+
+export function createEpicQueueValidationFailureManifest(
+  epicNumbers: number[],
+  errors: EpicQueueValidationError[],
+  now: Date = new Date(),
+): EpicQueueManifest {
+  const startedAt = now.toISOString();
+
+  return {
+    queueId: `queue-${formatQueueTimestamp(now)}`,
+    epicIds: epicNumbers,
+    status: 'stopped',
+    startedAt,
+    endedAt: startedAt,
+    stopReason: 'queue-validation-failed',
+    epics: epicNumbers.map((epicNumber) => {
+      const failures = errors
+        .filter((error) => error.epicNumber === epicNumber)
+        .map((error) => ({ code: error.code, message: error.message }));
+      return {
+        epicNumber,
+        title: '',
+        status: failures.length > 0 ? 'failure' : 'pending',
+        sessionName: null,
+        sessionBranch: null,
+        sessionPrUrl: null,
+        startedAt: null,
+        endedAt: failures.length > 0 ? startedAt : null,
+        failures,
+      };
+    }),
+  };
+}
+
+export function writeQueueManifest(projectDir: string, manifest: EpicQueueManifest): string {
+  const queueDir = join(projectDir, '.alpha-loop', 'sessions', manifest.queueId);
+  mkdirSync(queueDir, { recursive: true });
+  const manifestPath = join(queueDir, 'queue.json');
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+  return manifestPath;
+}

--- a/src/lib/epic-queue.ts
+++ b/src/lib/epic-queue.ts
@@ -2,6 +2,33 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getIssueWithComments, type Issue } from './github.js';
 
+export type BranchAncestryMode = 'stacked' | 'independent';
+
+export type QueueEpicLink = {
+  number: number;
+  title: string;
+  sessionBranch?: string | null;
+  sessionPrUrl?: string | null;
+};
+
+export type QueueSessionContext = {
+  queueId: string;
+  queueIndex: number;
+  queueTotal: number;
+  currentEpic: QueueEpicLink;
+  previousEpic: QueueEpicLink | null;
+  nextEpic: QueueEpicLink | null;
+  previousSessionBranch: string | null;
+  previousSessionPrUrl: string | null;
+  branchAncestryMode: BranchAncestryMode;
+  branchedFromBranch: string;
+  dependsOnSessionBranch: string | null;
+  dependsOnSessionPrUrl: string | null;
+  rebaseOntoBranch: string | null;
+  dependencyWarnings: string[];
+  overlapWarnings: string[];
+};
+
 export type EpicQueueValidationErrorCode =
   | 'duplicate-epic'
   | 'epic-not-found'
@@ -47,10 +74,23 @@ export type EpicQueueManifestFailure = {
 export type EpicQueueManifestEntry = {
   epicNumber: number;
   title: string;
+  queueIndex: number;
+  queueTotal: number;
+  previousEpic: QueueEpicLink | null;
+  nextEpic: QueueEpicLink | null;
   status: EpicQueueManifestEntryStatus;
   sessionName: string | null;
   sessionBranch: string | null;
   sessionPrUrl: string | null;
+  nextSessionBranch: string | null;
+  nextSessionPrUrl: string | null;
+  branchAncestryMode: BranchAncestryMode;
+  branchedFromBranch: string | null;
+  dependsOnSessionBranch: string | null;
+  dependsOnSessionPrUrl: string | null;
+  rebaseOntoBranch: string | null;
+  dependencyWarnings: string[];
+  overlapWarnings: string[];
   startedAt: string | null;
   endedAt: string | null;
   skipReason?: string;
@@ -60,6 +100,7 @@ export type EpicQueueManifestEntry = {
 export type EpicQueueManifest = {
   queueId: string;
   epicIds: number[];
+  branchAncestryMode: BranchAncestryMode;
   status: EpicQueueManifestStatus;
   startedAt: string;
   endedAt: string | null;
@@ -209,23 +250,43 @@ export function validateEpicQueue(
 export function createEpicQueueManifest(
   entries: ValidatedEpicQueueEntry[],
   now: Date = new Date(),
+  branchAncestryMode: BranchAncestryMode = 'stacked',
 ): EpicQueueManifest {
   const startedAt = now.toISOString();
+  const queueTotal = entries.length;
 
   return {
     queueId: `queue-${formatQueueTimestamp(now)}`,
     epicIds: entries.map((entry) => entry.epicNumber),
+    branchAncestryMode,
     status: 'running',
     startedAt,
     endedAt: null,
     stopReason: null,
-    epics: entries.map((entry) => ({
+    epics: entries.map((entry, index) => ({
       epicNumber: entry.epicNumber,
       title: entry.title,
+      queueIndex: index + 1,
+      queueTotal,
+      previousEpic: index > 0
+        ? { number: entries[index - 1].epicNumber, title: entries[index - 1].title }
+        : null,
+      nextEpic: index < entries.length - 1
+        ? { number: entries[index + 1].epicNumber, title: entries[index + 1].title }
+        : null,
       status: entry.status === 'already-complete' ? 'skipped' : 'pending',
       sessionName: null,
       sessionBranch: null,
       sessionPrUrl: null,
+      nextSessionBranch: null,
+      nextSessionPrUrl: null,
+      branchAncestryMode,
+      branchedFromBranch: null,
+      dependsOnSessionBranch: null,
+      dependsOnSessionPrUrl: null,
+      rebaseOntoBranch: null,
+      dependencyWarnings: [],
+      overlapWarnings: [],
       startedAt: null,
       endedAt: entry.status === 'already-complete' ? startedAt : null,
       skipReason: entry.skipReason,
@@ -238,27 +299,43 @@ export function createEpicQueueValidationFailureManifest(
   epicNumbers: number[],
   errors: EpicQueueValidationError[],
   now: Date = new Date(),
+  branchAncestryMode: BranchAncestryMode = 'stacked',
 ): EpicQueueManifest {
   const startedAt = now.toISOString();
+  const queueTotal = epicNumbers.length;
 
   return {
     queueId: `queue-${formatQueueTimestamp(now)}`,
     epicIds: epicNumbers,
+    branchAncestryMode,
     status: 'stopped',
     startedAt,
     endedAt: startedAt,
     stopReason: 'queue-validation-failed',
-    epics: epicNumbers.map((epicNumber) => {
+    epics: epicNumbers.map((epicNumber, index) => {
       const failures = errors
         .filter((error) => error.epicNumber === epicNumber)
         .map((error) => ({ code: error.code, message: error.message }));
       return {
         epicNumber,
         title: '',
+        queueIndex: index + 1,
+        queueTotal,
+        previousEpic: index > 0 ? { number: epicNumbers[index - 1], title: '' } : null,
+        nextEpic: index < epicNumbers.length - 1 ? { number: epicNumbers[index + 1], title: '' } : null,
         status: failures.length > 0 ? 'failure' : 'pending',
         sessionName: null,
         sessionBranch: null,
         sessionPrUrl: null,
+        nextSessionBranch: null,
+        nextSessionPrUrl: null,
+        branchAncestryMode,
+        branchedFromBranch: null,
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+        rebaseOntoBranch: null,
+        dependencyWarnings: [],
+        overlapWarnings: [],
         startedAt: null,
         endedAt: failures.length > 0 ? startedAt : null,
         failures,

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -39,6 +39,9 @@ export type RoadmapEpicChildContext = {
   title: string;
   bodySummary: string;
   checked: boolean;
+  labels?: string[];
+  state?: string;
+  milestone?: string | null;
 };
 
 export type RoadmapEpicContext = {
@@ -732,6 +735,9 @@ export function listRoadmapEpics(repo: string, knownOpenIssues: Issue[] = []): R
         title: child?.title ?? '(issue details unavailable)',
         bodySummary: child ? summarizeBody(child.body, 220) : '',
         checked: ref.checked,
+        labels: child?.labels ?? [],
+        state: child?.state ?? (child ? 'OPEN' : undefined),
+        milestone: child?.milestone ?? null,
       };
     });
 
@@ -817,7 +823,7 @@ export function getIssueComments(repo: string, issueNum: number): Comment[] {
  */
 export function getIssueWithComments(repo: string, issueNum: number): Issue | null {
   const result = ghExec(
-    `gh issue view ${issueNum} --repo "${repo}" --json number,title,body,labels,comments,state,stateReason`,
+    `gh issue view ${issueNum} --repo "${repo}" --json number,title,body,labels,comments,state,stateReason,milestone`,
   );
   if (result.exitCode !== 0) {
     log.warn(`Failed to fetch issue #${issueNum}: ${result.stderr}`);
@@ -832,6 +838,7 @@ export function getIssueWithComments(repo: string, issueNum: number): Issue | nu
       comments: Array<{ author: { login: string }; body: string; createdAt: string }>;
       state?: string;
       stateReason?: string | null;
+      milestone?: unknown;
     };
     const issue: Issue = {
       number: data.number,
@@ -846,6 +853,7 @@ export function getIssueWithComments(repo: string, issueNum: number): Issue | nu
     };
     if (data.state !== undefined) issue.state = data.state;
     if (data.stateReason !== undefined) issue.stateReason = data.stateReason;
+    if (data.milestone !== undefined) issue.milestone = milestoneTitle(data.milestone);
     return issue;
   } catch {
     log.warn(`Failed to parse issue #${issueNum}`);

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,6 +30,8 @@ export type Issue = {
   labels: string[];
   comments?: Comment[];
   milestone?: string | null;
+  state?: string;
+  stateReason?: string | null;
 };
 
 export type RoadmapEpicChildContext = {
@@ -815,7 +817,7 @@ export function getIssueComments(repo: string, issueNum: number): Comment[] {
  */
 export function getIssueWithComments(repo: string, issueNum: number): Issue | null {
   const result = ghExec(
-    `gh issue view ${issueNum} --repo "${repo}" --json number,title,body,labels,comments`,
+    `gh issue view ${issueNum} --repo "${repo}" --json number,title,body,labels,comments,state,stateReason`,
   );
   if (result.exitCode !== 0) {
     log.warn(`Failed to fetch issue #${issueNum}: ${result.stderr}`);
@@ -828,8 +830,10 @@ export function getIssueWithComments(repo: string, issueNum: number): Issue | nu
       body: string;
       labels: Array<{ name: string }>;
       comments: Array<{ author: { login: string }; body: string; createdAt: string }>;
+      state?: string;
+      stateReason?: string | null;
     };
-    return {
+    const issue: Issue = {
       number: data.number,
       title: data.title,
       body: data.body ?? '',
@@ -840,6 +844,9 @@ export function getIssueWithComments(repo: string, issueNum: number): Issue | nu
         createdAt: c.createdAt ?? '',
       })),
     };
+    if (data.state !== undefined) issue.state = data.state;
+    if (data.stateReason !== undefined) issue.stateReason = data.stateReason;
+    return issue;
   } catch {
     log.warn(`Failed to parse issue #${issueNum}`);
     return null;

--- a/src/lib/planning.ts
+++ b/src/lib/planning.ts
@@ -7,8 +7,9 @@ import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'n
 import { join, relative } from 'node:path';
 import { getVisionContext } from './vision.js';
 import { getProjectContext } from './context.js';
-import { pollIssues, type Issue } from './github.js';
+import { pollIssues, type Issue, type Milestone, type RoadmapEpicContext } from './github.js';
 import type { Config } from './config.js';
+import { extractFilePaths, parseDependencies } from './validation.js';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -86,6 +87,57 @@ export type RoadmapAssignmentGroups = {
 
 export type RoadmapPlan = RoadmapAssignmentGroups & {
   milestones: PlannedMilestone[];
+};
+
+export type EpicQueueChildStatus = 'complete' | 'ready' | 'not_ready' | 'blocked';
+
+export type EpicQueueChildReadiness = {
+  issueNum: number;
+  title: string;
+  checked: boolean;
+  labels: string[];
+  state: string | null;
+  milestone: string | null;
+  status: EpicQueueChildStatus;
+  reason: string;
+};
+
+export type EpicQueuePlanItemStatus = 'runnable' | 'blocked';
+
+export type EpicQueuePlanItem = {
+  issueNum: number;
+  title: string;
+  milestone: string | null;
+  status: EpicQueuePlanItemStatus;
+  childReadiness: EpicQueueChildReadiness[];
+  completedChildCount: number;
+  readyChildCount: number;
+  blockedChildCount: number;
+  totalChildCount: number;
+  explicitDependencies: number[];
+  queueDependencies: number[];
+  externalOpenDependencies: number[];
+  resolvedDependencies: number[];
+  filePaths: string[];
+  rationale: string[];
+  blockers: string[];
+  risks: string[];
+};
+
+export type EpicQueuePlan = {
+  milestoneFilter: string | null;
+  totalEpicCount: number;
+  consideredEpicCount: number;
+  orderedEpics: EpicQueuePlanItem[];
+  blockedEpics: EpicQueuePlanItem[];
+  command: string | null;
+};
+
+export type EpicQueuePlanOptions = {
+  labelReady: string;
+  milestone?: string | null;
+  openIssues?: Issue[];
+  milestones?: Milestone[];
 };
 
 // ── ANSI Colors ──────────────────────────────────────────────────────────────
@@ -679,6 +731,417 @@ function formatRoadmapAssignmentSection(
         : `${GRAY}[currently: unassigned]${NC}`;
       lines.push(`  #${a.issueNum}  ${a.title}  ${current}`);
     }
+  }
+
+  return lines.join('\n');
+}
+
+function normalizeLabel(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function hasLabel(labels: string[] | undefined, label: string): boolean {
+  const wanted = normalizeLabel(label);
+  return (labels ?? []).some((candidate) => normalizeLabel(candidate) === wanted);
+}
+
+function normalizeIssueState(value: string | undefined): string | null {
+  return value ? value.toLowerCase() : null;
+}
+
+function childReadiness(
+  child: RoadmapEpicContext['children'][number],
+  labelReady: string,
+): EpicQueueChildReadiness {
+  const labels = child.labels ?? [];
+  const state = normalizeIssueState(child.state);
+  const milestone = child.milestone ?? null;
+
+  if (child.checked) {
+    return {
+      issueNum: child.issueNum,
+      title: child.title,
+      checked: child.checked,
+      labels,
+      state,
+      milestone,
+      status: 'complete',
+      reason: 'Checklist item is already complete',
+    };
+  }
+
+  if (!child.title || child.title === '(issue details unavailable)') {
+    return {
+      issueNum: child.issueNum,
+      title: child.title,
+      checked: child.checked,
+      labels,
+      state,
+      milestone,
+      status: 'blocked',
+      reason: 'Issue details could not be fetched',
+    };
+  }
+
+  if (state && state !== 'open') {
+    return {
+      issueNum: child.issueNum,
+      title: child.title,
+      checked: child.checked,
+      labels,
+      state,
+      milestone,
+      status: 'blocked',
+      reason: `Issue is ${state}`,
+    };
+  }
+
+  if (hasLabel(labels, 'epic')) {
+    return {
+      issueNum: child.issueNum,
+      title: child.title,
+      checked: child.checked,
+      labels,
+      state,
+      milestone,
+      status: 'blocked',
+      reason: 'Nested epic child issues are not supported',
+    };
+  }
+
+  if (!hasLabel(labels, labelReady)) {
+    return {
+      issueNum: child.issueNum,
+      title: child.title,
+      checked: child.checked,
+      labels,
+      state,
+      milestone,
+      status: 'not_ready',
+      reason: `Missing '${labelReady}' label`,
+    };
+  }
+
+  return {
+    issueNum: child.issueNum,
+    title: child.title,
+    checked: child.checked,
+    labels,
+    state,
+    milestone,
+    status: 'ready',
+    reason: `Open and labeled '${labelReady}'`,
+  };
+}
+
+function collectEpicText(epic: RoadmapEpicContext): string {
+  return [
+    epic.title,
+    epic.bodySummary,
+    ...epic.children.map((child) => child.bodySummary),
+  ].filter(Boolean).join('\n');
+}
+
+function uniqueSorted(values: number[]): number[] {
+  return [...new Set(values)].sort((a, b) => a - b);
+}
+
+function collectEpicDependencies(epic: RoadmapEpicContext): number[] {
+  const childIssueNums = new Set(epic.children.map((child) => child.issueNum));
+  return uniqueSorted(parseDependencies(collectEpicText(epic)))
+    .filter((issueNum) => issueNum !== epic.issueNum && !childIssueNums.has(issueNum));
+}
+
+function collectEpicFiles(epic: RoadmapEpicContext): string[] {
+  return [...new Set(extractFilePaths(collectEpicText(epic)))].sort();
+}
+
+function milestoneSortIndex(milestones: Milestone[] | undefined, milestone: string | null): number {
+  if (!milestone) return Number.MAX_SAFE_INTEGER - 1;
+  const index = (milestones ?? []).findIndex((candidate) => candidate.title === milestone);
+  return index === -1 ? Number.MAX_SAFE_INTEGER - 2 : index;
+}
+
+function sortEpicsForPlanning(
+  epics: RoadmapEpicContext[],
+  milestones: Milestone[] | undefined,
+): RoadmapEpicContext[] {
+  return [...epics].sort((a, b) => {
+    const milestoneDelta = milestoneSortIndex(milestones, a.currentMilestone ?? null) -
+      milestoneSortIndex(milestones, b.currentMilestone ?? null);
+    if (milestoneDelta !== 0) return milestoneDelta;
+    return a.issueNum - b.issueNum;
+  });
+}
+
+function topologicalOrderEpicItems(items: EpicQueuePlanItem[]): {
+  ordered: EpicQueuePlanItem[];
+  cycleIssueNums: number[];
+} {
+  const itemMap = new Map(items.map((item) => [item.issueNum, item]));
+  const originalIndex = new Map(items.map((item, index) => [item.issueNum, index]));
+  const dependents = new Map<number, number[]>();
+  const remainingDeps = new Map<number, Set<number>>();
+
+  for (const item of items) {
+    const deps = item.queueDependencies.filter((dep) => itemMap.has(dep));
+    remainingDeps.set(item.issueNum, new Set(deps));
+    for (const dep of deps) {
+      if (!dependents.has(dep)) dependents.set(dep, []);
+      dependents.get(dep)!.push(item.issueNum);
+    }
+  }
+
+  const ready = items
+    .filter((item) => (remainingDeps.get(item.issueNum)?.size ?? 0) === 0)
+    .map((item) => item.issueNum)
+    .sort((a, b) => (originalIndex.get(a) ?? 0) - (originalIndex.get(b) ?? 0));
+  const ordered: EpicQueuePlanItem[] = [];
+
+  while (ready.length > 0) {
+    const current = ready.shift()!;
+    const item = itemMap.get(current);
+    if (!item) continue;
+    ordered.push(item);
+
+    for (const dependent of dependents.get(current) ?? []) {
+      const deps = remainingDeps.get(dependent);
+      if (!deps) continue;
+      deps.delete(current);
+      if (deps.size === 0) {
+        ready.push(dependent);
+        ready.sort((a, b) => (originalIndex.get(a) ?? 0) - (originalIndex.get(b) ?? 0));
+      }
+    }
+  }
+
+  if (ordered.length === items.length) {
+    return { ordered, cycleIssueNums: [] };
+  }
+
+  const orderedSet = new Set(ordered.map((item) => item.issueNum));
+  return {
+    ordered,
+    cycleIssueNums: items
+      .map((item) => item.issueNum)
+      .filter((issueNum) => !orderedSet.has(issueNum)),
+  };
+}
+
+function addFileOverlapRisks(items: EpicQueuePlanItem[]): void {
+  for (let i = 0; i < items.length; i++) {
+    for (let j = i + 1; j < items.length; j++) {
+      const left = items[i];
+      const right = items[j];
+      const shared = left.filePaths.filter((file) => right.filePaths.includes(file));
+      if (shared.length === 0) continue;
+      const files = shared.slice(0, 5).join(', ');
+      const suffix = shared.length > 5 ? `, +${shared.length - 5} more` : '';
+      left.risks.push(`Likely file overlap with #${right.issueNum}: ${files}${suffix}`);
+      right.risks.push(`Likely file overlap with #${left.issueNum}: ${files}${suffix}`);
+    }
+  }
+}
+
+function buildEpicQueuePlanItem(
+  epic: RoadmapEpicContext,
+  options: Required<Pick<EpicQueuePlanOptions, 'labelReady'>> & EpicQueuePlanOptions,
+  candidateNums: Set<number>,
+  openIssueNums: Set<number>,
+): EpicQueuePlanItem {
+  const childSignals = epic.children.map((child) => childReadiness(child, options.labelReady));
+  const completedChildCount = childSignals.filter((child) => child.status === 'complete').length;
+  const readyChildCount = childSignals.filter((child) => child.status === 'ready').length;
+  const blockedChildren = childSignals.filter((child) => child.status === 'blocked' || child.status === 'not_ready');
+  const explicitDependencies = collectEpicDependencies(epic);
+  const queueDependencies = explicitDependencies.filter((issueNum) => candidateNums.has(issueNum));
+  const externalOpenDependencies = explicitDependencies.filter((issueNum) => (
+    !candidateNums.has(issueNum) && openIssueNums.has(issueNum)
+  ));
+  const resolvedDependencies = explicitDependencies.filter((issueNum) => (
+    !candidateNums.has(issueNum) && !openIssueNums.has(issueNum)
+  ));
+  const filePaths = collectEpicFiles(epic);
+  const blockers: string[] = [];
+
+  if (epic.children.length === 0) {
+    blockers.push('No child issues found in the epic checklist');
+  }
+  for (const child of blockedChildren) {
+    blockers.push(`Child #${child.issueNum} ${child.title}: ${child.reason}`);
+  }
+  for (const dep of externalOpenDependencies) {
+    blockers.push(`Open dependency #${dep} is outside the planned epic queue`);
+  }
+
+  const rationale = [
+    epic.currentMilestone ? `Milestone: ${epic.currentMilestone}` : 'Milestone: unassigned',
+    `Child readiness: ${readyChildCount} ready, ${completedChildCount} complete, ${blockedChildren.length} blocked/not ready`,
+  ];
+  if (queueDependencies.length > 0) {
+    rationale.push(`Queue dependencies: ${queueDependencies.map((dep) => `#${dep}`).join(', ')}`);
+  } else {
+    rationale.push('Queue dependencies: none');
+  }
+  if (resolvedDependencies.length > 0) {
+    rationale.push(`Dependencies not open: ${resolvedDependencies.map((dep) => `#${dep}`).join(', ')} (assumed complete)`);
+  }
+
+  return {
+    issueNum: epic.issueNum,
+    title: epic.title,
+    milestone: epic.currentMilestone ?? null,
+    status: blockers.length > 0 ? 'blocked' : 'runnable',
+    childReadiness: childSignals,
+    completedChildCount,
+    readyChildCount,
+    blockedChildCount: blockedChildren.length,
+    totalChildCount: epic.children.length,
+    explicitDependencies,
+    queueDependencies,
+    externalOpenDependencies,
+    resolvedDependencies,
+    filePaths,
+    rationale,
+    blockers,
+    risks: [],
+  };
+}
+
+/**
+ * Analyze open roadmap epics and recommend a safe ordered `run --epics` queue.
+ *
+ * The helper is intentionally pure: it only consumes already-fetched GitHub
+ * context and never mutates issues, milestones, projects, branches, or sessions.
+ */
+export function planEpicQueue(
+  epics: RoadmapEpicContext[],
+  options: EpicQueuePlanOptions,
+): EpicQueuePlan {
+  const milestoneFilter = options.milestone?.trim() || null;
+  const considered = milestoneFilter
+    ? epics.filter((epic) => epic.currentMilestone === milestoneFilter)
+    : epics;
+  const sortedEpics = sortEpicsForPlanning(considered, options.milestones);
+  const candidateNums = new Set(sortedEpics.map((epic) => epic.issueNum));
+  const openIssueNums = new Set((options.openIssues ?? []).map((issue) => issue.number));
+  const items = sortedEpics.map((epic) => buildEpicQueuePlanItem(epic, options, candidateNums, openIssueNums));
+  const itemMap = new Map(items.map((item) => [item.issueNum, item]));
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const item of items) {
+      if (item.status === 'blocked') continue;
+      const blockedDeps = item.queueDependencies.filter((dep) => itemMap.get(dep)?.status === 'blocked');
+      if (blockedDeps.length === 0) continue;
+      for (const dep of blockedDeps) {
+        item.blockers.push(`Depends on blocked epic #${dep}`);
+      }
+      item.status = 'blocked';
+      changed = true;
+    }
+  }
+
+  const runnableCandidates = items.filter((item) => item.status === 'runnable');
+  const topo = topologicalOrderEpicItems(runnableCandidates);
+  if (topo.cycleIssueNums.length > 0) {
+    for (const issueNum of topo.cycleIssueNums) {
+      const item = itemMap.get(issueNum);
+      if (!item) continue;
+      item.status = 'blocked';
+      item.blockers.push('Cyclic dependency with another runnable epic');
+    }
+  }
+
+  const orderedEpics = topo.cycleIssueNums.length > 0
+    ? topologicalOrderEpicItems(items.filter((item) => item.status === 'runnable')).ordered
+    : topo.ordered;
+  const blockedEpics = items.filter((item) => item.status === 'blocked');
+
+  addFileOverlapRisks([...orderedEpics, ...blockedEpics]);
+
+  return {
+    milestoneFilter,
+    totalEpicCount: epics.length,
+    consideredEpicCount: considered.length,
+    orderedEpics,
+    blockedEpics,
+    command: orderedEpics.length > 0
+      ? `alpha-loop run --epics ${orderedEpics.map((item) => item.issueNum).join(',')}`
+      : null,
+  };
+}
+
+function formatPlanList(values: string[], empty: string): string[] {
+  return values.length > 0
+    ? values.map((value) => `     - ${value}`)
+    : [`     - ${empty}`];
+}
+
+function formatEpicQueuePlanItem(item: EpicQueuePlanItem, index?: number): string[] {
+  const prefix = index === undefined ? '-' : `${index + 1}.`;
+  const lines = [
+    `  ${prefix} #${item.issueNum} ${item.title}`,
+    `     Readiness: ${item.readyChildCount} ready, ${item.completedChildCount} complete, ${item.blockedChildCount} blocked/not ready (${item.totalChildCount} total)`,
+    '     Rationale:',
+    ...formatPlanList(item.rationale, 'No rationale signals found'),
+    '     Blockers:',
+    ...formatPlanList(item.blockers, 'None'),
+    '     Risks:',
+    ...formatPlanList(item.risks, 'None detected'),
+  ];
+  return lines;
+}
+
+export function formatEpicQueuePlan(plan: EpicQueuePlan): string {
+  const scope = plan.milestoneFilter
+    ? `milestone "${plan.milestoneFilter}"`
+    : 'all open epics';
+  const lines = [
+    `${BOLD}${CYAN}Epic Queue Recommendation${NC}`,
+    `Scope: ${scope}`,
+    `Open epics considered: ${plan.consideredEpicCount}/${plan.totalEpicCount}`,
+    '',
+  ];
+
+  if (plan.totalEpicCount === 0) {
+    lines.push('No open epics found.');
+    return lines.join('\n');
+  }
+
+  if (plan.consideredEpicCount === 0) {
+    lines.push('No open epics matched the requested scope.');
+    return lines.join('\n');
+  }
+
+  if (plan.orderedEpics.length > 0) {
+    lines.push(`${BOLD}Runnable Queue (${plan.orderedEpics.length})${NC}`);
+    plan.orderedEpics.forEach((item, index) => {
+      lines.push(...formatEpicQueuePlanItem(item, index));
+    });
+  } else {
+    lines.push(`${BOLD}Runnable Queue (0)${NC}`);
+    lines.push('  No runnable epic queue found.');
+  }
+
+  lines.push('');
+  if (plan.blockedEpics.length > 0) {
+    lines.push(`${BOLD}Blocked Epics (${plan.blockedEpics.length})${NC}`);
+    for (const item of plan.blockedEpics) {
+      lines.push(...formatEpicQueuePlanItem(item));
+    }
+  } else {
+    lines.push(`${BOLD}Blocked Epics (0)${NC}`);
+    lines.push('  None');
+  }
+
+  lines.push('');
+  lines.push(`${BOLD}Command${NC}`);
+  if (plan.command) {
+    lines.push(`  ${plan.command}`);
+  } else {
+    lines.push('  No executable queue command because no runnable epics were found.');
   }
 
   return lines.join('\n');

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -12,6 +12,7 @@ import { readStageTelemetry } from './telemetry.js';
 import { runDir } from './traces.js';
 import type { Config } from './config.js';
 import type { PipelineResult, GateResult } from './pipeline.js';
+import type { QueueEpicLink, QueueSessionContext } from './epic-queue.js';
 
 export type SessionContext = {
   name: string;
@@ -23,6 +24,8 @@ export type SessionContext = {
   sessionPrUrl?: string;
   /** When set, this session processes sub-issues of the given epic. */
   epic?: number;
+  /** Queue metadata for multi-epic queue sessions. */
+  queue?: QueueSessionContext;
 };
 
 export type CreateSessionOptions = {
@@ -31,10 +34,130 @@ export type CreateSessionOptions = {
   epicNum?: number;
   /** Title of the epic, used to form a human-readable session slug. */
   epicTitle?: string;
+  /** Queue metadata when this session belongs to an ordered epic queue. */
+  queue?: QueueSessionContext;
 };
 
 function slugify(text: string): string {
   return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+function draftSessionPrTitle(name: string, milestone: string | undefined, epicNum: number | undefined, epicTitle: string | undefined): string {
+  if (epicNum !== undefined) {
+    return `Epic #${epicNum}${epicTitle ? `: ${epicTitle}` : ''}`;
+  }
+  return milestone ? `Milestone: ${milestone}` : `Session: ${name}`;
+}
+
+function formatEpicLink(epic: QueueEpicLink | null): string {
+  if (!epic) return 'None';
+  const title = epic.title ? ` - ${epic.title}` : '';
+  const pr = epic.sessionPrUrl ? ` ([session PR](${epic.sessionPrUrl}))` : '';
+  const branch = !epic.sessionPrUrl && epic.sessionBranch ? ` (${epic.sessionBranch})` : '';
+  return `#${epic.number}${title}${pr}${branch}`;
+}
+
+function previousPrLabel(queue: QueueSessionContext): string {
+  if (queue.dependsOnSessionPrUrl) {
+    return `[the previous session PR](${queue.dependsOnSessionPrUrl})`;
+  }
+  if (queue.previousSessionPrUrl) {
+    return `[the previous session PR](${queue.previousSessionPrUrl})`;
+  }
+  if (queue.previousEpic) {
+    return `the previous session PR for #${queue.previousEpic.number}`;
+  }
+  return 'the previous session PR';
+}
+
+function buildQueueSection(queue: QueueSessionContext, branch: string, baseBranch: string): string[] {
+  const lines: string[] = [
+    '## Execution Queue',
+    '',
+    `**Queue:** ${queue.queueId}`,
+    `**Position:** ${queue.queueIndex} of ${queue.queueTotal}`,
+    `**Parent epic:** ${formatEpicLink(queue.currentEpic)}`,
+    `**Previous queued epic:** ${formatEpicLink(queue.previousEpic)}`,
+    `**Next queued epic:** ${formatEpicLink(queue.nextEpic)}`,
+    `**Branch ancestry:** ${queue.branchAncestryMode}`,
+  ];
+
+  if (queue.branchAncestryMode === 'stacked') {
+    if (queue.dependsOnSessionBranch) {
+      lines.push(`**Branched from:** ${queue.dependsOnSessionBranch}`);
+      lines.push(`**Depends on:** ${queue.dependsOnSessionPrUrl ? `[${queue.dependsOnSessionBranch}](${queue.dependsOnSessionPrUrl})` : queue.dependsOnSessionBranch}`);
+    } else {
+      lines.push(`**Branched from:** ${queue.branchedFromBranch}`);
+      lines.push('**Depends on:** None - this is the first queued session branch.');
+    }
+  } else {
+    lines.push(`**Branched from:** ${queue.branchedFromBranch}`);
+    lines.push('**Depends on:** None - no branch ancestry dependency was created.');
+  }
+
+  lines.push('');
+  lines.push('### Merge Order');
+  lines.push('');
+
+  if (queue.branchAncestryMode === 'stacked' && queue.dependsOnSessionBranch) {
+    const rebaseTarget = queue.rebaseOntoBranch ?? baseBranch;
+    lines.push(`- Merge ${previousPrLabel(queue)} first; after it lands on ${rebaseTarget}, rebase \`${branch}\` onto \`${rebaseTarget}\` before final review/merge.`);
+    lines.push(`- This PR still targets \`${baseBranch}\`, but its branch was created from \`${queue.dependsOnSessionBranch}\`.`);
+  } else if (queue.branchAncestryMode === 'stacked') {
+    lines.push(`- This is the first queued session PR. Merge it before later queued session PRs.`);
+    if (queue.nextEpic) {
+      lines.push(`- Later queued sessions may be branched from \`${branch}\`; review ${formatEpicLink(queue.nextEpic)} after this PR.`);
+    }
+  } else {
+    lines.push(`- Review this PR in queue order, but it can merge independently once ready.`);
+    lines.push(`- No branch ancestry dependency was created; this branch starts from \`${queue.branchedFromBranch}\`.`);
+  }
+
+  lines.push('');
+  lines.push('### Dependency And Overlap Notes');
+  lines.push('');
+  const riskLines = [
+    ...queue.dependencyWarnings.map((warning) => `- Dependency: ${warning}`),
+    ...queue.overlapWarnings.map((warning) => `- File overlap: ${warning}`),
+  ];
+  if (riskLines.length > 0) {
+    lines.push(...riskLines);
+  } else {
+    lines.push('- No queued dependency or file-overlap risks detected.');
+  }
+
+  return lines;
+}
+
+function buildDraftSessionPrBody(args: {
+  branch: string;
+  startedAt: string;
+  milestone?: string;
+  epicNum?: number;
+  epicTitle?: string;
+  queue?: QueueSessionContext;
+  baseBranch: string;
+}): string {
+  const lines: string[] = ['## Session In Progress', ''];
+  if (args.epicNum !== undefined) {
+    lines.push(`**Epic:** #${args.epicNum}${args.epicTitle ? ` — ${args.epicTitle}` : ''}`);
+  } else if (args.milestone) {
+    lines.push(`**Milestone:** ${args.milestone}`);
+  }
+  lines.push(`**Branch:** ${args.branch}`);
+  lines.push(`**Started:** ${args.startedAt}`);
+  lines.push('');
+
+  if (args.queue) {
+    lines.push(...buildQueueSection(args.queue, args.branch, args.baseBranch));
+    lines.push('');
+  }
+
+  lines.push('This PR will be updated as issues are processed.');
+  lines.push('');
+  lines.push('---');
+  lines.push('*Automated by alpha-loop*');
+  return lines.join('\n');
 }
 
 /**
@@ -47,6 +170,7 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
   const milestone = options?.milestone;
   const epicNum = options?.epicNum;
   const epicTitle = options?.epicTitle;
+  const queue = options?.queue;
 
   let slug: string;
   if (epicNum !== undefined) {
@@ -64,6 +188,7 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
   const resultsDir = join(projectDir, '.alpha-loop', 'sessions', name);
   const logsDir = join(resultsDir, 'logs');
   let sessionPrUrl: string | undefined;
+  const branchSource = queue?.branchedFromBranch ?? config.baseBranch;
 
   mkdirSync(resultsDir, { recursive: true });
   mkdirSync(logsDir, { recursive: true });
@@ -75,13 +200,13 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
 
     const branchExists = exec(`git rev-parse --verify "${branch}"`, { cwd: projectDir });
     if (branchExists.exitCode !== 0) {
-      // Create from remote base branch first, fall back to local
+      // Create from the queue ancestry branch (or base branch) first, fall back to local.
       const fromRemote = exec(
-        `git checkout -b "${branch}" "origin/${config.baseBranch}"`,
+        `git checkout -b "${branch}" "origin/${branchSource}"`,
         { cwd: projectDir },
       );
       if (fromRemote.exitCode !== 0) {
-        exec(`git checkout -b "${branch}" "${config.baseBranch}"`, { cwd: projectDir });
+        exec(`git checkout -b "${branch}" "${branchSource}"`, { cwd: projectDir });
       }
       // Create an initial commit so the branch has a diff from base (required for PR creation)
       exec(`git commit --allow-empty -m "chore: start session ${name}"`, { cwd: projectDir });
@@ -97,14 +222,16 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
           repo: config.repo,
           base: config.baseBranch,
           head: branch,
-          title: epicNum !== undefined
-            ? `Epic #${epicNum}${epicTitle ? `: ${epicTitle}` : ''}`
-            : milestone ? `Milestone: ${milestone}` : `Session: ${name}`,
-          body: `## Session In Progress\n\n${
-            epicNum !== undefined
-              ? `**Epic:** #${epicNum}${epicTitle ? ` — ${epicTitle}` : ''}\n`
-              : milestone ? `**Milestone:** ${milestone}\n` : ''
-          }**Branch:** ${branch}\n**Started:** ${new Date().toISOString()}\n\nThis PR will be updated as issues are processed.\n\n---\n*Automated by alpha-loop*`,
+          title: draftSessionPrTitle(name, milestone, epicNum, epicTitle),
+          body: buildDraftSessionPrBody({
+            branch,
+            startedAt: new Date().toISOString(),
+            milestone,
+            epicNum,
+            epicTitle,
+            queue,
+            baseBranch: config.baseBranch,
+          }),
           cwd: projectDir,
         });
         sessionPrUrl = draftPR;
@@ -117,17 +244,17 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
       // Ensure session branch exists on remote (may have been deleted after a previous merge)
       const remoteCheck = exec(`git ls-remote --heads origin "${branch}"`, { cwd: projectDir });
       if (!remoteCheck.stdout.trim()) {
-        log.warn(`Session branch "${branch}" exists locally but not on remote — recreating from ${config.baseBranch}`);
+        log.warn(`Session branch "${branch}" exists locally but not on remote — recreating from ${branchSource}`);
         // Ensure we're not on the branch we're about to delete
-        exec(`git checkout "${config.baseBranch}"`, { cwd: projectDir });
+        exec(`git checkout "${branchSource}"`, { cwd: projectDir });
         // Delete stale local branch and recreate from current base (the old one is behind after merge)
         exec(`git branch -D "${branch}"`, { cwd: projectDir });
         const fromRemote = exec(
-          `git checkout -b "${branch}" "origin/${config.baseBranch}"`,
+          `git checkout -b "${branch}" "origin/${branchSource}"`,
           { cwd: projectDir },
         );
         if (fromRemote.exitCode !== 0) {
-          exec(`git checkout -b "${branch}" "${config.baseBranch}"`, { cwd: projectDir });
+          exec(`git checkout -b "${branch}" "${branchSource}"`, { cwd: projectDir });
         }
         exec(`git commit --allow-empty -m "chore: start session ${name}"`, { cwd: projectDir });
         const pushResult = exec(`git push origin "${branch}"`, { cwd: projectDir });
@@ -143,8 +270,16 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
             repo: config.repo,
             base: config.baseBranch,
             head: branch,
-            title: milestone ? `Milestone: ${milestone}` : `Session: ${name}`,
-            body: `## Session In Progress\n\n${milestone ? `**Milestone:** ${milestone}\n` : ''}**Branch:** ${branch}\n**Started:** ${new Date().toISOString()}\n\nThis PR will be updated as issues are processed.\n\n---\n*Automated by alpha-loop*`,
+            title: draftSessionPrTitle(name, milestone, epicNum, epicTitle),
+            body: buildDraftSessionPrBody({
+              branch,
+              startedAt: new Date().toISOString(),
+              milestone,
+              epicNum,
+              epicTitle,
+              queue,
+              baseBranch: config.baseBranch,
+            }),
             cwd: projectDir,
           });
           sessionPrUrl = draftPR;
@@ -158,7 +293,7 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
     }
   }
 
-  return { name, branch, resultsDir, logsDir, results: [], sessionPrUrl, epic: epicNum };
+  return { name, branch, resultsDir, logsDir, results: [], sessionPrUrl, epic: epicNum, queue };
 }
 
 /**
@@ -267,6 +402,9 @@ export async function finalizeSession(
       filesChanged: r.filesChanged,
     })),
   };
+  if (session.queue) {
+    manifest.queue = session.queue;
+  }
   if (stageEntries.length > 0) {
     manifest.stages = stageEntries;
   }
@@ -306,6 +444,11 @@ export async function finalizeSession(
     `**Completed:** ${new Date().toISOString()}`,
     '',
   ];
+
+  if (session.queue) {
+    prLines.push(...buildQueueSection(session.queue, session.branch, config.baseBranch));
+    prLines.push('');
+  }
 
   // Successes — the main content
   if (successes.length > 0) {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -20,6 +20,7 @@ export type SessionContext = {
   logsDir: string;
   results: PipelineResult[];
   sessionReviewFindings?: GateResult;
+  sessionPrUrl?: string;
   /** When set, this session processes sub-issues of the given epic. */
   epic?: number;
 };
@@ -62,6 +63,7 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
   const projectDir = process.cwd();
   const resultsDir = join(projectDir, '.alpha-loop', 'sessions', name);
   const logsDir = join(resultsDir, 'logs');
+  let sessionPrUrl: string | undefined;
 
   mkdirSync(resultsDir, { recursive: true });
   mkdirSync(logsDir, { recursive: true });
@@ -105,6 +107,7 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
           }**Branch:** ${branch}\n**Started:** ${new Date().toISOString()}\n\nThis PR will be updated as issues are processed.\n\n---\n*Automated by alpha-loop*`,
           cwd: projectDir,
         });
+        sessionPrUrl = draftPR;
         log.success(`Session PR (draft): ${draftPR}`);
       } catch {
         // Non-fatal — PR can be created later during finalization
@@ -144,6 +147,7 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
             body: `## Session In Progress\n\n${milestone ? `**Milestone:** ${milestone}\n` : ''}**Branch:** ${branch}\n**Started:** ${new Date().toISOString()}\n\nThis PR will be updated as issues are processed.\n\n---\n*Automated by alpha-loop*`,
             cwd: projectDir,
           });
+          sessionPrUrl = draftPR;
           log.success(`Session PR (draft): ${draftPR}`);
         } catch {
           log.warn('Could not create draft session PR — will create during finalization');
@@ -154,7 +158,7 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
     }
   }
 
-  return { name, branch, resultsDir, logsDir, results: [], epic: epicNum };
+  return { name, branch, resultsDir, logsDir, results: [], sessionPrUrl, epic: epicNum };
 }
 
 /**
@@ -366,6 +370,7 @@ export async function finalizeSession(
       body: prBody,
       cwd: projectDir,
     });
+    session.sessionPrUrl = prUrl;
     log.success(`Session PR: ${prUrl}`);
 
     // Mark successful issues on the project board
@@ -388,8 +393,10 @@ export async function finalizeSession(
         { cwd: projectDir }, true,
       );
       if (fallback.exitCode === 0 && fallback.stdout.trim()) {
-        log.success(`Session PR (fallback): ${fallback.stdout.trim()}`);
-        return fallback.stdout.trim();
+        const fallbackPrUrl = fallback.stdout.trim();
+        session.sessionPrUrl = fallbackPrUrl;
+        log.success(`Session PR (fallback): ${fallbackPrUrl}`);
+        return fallbackPrUrl;
       }
     } catch {
       // Fall through

--- a/tests/commands/history.test.ts
+++ b/tests/commands/history.test.ts
@@ -35,6 +35,97 @@ function createSession(
   }
 }
 
+function createQueueManifest(sessionsDir: string): void {
+  const queueDir = path.join(sessionsDir, 'queue-20260521T101112Z');
+  fs.mkdirSync(queueDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(queueDir, 'queue.json'),
+    JSON.stringify({
+      queueId: 'queue-20260521T101112Z',
+      epicIds: [205, 166, 214],
+      branchAncestryMode: 'stacked',
+      status: 'stopped',
+      startedAt: '2026-05-21T10:11:12.000Z',
+      endedAt: '2026-05-21T10:45:00.000Z',
+      stopReason: 'Epic #166 stopped: transient-agent-stop',
+      epics: [
+        {
+          epicNumber: 205,
+          title: 'First Epic',
+          queueIndex: 1,
+          queueTotal: 3,
+          previousEpic: null,
+          nextEpic: { number: 166, title: 'Second Epic' },
+          status: 'success',
+          sessionName: 'session/epic-205-first-epic',
+          sessionBranch: 'session/epic-205-first-epic',
+          sessionPrUrl: 'https://github.com/owner/repo/pull/205',
+          nextSessionBranch: 'session/epic-166-second-epic',
+          nextSessionPrUrl: null,
+          branchAncestryMode: 'stacked',
+          branchedFromBranch: 'master',
+          dependsOnSessionBranch: null,
+          dependsOnSessionPrUrl: null,
+          rebaseOntoBranch: null,
+          dependencyWarnings: ['Later queued epic #166 declares a dependency on this epic.'],
+          overlapWarnings: [],
+          startedAt: '2026-05-21T10:11:12.000Z',
+          endedAt: '2026-05-21T10:30:00.000Z',
+          failures: [],
+        },
+        {
+          epicNumber: 166,
+          title: 'Second Epic',
+          queueIndex: 2,
+          queueTotal: 3,
+          previousEpic: { number: 205, title: 'First Epic', sessionPrUrl: 'https://github.com/owner/repo/pull/205' },
+          nextEpic: { number: 214, title: 'Third Epic' },
+          status: 'failure',
+          sessionName: 'session/epic-166-second-epic',
+          sessionBranch: 'session/epic-166-second-epic',
+          sessionPrUrl: 'https://github.com/owner/repo/pull/166',
+          nextSessionBranch: null,
+          nextSessionPrUrl: null,
+          branchAncestryMode: 'stacked',
+          branchedFromBranch: 'session/epic-205-first-epic',
+          dependsOnSessionBranch: 'session/epic-205-first-epic',
+          dependsOnSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+          rebaseOntoBranch: 'master',
+          dependencyWarnings: ['Epic #166 declares a dependency on queued epic #205.'],
+          overlapWarnings: ['Epics #166 and #214 both mention src/lib/session.ts.'],
+          startedAt: '2026-05-21T10:30:00.000Z',
+          endedAt: '2026-05-21T10:45:00.000Z',
+          failures: [{ code: 'transient-stop', message: 'Agent rate limit', issueNum: 266 }],
+        },
+        {
+          epicNumber: 214,
+          title: 'Third Epic',
+          queueIndex: 3,
+          queueTotal: 3,
+          previousEpic: { number: 166, title: 'Second Epic' },
+          nextEpic: null,
+          status: 'pending',
+          sessionName: null,
+          sessionBranch: null,
+          sessionPrUrl: null,
+          nextSessionBranch: null,
+          nextSessionPrUrl: null,
+          branchAncestryMode: 'stacked',
+          branchedFromBranch: null,
+          dependsOnSessionBranch: null,
+          dependsOnSessionPrUrl: null,
+          rebaseOntoBranch: null,
+          dependencyWarnings: [],
+          overlapWarnings: [],
+          startedAt: null,
+          endedAt: null,
+          failures: [],
+        },
+      ],
+    }, null, 2),
+  );
+}
+
 describe('history', () => {
   let tmpDir: string;
   let consoleSpy: jest.SpyInstance;
@@ -98,6 +189,20 @@ describe('history', () => {
       expect(output).toContain('\u2717');
       expect(output).toContain('5m 00s');
     });
+
+    it('lists multi-epic queue manifests with status and pending counts', () => {
+      const sessionsDir = path.join(tmpDir, '.alpha-loop', 'sessions');
+      createQueueManifest(sessionsDir);
+
+      historyList(sessionsDir, tmpDir);
+
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('Queues:');
+      expect(output).toContain('queue-20260521T101112Z');
+      expect(output).toContain('3 epics');
+      expect(output).toContain('1 ok, 1 failed, 1 pending');
+      expect(output).toContain('Epic #166 stopped: transient-agent-stop');
+    });
   });
 
   describe('historyDetail', () => {
@@ -125,6 +230,78 @@ describe('history', () => {
       const errorOutput = errorSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
       expect(errorOutput).toContain('Session not found');
       errorSpy.mockRestore();
+    });
+
+    it('shows queue manifest detail for stopped multi-epic queues', () => {
+      const sessionsDir = path.join(tmpDir, '.alpha-loop', 'sessions');
+      createQueueManifest(sessionsDir);
+
+      historyDetail(sessionsDir, 'queue-20260521T101112Z', tmpDir);
+
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('Queue:       queue-20260521T101112Z');
+      expect(output).toContain('Status:      stopped');
+      expect(output).toContain('Branch mode: stacked');
+      expect(output).toContain('Manifest:    .alpha-loop/sessions/queue-20260521T101112Z/queue.json');
+      expect(output).toContain('Stop reason: Epic #166 stopped: transient-agent-stop');
+      expect(output).toContain('2/3 #166 Second Epic');
+      expect(output).toContain('Depends: session/epic-205-first-epic (https://github.com/owner/repo/pull/205)');
+      expect(output).toContain('Rebase:  session/epic-166-second-epic onto master after the dependency PR lands');
+      expect(output).toContain('Dependency: Epic #166 declares a dependency on queued epic #205.');
+      expect(output).toContain('File overlap: Epics #166 and #214 both mention src/lib/session.ts.');
+      expect(output).toContain('Failure: transient-stop');
+      expect(output).toContain('3/3 #214 Third Epic');
+      expect(output).toContain('pending');
+    });
+
+    it('shows queue metadata from checked-in session manifests', () => {
+      const sessionsDir = path.join(tmpDir, '.alpha-loop', 'sessions');
+      const learningsDir = path.join(tmpDir, '.alpha-loop', 'learnings');
+      fs.mkdirSync(learningsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(learningsDir, 'session-session-epic-166-second-epic.json'),
+        JSON.stringify({
+          name: 'session/epic-166-second-epic',
+          branch: 'session/epic-166-second-epic',
+          completed: '2026-05-21T10:45:00.000Z',
+          results: [{
+            issueNum: 266,
+            title: 'Second child',
+            status: 'success',
+            testsPassing: true,
+            verifyPassing: true,
+            duration: 60,
+            filesChanged: 2,
+          }],
+          queue: {
+            queueId: 'queue-20260521T101112Z',
+            queueIndex: 2,
+            queueTotal: 3,
+            currentEpic: { number: 166, title: 'Second Epic' },
+            previousEpic: { number: 205, title: 'First Epic' },
+            nextEpic: { number: 214, title: 'Third Epic' },
+            previousSessionBranch: 'session/epic-205-first-epic',
+            previousSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+            branchAncestryMode: 'stacked',
+            branchedFromBranch: 'session/epic-205-first-epic',
+            dependsOnSessionBranch: 'session/epic-205-first-epic',
+            dependsOnSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+            rebaseOntoBranch: 'master',
+            dependencyWarnings: [],
+            overlapWarnings: [],
+          },
+        }, null, 2),
+      );
+
+      historyDetail(sessionsDir, 'session/epic-166-second-epic', tmpDir);
+
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('Session:  session/epic-166-second-epic');
+      expect(output).toContain('Queue:');
+      expect(output).toContain('ID:        queue-20260521T101112Z');
+      expect(output).toContain('Position:  2 of 3');
+      expect(output).toContain('Depends:   session/epic-205-first-epic (https://github.com/owner/repo/pull/205)');
+      expect(output).toContain('Rebase:    onto master after the dependency PR lands');
     });
   });
 

--- a/tests/commands/resume.test.ts
+++ b/tests/commands/resume.test.ts
@@ -2,16 +2,119 @@ jest.mock('../../src/lib/shell', () => ({
   exec: jest.fn(),
 }));
 
-import { findStrandedBranches } from '../../src/commands/resume';
+jest.mock('../../src/lib/config', () => ({
+  loadConfig: jest.fn(),
+  resolveStepConfig: jest.fn(),
+}));
+
+jest.mock('../../src/lib/rate-limit', () => ({
+  ghExec: jest.fn(),
+}));
+
+jest.mock('../../src/lib/agent', () => ({
+  spawnAgent: jest.fn(),
+}));
+
+jest.mock('../../src/lib/prompts', () => ({
+  buildReviewPrompt: jest.fn(() => 'review prompt'),
+}));
+
+jest.mock('../../src/lib/github', () => ({
+  labelIssue: jest.fn(),
+  commentIssue: jest.fn(),
+  createPR: jest.fn(),
+  updateProjectStatus: jest.fn(),
+}));
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { findStrandedBranches, resumeCommand } from '../../src/commands/resume';
+import { loadConfig, resolveStepConfig, type Config } from '../../src/lib/config';
+import { createPR, labelIssue, commentIssue, updateProjectStatus } from '../../src/lib/github';
+import { ghExec } from '../../src/lib/rate-limit';
+import { spawnAgent } from '../../src/lib/agent';
 import { exec } from '../../src/lib/shell';
 
 const mockExec = exec as jest.MockedFunction<typeof exec>;
+const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
+const mockResolveStepConfig = resolveStepConfig as jest.MockedFunction<typeof resolveStepConfig>;
+const mockGhExec = ghExec as jest.MockedFunction<typeof ghExec>;
+const mockCreatePR = createPR as jest.MockedFunction<typeof createPR>;
+const mockLabelIssue = labelIssue as jest.MockedFunction<typeof labelIssue>;
+const mockCommentIssue = commentIssue as jest.MockedFunction<typeof commentIssue>;
+const mockUpdateProjectStatus = updateProjectStatus as jest.MockedFunction<typeof updateProjectStatus>;
+const mockSpawnAgent = spawnAgent as jest.MockedFunction<typeof spawnAgent>;
 
 const ok = (stdout = '') => ({ stdout, stderr: '', exitCode: 0 });
+const repoRoot = process.cwd();
+let tempDir: string | undefined;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  process.chdir(repoRoot);
+  tempDir = undefined;
+  mockResolveStepConfig.mockReturnValue({ agent: 'codex', model: 'gpt-5' });
+  mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/269');
 });
+
+afterEach(() => {
+  process.chdir(repoRoot);
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+});
+
+function baseConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    repo: 'owner/repo',
+    repoOwner: 'owner',
+    project: 2,
+    agent: 'codex',
+    model: 'gpt-5',
+    reviewModel: '',
+    pollInterval: 60,
+    dryRun: false,
+    baseBranch: 'master',
+    logDir: 'logs',
+    labelReady: 'ready',
+    maxTestRetries: 3,
+    testCommand: 'pnpm test',
+    devCommand: 'pnpm dev',
+    skipTests: false,
+    skipReview: true,
+    skipInstall: false,
+    skipPreflight: false,
+    skipVerify: false,
+    skipLearn: false,
+    skipE2e: false,
+    maxIssues: 0,
+    maxSessionDuration: 0,
+    milestone: '',
+    autoMerge: false,
+    mergeTo: '',
+    autoCleanup: true,
+    runFull: false,
+    verbose: false,
+    harnesses: [],
+    setupCommand: '',
+    evalDir: '.alpha-loop/evals',
+    evalModel: '',
+    skipEval: false,
+    evalTimeout: 300,
+    autoCapture: true,
+    skipPostSessionReview: false,
+    skipPostSessionSecurity: false,
+    batch: false,
+    batchSize: 5,
+    smokeTest: '',
+    agentTimeout: 1800,
+    pricing: {},
+    pipeline: {},
+    evalIncludeAgentPrompts: true,
+    evalIncludeSkills: true,
+    preferEpics: false,
+    ...overrides,
+  };
+}
 
 describe('findStrandedBranches', () => {
   test('normalizes + prefixed branches checked out in another worktree', () => {
@@ -72,5 +175,90 @@ describe('findStrandedBranches', () => {
         filesChanged: ['src/commands/resume.ts'],
       },
     ]);
+  });
+});
+
+describe('resumeCommand', () => {
+  test('records recovered PRs as unverified WIP and updates the session PR without CommonJS require', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-resume-'));
+    process.chdir(tempDir);
+
+    const sessionDir = join(tempDir, '.alpha-loop', 'sessions', 'session', 'epic-123');
+    mkdirSync(join(sessionDir, 'logs'), { recursive: true });
+    writeFileSync(join(sessionDir, 'logs', 'issue-269-review.log'), 'review agent hit max turns');
+
+    let sessionPrBody = '';
+    mockLoadConfig.mockReturnValue(baseConfig());
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd === 'git branch --list "agent/issue-*"') return ok('  agent/issue-269\n');
+      if (cmd === 'git worktree list --porcelain') return ok('');
+      if (cmd === 'git log "origin/master..agent/issue-269" --oneline') return ok('abc123 recover stranded work\n');
+      if (cmd === 'git diff --name-only "origin/master...agent/issue-269"') return ok('reports/final.pdf\nslides/final.pptx\n');
+      if (cmd === 'git push -u origin "agent/issue-269"') return ok('');
+      return ok('');
+    });
+    mockGhExec.mockImplementation((cmd: string) => {
+      if (cmd === 'gh pr list --repo "owner/repo" --head "agent/issue-269" --state open --json number --limit 1') return ok('[]');
+      if (cmd === 'gh issue view 269 --repo "owner/repo" --json title') return ok('{"title":"Recover artifact exports"}');
+      if (cmd === 'gh pr list --repo "owner/repo" --head "session/epic-123" --state open --json number,url --limit 1') {
+        return ok('[{"number":999,"url":"https://github.com/owner/repo/pull/999"}]');
+      }
+      if (cmd.startsWith('gh pr edit 999 --repo "owner/repo" --body-file ')) {
+        const bodyFile = cmd.match(/--body-file "([^"]+)"/)?.[1];
+        if (bodyFile) sessionPrBody = readFileSync(bodyFile, 'utf-8');
+        return ok('');
+      }
+      if (cmd.startsWith('gh pr edit 999 --repo "owner/repo" --title ')) return ok('');
+      return ok('');
+    });
+
+    await resumeCommand({ issue: '269' });
+
+    expect(mockCreatePR).toHaveBeenCalledWith(expect.objectContaining({
+      repo: 'owner/repo',
+      base: 'master',
+      head: 'agent/issue-269',
+      title: 'feat: Recover artifact exports (closes #269)',
+      body: expect.stringContaining('Treat this PR as WIP until those checks pass.'),
+    }));
+    expect(mockLabelIssue).toHaveBeenCalledWith('owner/repo', 269, 'in-review', 'in-progress');
+    expect(mockUpdateProjectStatus).toHaveBeenCalledWith('owner/repo', 2, 'owner', 269, 'In Review');
+    expect(mockCommentIssue).toHaveBeenCalledWith(
+      'owner/repo',
+      269,
+      expect.stringContaining('Final tests and verification were not run by resume'),
+    );
+    expect(mockSpawnAgent).not.toHaveBeenCalled();
+
+    const resultPath = join(sessionDir, 'result-269.json');
+    expect(existsSync(resultPath)).toBe(true);
+    const result = JSON.parse(readFileSync(resultPath, 'utf-8'));
+    expect(result).toEqual(expect.objectContaining({
+      issueNum: 269,
+      title: 'Recover artifact exports',
+      status: 'failure',
+      failureReason: 'transient',
+      prUrl: 'https://github.com/owner/repo/pull/269',
+      testsPassing: false,
+      verifyPassing: false,
+      verifySkipped: true,
+      filesChanged: 2,
+    }));
+
+    expect(mockGhExec).toHaveBeenCalledWith(
+      expect.stringContaining('gh pr edit 999 --repo "owner/repo" --title "Session: session/epic-123'),
+      undefined,
+      true,
+    );
+    expect(sessionPrBody).toContain('0 succeeded, 1 failed');
+    expect(sessionPrBody).toContain('Resume Caveat');
+    expect(sessionPrBody).toContain('#269: Recover artifact exports — RECOVERED - VERIFY SKIPPED');
+    expect(sessionPrBody).toContain('https://github.com/owner/repo/pull/269');
+  });
+
+  test('keeps the ESM resume command free of runtime CommonJS require calls', () => {
+    const source = readFileSync(join(repoRoot, 'src', 'commands', 'resume.ts'), 'utf-8');
+
+    expect(source).not.toMatch(/\brequire\s*\(/);
   });
 });

--- a/tests/commands/roadmap.test.ts
+++ b/tests/commands/roadmap.test.ts
@@ -57,8 +57,17 @@ jest.mock('../../src/lib/rate-limit', () => ({
 
 jest.mock('../../src/lib/planning', () => ({
   extractJsonFromResponse: jest.fn(),
+  formatEpicQueuePlan: jest.fn(() => 'FORMATTED QUEUE PLAN'),
   formatRoadmapTable: jest.fn(() => 'FORMATTED ROADMAP'),
   normalizeRoadmapPlan: jest.requireActual('../../src/lib/planning').normalizeRoadmapPlan,
+  planEpicQueue: jest.fn(() => ({
+    milestoneFilter: null,
+    totalEpicCount: 0,
+    consideredEpicCount: 0,
+    orderedEpics: [],
+    blockedEpics: [],
+    command: null,
+  })),
   buildPlanningContext: jest.fn(() => ({
     visionContext: null,
     projectContext: null,
@@ -79,7 +88,7 @@ import { checkbox, confirm } from '@inquirer/prompts';
 import { exec } from '../../src/lib/shell';
 import { log } from '../../src/lib/logger';
 import { buildRoadmapPrompt } from '../../src/lib/prompts';
-import { extractJsonFromResponse } from '../../src/lib/planning';
+import { extractJsonFromResponse, formatEpicQueuePlan, planEpicQueue } from '../../src/lib/planning';
 import {
   listOpenIssues,
   listRoadmapEpics,
@@ -94,6 +103,8 @@ const mockConfirm = confirm as jest.MockedFunction<typeof confirm>;
 const mockExec = exec as jest.MockedFunction<typeof exec>;
 const mockBuildRoadmapPrompt = buildRoadmapPrompt as jest.MockedFunction<typeof buildRoadmapPrompt>;
 const mockExtractJson = extractJsonFromResponse as jest.MockedFunction<typeof extractJsonFromResponse>;
+const mockFormatEpicQueuePlan = formatEpicQueuePlan as jest.MockedFunction<typeof formatEpicQueuePlan>;
+const mockPlanEpicQueue = planEpicQueue as jest.MockedFunction<typeof planEpicQueue>;
 const mockListOpenIssues = listOpenIssues as jest.MockedFunction<typeof listOpenIssues>;
 const mockListRoadmapEpics = listRoadmapEpics as jest.MockedFunction<typeof listRoadmapEpics>;
 const mockListMilestones = listMilestones as jest.MockedFunction<typeof listMilestones>;
@@ -168,6 +179,45 @@ describe('roadmap command', () => {
     expect(mockExec).not.toHaveBeenCalled();
     expect(mockCreateMilestone).not.toHaveBeenCalled();
     expect(mockSetIssueMilestone).not.toHaveBeenCalled();
+  });
+
+  it('prints an epic queue recommendation without invoking AI or mutating GitHub', async () => {
+    const { loadConfig } = require('../../src/lib/config');
+    const milestones = [
+      { number: 4, title: '001 - Existing Core', description: 'Core', openIssues: 0, closedIssues: 0, dueOn: null, state: 'open' },
+    ];
+    mockListOpenIssues.mockReturnValue([
+      { number: 195, title: 'Epic: Scheduling', body: 'Epic body', labels: ['epic'], milestone: '001 - Existing Core' },
+      { number: 7, title: 'Create API endpoints', body: 'REST API', labels: ['ready'] },
+    ]);
+    mockListRoadmapEpics.mockReturnValue(SAMPLE_EPIC_CONTEXT);
+    mockListMilestones.mockReturnValue(milestones);
+    mockFormatEpicQueuePlan.mockReturnValue('FORMATTED QUEUE PLAN');
+
+    await roadmapCommand({ queue: true, milestone: '001 - Existing Core' });
+
+    expect(mockListOpenIssues).toHaveBeenCalledWith('owner/repo', 1000);
+    expect(loadConfig).toHaveBeenCalledWith({
+      dryRun: true,
+      milestone: '001 - Existing Core',
+    });
+    expect(mockPlanEpicQueue).toHaveBeenCalledWith(SAMPLE_EPIC_CONTEXT, {
+      labelReady: 'ready',
+      milestone: '001 - Existing Core',
+      openIssues: expect.arrayContaining([
+        expect.objectContaining({ number: 195 }),
+        expect.objectContaining({ number: 7 }),
+      ]),
+      milestones,
+    });
+    expect(consoleSpy).toHaveBeenCalledWith('FORMATTED QUEUE PLAN');
+    expect(log.dry).toHaveBeenCalledWith(expect.stringContaining('Queue planning only'));
+    expect(mockBuildRoadmapPrompt).not.toHaveBeenCalled();
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(mockCheckbox).not.toHaveBeenCalled();
+    expect(mockCreateMilestone).not.toHaveBeenCalled();
+    expect(mockSetIssueMilestone).not.toHaveBeenCalled();
+    expect(mockAddIssueToProject).not.toHaveBeenCalled();
   });
 
   it('creates milestones and assigns issues on happy path', async () => {

--- a/tests/commands/roadmap.test.ts
+++ b/tests/commands/roadmap.test.ts
@@ -164,6 +164,15 @@ describe('roadmap command', () => {
     jest.clearAllMocks();
     mockBuildRoadmapPrompt.mockReturnValue('ROADMAP PROMPT');
     mockListRoadmapEpics.mockReturnValue([]);
+    mockFormatEpicQueuePlan.mockReturnValue('FORMATTED QUEUE PLAN');
+    mockPlanEpicQueue.mockReturnValue({
+      milestoneFilter: null,
+      totalEpicCount: 0,
+      consideredEpicCount: 0,
+      orderedEpics: [],
+      blockedEpics: [],
+      command: null,
+    });
   });
 
   afterEach(() => {
@@ -218,6 +227,85 @@ describe('roadmap command', () => {
     expect(mockCreateMilestone).not.toHaveBeenCalled();
     expect(mockSetIssueMilestone).not.toHaveBeenCalled();
     expect(mockAddIssueToProject).not.toHaveBeenCalled();
+  });
+
+  it('prints runnable command text and blocked epic notes for planned queue output', async () => {
+    const actualPlanning = jest.requireActual('../../src/lib/planning');
+    mockFormatEpicQueuePlan.mockImplementation(actualPlanning.formatEpicQueuePlan);
+    mockListOpenIssues.mockReturnValue([
+      { number: 205, title: 'Epic: Foundation', body: 'Epic body', labels: ['epic'], milestone: '001 - Existing Core' },
+      { number: 214, title: 'Epic: Follow-up', body: 'Depends on #205', labels: ['epic'], milestone: '001 - Existing Core' },
+      { number: 300, title: 'Epic: Blocked', body: 'Depends on #999', labels: ['epic'], milestone: '001 - Existing Core' },
+      { number: 305, title: 'Ready child', body: 'Child body', labels: ['ready'] },
+    ]);
+    mockListRoadmapEpics.mockReturnValue(SAMPLE_EPIC_CONTEXT);
+    mockListMilestones.mockReturnValue([
+      { number: 4, title: '001 - Existing Core', description: 'Core', openIssues: 0, closedIssues: 0, dueOn: null, state: 'open' },
+    ]);
+    mockPlanEpicQueue.mockReturnValue({
+      milestoneFilter: '001 - Existing Core',
+      totalEpicCount: 3,
+      consideredEpicCount: 3,
+      orderedEpics: [
+        {
+          issueNum: 205,
+          title: 'Epic: Foundation',
+          status: 'runnable',
+          readyChildCount: 1,
+          completedChildCount: 0,
+          blockedChildCount: 0,
+          totalChildCount: 1,
+          queueDependencies: [],
+          rationale: ['Child readiness: 1 ready'],
+          blockers: [],
+          risks: ['Likely file overlap with #214: src/lib/session.ts'],
+        },
+        {
+          issueNum: 214,
+          title: 'Epic: Follow-up',
+          status: 'runnable',
+          readyChildCount: 1,
+          completedChildCount: 0,
+          blockedChildCount: 0,
+          totalChildCount: 1,
+          queueDependencies: [205],
+          rationale: ['Queue dependencies: #205'],
+          blockers: [],
+          risks: ['Likely file overlap with #205: src/lib/session.ts'],
+        },
+      ],
+      blockedEpics: [
+        {
+          issueNum: 300,
+          title: 'Epic: Blocked',
+          status: 'blocked',
+          readyChildCount: 0,
+          completedChildCount: 0,
+          blockedChildCount: 1,
+          totalChildCount: 1,
+          queueDependencies: [],
+          rationale: [],
+          blockers: ['Open dependency #999 is outside the planned epic queue'],
+          risks: [],
+        },
+      ],
+      command: 'alpha-loop run --epics 205,214',
+    } as any);
+
+    await roadmapCommand({ queue: true, milestone: '001 - Existing Core' });
+
+    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+    expect(output).toContain('Epic Queue Recommendation');
+    expect(output).toContain('Scope: milestone "001 - Existing Core"');
+    expect(output).toContain('Runnable Queue (2)');
+    expect(output).toContain('#205 Epic: Foundation');
+    expect(output).toContain('#214 Epic: Follow-up');
+    expect(output).toContain('Blocked Epics (1)');
+    expect(output).toContain('Open dependency #999 is outside the planned epic queue');
+    expect(output).toContain('alpha-loop run --epics 205,214');
+    expect(mockBuildRoadmapPrompt).not.toHaveBeenCalled();
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(mockSetIssueMilestone).not.toHaveBeenCalled();
   });
 
   it('creates milestones and assigns issues on happy path', async () => {

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -395,8 +395,8 @@ describe('runCommand', () => {
     }) as any);
 
     const issues = new Map([
-      [205, { number: 205, title: 'First Epic', body: '- [ ] #305 First child', labels: ['epic'], state: 'OPEN' }],
-      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
+      [205, { number: 205, title: 'First Epic', body: 'Touches `src/lib/session.ts`.\n- [ ] #305 First child', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: 'Depends on #205. Also touches `src/lib/session.ts`.\n- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
       [214, { number: 214, title: 'Third Epic', body: '- [ ] #314 Third child', labels: ['epic'], state: 'OPEN' }],
       [305, { number: 305, title: 'First child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
       [266, { number: 266, title: 'Second child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
@@ -443,6 +443,8 @@ describe('runCommand', () => {
         branchAncestryMode: 'stacked',
         branchedFromBranch: 'master',
         dependsOnSessionBranch: null,
+        dependencyWarnings: expect.arrayContaining(['Later queued epic #166 declares a dependency on this epic.']),
+        overlapWarnings: expect.arrayContaining(['Epics #205 and #166 both mention src/lib/session.ts.']),
       }),
       expect.objectContaining({
         queueIndex: 2,
@@ -454,6 +456,8 @@ describe('runCommand', () => {
         branchedFromBranch: 'session/epic-205',
         dependsOnSessionBranch: 'session/epic-205',
         rebaseOntoBranch: 'master',
+        dependencyWarnings: expect.arrayContaining(['Epic #166 declares a dependency on queued epic #205.']),
+        overlapWarnings: expect.arrayContaining(['Epics #205 and #166 both mention src/lib/session.ts.']),
       }),
       expect.objectContaining({
         queueIndex: 3,
@@ -523,6 +527,15 @@ describe('runCommand', () => {
         nextSessionPrUrl: null,
       },
     ]);
+    expect(manifest.epics[0].dependencyWarnings).toEqual(expect.arrayContaining([
+      'Later queued epic #166 declares a dependency on this epic.',
+    ]));
+    expect(manifest.epics[1].dependencyWarnings).toEqual(expect.arrayContaining([
+      'Epic #166 declares a dependency on queued epic #205.',
+    ]));
+    expect(manifest.epics[1].overlapWarnings).toEqual(expect.arrayContaining([
+      'Epics #205 and #166 both mention src/lib/session.ts.',
+    ]));
     expect(mockFinalizeSession.mock.calls.map((call) => (call[0] as any).queue?.queueIndex)).toEqual([1, 2, 3]);
     expect(mockExit).not.toHaveBeenCalled();
   });

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -19,6 +19,7 @@ jest.mock('../../src/lib/logger', () => ({
 jest.mock('../../src/lib/config', () => ({
   loadConfig: jest.fn(),
   assertSafeShellArg: jest.fn((value: string) => value),
+  resolveStepConfig: jest.fn((config: any) => ({ agent: config.agent, model: config.model })),
 }));
 
 jest.mock('../../src/lib/github', () => ({
@@ -77,6 +78,11 @@ jest.mock('../../src/lib/preflight', () => ({
   runPortCheck: jest.fn().mockReturnValue([]),
 }));
 
+jest.mock('../../src/lib/eval', () => ({
+  saveCapturedCase: jest.fn(),
+  detectFailureStep: jest.fn(() => 'implement'),
+}));
+
 jest.mock('../../src/commands/sync', () => ({
   syncAgentAssets: jest.fn().mockReturnValue({ synced: false, docSynced: false, skillsDirs: [] }),
   resolveHarnesses: jest.fn((harnesses: string[], _agent: string) => harnesses),
@@ -85,19 +91,23 @@ jest.mock('../../src/commands/sync', () => ({
 jest.mock('node:fs', () => ({
   existsSync: jest.fn().mockReturnValue(false),
   readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
   mkdirSync: jest.fn(),
   renameSync: jest.fn(),
   unlinkSync: jest.fn(),
 }));
 
 import { exec } from '../../src/lib/shell';
+import { log } from '../../src/lib/logger';
 import { loadConfig } from '../../src/lib/config';
 import { pollIssues, listEpics, getEpicSubIssues, getIssueWithComments, updateEpicChecklist } from '../../src/lib/github';
 import { processIssue, processBatch } from '../../src/lib/pipeline';
 import { createSession, finalizeSession } from '../../src/lib/session';
 import { repairSessionLearningArtifacts, repairSessionSummaryArtifact } from '../../src/lib/learning';
+import { writeFileSync } from 'node:fs';
 
 const mockExec = exec as jest.MockedFunction<typeof exec>;
+const mockLog = log as jest.Mocked<typeof log>;
 const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
 const mockPollIssues = pollIssues as jest.MockedFunction<typeof pollIssues>;
 const mockListEpics = listEpics as jest.MockedFunction<typeof listEpics>;
@@ -110,6 +120,7 @@ const mockCreateSession = createSession as jest.MockedFunction<typeof createSess
 const mockFinalizeSession = finalizeSession as jest.MockedFunction<typeof finalizeSession>;
 const mockRepairSessionLearningArtifacts = repairSessionLearningArtifacts as jest.MockedFunction<typeof repairSessionLearningArtifacts>;
 const mockRepairSessionSummaryArtifact = repairSessionSummaryArtifact as jest.MockedFunction<typeof repairSessionSummaryArtifact>;
+const mockWriteFileSync = writeFileSync as jest.MockedFunction<typeof writeFileSync>;
 
 function makeConfig(overrides: Record<string, unknown> = {}) {
   return {
@@ -308,6 +319,253 @@ describe('runCommand', () => {
     ]);
     expect(mockProcessIssue).not.toHaveBeenCalled();
     expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('--epics dry-run validates the full queue in order without creating sessions or manifests', async () => {
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266', labels: ['epic'], state: 'OPEN' }],
+      [214, { number: 214, title: 'Third Epic', body: '- [ ] #314', labels: ['epic'], state: 'OPEN' }],
+    ]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+
+    await runCommand({ epics: '205,166,214', dryRun: true });
+
+    expect(mockGetIssueWithComments.mock.calls.map((call) => call[1])).toEqual([205, 166, 214]);
+    expect(mockLog.dry).toHaveBeenCalledWith('Validated epic queue (3 epics):');
+    expect(mockLog.dry).toHaveBeenCalledWith('  1. #205 First Epic');
+    expect(mockLog.dry).toHaveBeenCalledWith('  2. #166 Second Epic');
+    expect(mockLog.dry).toHaveBeenCalledWith('  3. #214 Third Epic');
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+    expect(mockUpdateEpicChecklist).not.toHaveBeenCalled();
+    expect(mockFinalizeSession).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('--epics dry-run previews non-epic labels as warnings without mutating', async () => {
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305', labels: ['epic'], state: 'OPEN' }],
+      [214, { number: 214, title: 'Not Yet Labeled', body: '- [ ] #314', labels: ['ready'], state: 'OPEN' }],
+    ]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+
+    await runCommand({ epics: '205,214', dryRun: true });
+
+    expect(mockLog.dry).toHaveBeenCalledWith('  1. #205 First Epic');
+    expect(mockLog.dry).toHaveBeenCalledWith(expect.stringContaining('  2. #214 Not Yet Labeled (warning: Issue #214 is not labeled'));
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+    expect(mockUpdateEpicChecklist).not.toHaveBeenCalled();
+    expect(mockFinalizeSession).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('--epics rejects incompatible targeting flags before processing', async () => {
+    await runCommand({ epics: '205,166', epic: 205, dryRun: true });
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockGetIssueWithComments).not.toHaveBeenCalled();
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  test('--epics rejects invalid queued issues before processing the first epic', async () => {
+    mockGetIssueWithComments.mockReturnValue({
+      number: 205,
+      title: 'Not an epic',
+      body: '- [ ] #305',
+      labels: ['ready'],
+      state: 'OPEN',
+    });
+
+    await runCommand({ epics: '205' });
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+  });
+
+  test('--epics processes each epic sequentially and writes a successful queue manifest', async () => {
+    mockLoadConfig.mockImplementation((overrides: any = {}) => makeConfig({
+      skipPostSessionReview: true,
+      autoMerge: false,
+      ...overrides,
+    }) as any);
+
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305 First child', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
+      [214, { number: 214, title: 'Third Epic', body: '- [ ] #314 Third child', labels: ['epic'], state: 'OPEN' }],
+      [305, { number: 305, title: 'First child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [266, { number: 266, title: 'Second child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [314, { number: 314, title: 'Third child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+    ]);
+    const childByEpic = new Map([[205, 305], [166, 266], [214, 314]]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+    mockGetEpicSubIssues.mockImplementation((_repo: string, epicNum: number) => [{
+      number: childByEpic.get(epicNum) ?? 0,
+      checked: true,
+      lineIndex: 0,
+    }]);
+    mockCreateSession.mockImplementation((_config: any, options: any = {}) => ({
+      name: `session/epic-${options.epicNum}`,
+      branch: `session/epic-${options.epicNum}`,
+      resultsDir: `/tmp/sessions/epic-${options.epicNum}`,
+      logsDir: `/tmp/sessions/epic-${options.epicNum}/logs`,
+      results: [],
+      epic: options.epicNum,
+    }));
+    mockProcessIssue.mockImplementation(async (issueNum: number, title: string) => ({
+      issueNum,
+      title,
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    }));
+    mockFinalizeSession.mockImplementation(async (session: any) => `https://github.com/owner/repo/pull/${session.epic}`);
+
+    await runCommand({ epics: '205,166,214' });
+
+    expect(mockCreateSession.mock.calls.map((call) => call[1]?.epicNum)).toEqual([205, 166, 214]);
+    expect(mockCreateSession.mock.calls.map((call) => call[0])).toEqual([
+      expect.objectContaining({ autoMerge: true, mergeTo: '' }),
+      expect.objectContaining({ autoMerge: true, mergeTo: '' }),
+      expect.objectContaining({ autoMerge: true, mergeTo: '' }),
+    ]);
+    expect(mockProcessIssue.mock.calls.map((call) => call[0])).toEqual([305, 266, 314]);
+    expect(mockFinalizeSession).toHaveBeenCalledTimes(3);
+
+    const manifest = JSON.parse(String(mockWriteFileSync.mock.calls.at(-1)?.[1]));
+    expect(manifest).toEqual(expect.objectContaining({
+      epicIds: [205, 166, 214],
+      status: 'success',
+      stopReason: null,
+    }));
+    expect(manifest.epics.map((entry: any) => ({
+      epicNumber: entry.epicNumber,
+      status: entry.status,
+      sessionBranch: entry.sessionBranch,
+      sessionPrUrl: entry.sessionPrUrl,
+    }))).toEqual([
+      { epicNumber: 205, status: 'success', sessionBranch: 'session/epic-205', sessionPrUrl: 'https://github.com/owner/repo/pull/205' },
+      { epicNumber: 166, status: 'success', sessionBranch: 'session/epic-166', sessionPrUrl: 'https://github.com/owner/repo/pull/166' },
+      { epicNumber: 214, status: 'success', sessionBranch: 'session/epic-214', sessionPrUrl: 'https://github.com/owner/repo/pull/214' },
+    ]);
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('--epics stops on the first failed epic and records the stop reason in the manifest', async () => {
+    mockLoadConfig.mockImplementation((overrides: any = {}) => makeConfig({
+      skipPostSessionReview: true,
+      autoCapture: false,
+      ...overrides,
+    }) as any);
+
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305 First child', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
+      [214, { number: 214, title: 'Third Epic', body: '- [ ] #314 Third child', labels: ['epic'], state: 'OPEN' }],
+      [305, { number: 305, title: 'First child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [266, { number: 266, title: 'Second child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [314, { number: 314, title: 'Third child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+    ]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+    mockGetEpicSubIssues.mockReturnValue([{ number: 305, checked: true, lineIndex: 0 }]);
+    mockCreateSession.mockImplementation((_config: any, options: any = {}) => ({
+      name: `session/epic-${options.epicNum}`,
+      branch: `session/epic-${options.epicNum}`,
+      resultsDir: `/tmp/sessions/epic-${options.epicNum}`,
+      logsDir: `/tmp/sessions/epic-${options.epicNum}/logs`,
+      results: [],
+      epic: options.epicNum,
+    }));
+    mockProcessIssue.mockImplementation(async (issueNum: number, title: string) => ({
+      issueNum,
+      title,
+      status: issueNum === 266 ? 'failure' : 'success',
+      testsPassing: issueNum !== 266,
+      verifyPassing: issueNum !== 266,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+      ...(issueNum === 266 ? { failureReason: 'transient' as const } : {}),
+    }));
+    mockFinalizeSession.mockImplementation(async (session: any) => `https://github.com/owner/repo/pull/${session.epic}`);
+
+    await runCommand({ epics: '205,166,214' });
+
+    expect(mockProcessIssue.mock.calls.map((call) => call[0])).toEqual([305, 266]);
+    expect(mockCreateSession.mock.calls.map((call) => call[1]?.epicNum)).toEqual([205, 166]);
+    expect(mockExit).toHaveBeenCalledWith(1);
+
+    const manifest = JSON.parse(String(mockWriteFileSync.mock.calls.at(-1)?.[1]));
+    expect(manifest.status).toBe('stopped');
+    expect(manifest.stopReason).toBe('Epic #166 stopped: transient-agent-stop');
+    expect(manifest.epics.map((entry: any) => [entry.epicNumber, entry.status])).toEqual([
+      [205, 'success'],
+      [166, 'failure'],
+      [214, 'pending'],
+    ]);
+    expect(manifest.epics[1].failures).toEqual([
+      expect.objectContaining({ code: 'transient-stop', issueNum: 266 }),
+    ]);
+  });
+
+  test('--epics stops when an epic remains incomplete after processing eligible children', async () => {
+    mockLoadConfig.mockImplementation((overrides: any = {}) => makeConfig({
+      skipPostSessionReview: true,
+      ...overrides,
+    }) as any);
+
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305 Ready child\n- [ ] #306 Blocked child', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
+      [305, { number: 305, title: 'Ready child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [306, { number: 306, title: 'Blocked child', body: 'Body', labels: ['blocked'], state: 'OPEN' }],
+      [266, { number: 266, title: 'Second child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+    ]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+    mockCreateSession.mockImplementation((_config: any, options: any = {}) => ({
+      name: `session/epic-${options.epicNum}`,
+      branch: `session/epic-${options.epicNum}`,
+      resultsDir: `/tmp/sessions/epic-${options.epicNum}`,
+      logsDir: `/tmp/sessions/epic-${options.epicNum}/logs`,
+      results: [],
+      epic: options.epicNum,
+    }));
+    mockProcessIssue.mockResolvedValue({
+      issueNum: 305,
+      title: 'Ready child',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    });
+    mockFinalizeSession.mockImplementation(async (session: any) => `https://github.com/owner/repo/pull/${session.epic}`);
+
+    await runCommand({ epics: '205,166' });
+
+    expect(mockProcessIssue.mock.calls.map((call) => call[0])).toEqual([305]);
+    expect(mockCreateSession.mock.calls.map((call) => call[1]?.epicNum)).toEqual([205]);
+    expect(mockExit).toHaveBeenCalledWith(1);
+
+    const manifest = JSON.parse(String(mockWriteFileSync.mock.calls.at(-1)?.[1]));
+    expect(manifest.status).toBe('stopped');
+    expect(manifest.stopReason).toBe('Epic #205 stopped: epic-incomplete');
+    expect(manifest.epics.map((entry: any) => [entry.epicNumber, entry.status])).toEqual([
+      [205, 'failure'],
+      [166, 'pending'],
+    ]);
+    expect(manifest.epics[0].failures).toEqual([
+      expect.objectContaining({ code: 'epic-incomplete', issueNum: 205 }),
+    ]);
   });
 
   test('--verify-only bypasses normal session creation and issue processing', async () => {

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -416,6 +416,7 @@ describe('runCommand', () => {
       logsDir: `/tmp/sessions/epic-${options.epicNum}/logs`,
       results: [],
       epic: options.epicNum,
+      queue: options.queue,
     }));
     mockProcessIssue.mockImplementation(async (issueNum: number, title: string) => ({
       issueNum,
@@ -432,6 +433,37 @@ describe('runCommand', () => {
     await runCommand({ epics: '205,166,214' });
 
     expect(mockCreateSession.mock.calls.map((call) => call[1]?.epicNum)).toEqual([205, 166, 214]);
+    const queueContexts = mockCreateSession.mock.calls.map((call) => (call[1] as any)?.queue);
+    expect(queueContexts).toEqual([
+      expect.objectContaining({
+        queueIndex: 1,
+        queueTotal: 3,
+        currentEpic: expect.objectContaining({ number: 205, title: 'First Epic' }),
+        nextEpic: expect.objectContaining({ number: 166, title: 'Second Epic' }),
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+      }),
+      expect.objectContaining({
+        queueIndex: 2,
+        previousEpic: expect.objectContaining({ number: 205, title: 'First Epic', sessionPrUrl: 'https://github.com/owner/repo/pull/205' }),
+        nextEpic: expect.objectContaining({ number: 214, title: 'Third Epic' }),
+        previousSessionBranch: 'session/epic-205',
+        previousSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'session/epic-205',
+        dependsOnSessionBranch: 'session/epic-205',
+        rebaseOntoBranch: 'master',
+      }),
+      expect.objectContaining({
+        queueIndex: 3,
+        previousSessionBranch: 'session/epic-166',
+        previousSessionPrUrl: 'https://github.com/owner/repo/pull/166',
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'session/epic-166',
+        dependsOnSessionBranch: 'session/epic-166',
+      }),
+    ]);
     expect(mockCreateSession.mock.calls.map((call) => call[0])).toEqual([
       expect.objectContaining({ autoMerge: true, mergeTo: '' }),
       expect.objectContaining({ autoMerge: true, mergeTo: '' }),
@@ -451,11 +483,138 @@ describe('runCommand', () => {
       status: entry.status,
       sessionBranch: entry.sessionBranch,
       sessionPrUrl: entry.sessionPrUrl,
+      branchAncestryMode: entry.branchAncestryMode,
+      branchedFromBranch: entry.branchedFromBranch,
+      dependsOnSessionBranch: entry.dependsOnSessionBranch,
+      dependsOnSessionPrUrl: entry.dependsOnSessionPrUrl,
+      nextSessionPrUrl: entry.nextSessionPrUrl,
     }))).toEqual([
-      { epicNumber: 205, status: 'success', sessionBranch: 'session/epic-205', sessionPrUrl: 'https://github.com/owner/repo/pull/205' },
-      { epicNumber: 166, status: 'success', sessionBranch: 'session/epic-166', sessionPrUrl: 'https://github.com/owner/repo/pull/166' },
-      { epicNumber: 214, status: 'success', sessionBranch: 'session/epic-214', sessionPrUrl: 'https://github.com/owner/repo/pull/214' },
+      {
+        epicNumber: 205,
+        status: 'success',
+        sessionBranch: 'session/epic-205',
+        sessionPrUrl: 'https://github.com/owner/repo/pull/205',
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+        nextSessionPrUrl: 'https://github.com/owner/repo/pull/166',
+      },
+      {
+        epicNumber: 166,
+        status: 'success',
+        sessionBranch: 'session/epic-166',
+        sessionPrUrl: 'https://github.com/owner/repo/pull/166',
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'session/epic-205',
+        dependsOnSessionBranch: 'session/epic-205',
+        dependsOnSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+        nextSessionPrUrl: 'https://github.com/owner/repo/pull/214',
+      },
+      {
+        epicNumber: 214,
+        status: 'success',
+        sessionBranch: 'session/epic-214',
+        sessionPrUrl: 'https://github.com/owner/repo/pull/214',
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'session/epic-166',
+        dependsOnSessionBranch: 'session/epic-166',
+        dependsOnSessionPrUrl: 'https://github.com/owner/repo/pull/166',
+        nextSessionPrUrl: null,
+      },
     ]);
+    expect(mockFinalizeSession.mock.calls.map((call) => (call[0] as any).queue?.queueIndex)).toEqual([1, 2, 3]);
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('--epics can run independent queue branches without ancestry dependencies', async () => {
+    mockLoadConfig.mockImplementation((overrides: any = {}) => makeConfig({
+      skipPostSessionReview: true,
+      autoMerge: false,
+      ...overrides,
+    }) as any);
+
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305 First child', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
+      [305, { number: 305, title: 'First child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [266, { number: 266, title: 'Second child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+    ]);
+    const childByEpic = new Map([[205, 305], [166, 266]]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+    mockGetEpicSubIssues.mockImplementation((_repo: string, epicNum: number) => [{
+      number: childByEpic.get(epicNum) ?? 0,
+      checked: true,
+      lineIndex: 0,
+    }]);
+    mockCreateSession.mockImplementation((_config: any, options: any = {}) => ({
+      name: `session/epic-${options.epicNum}`,
+      branch: `session/epic-${options.epicNum}`,
+      resultsDir: `/tmp/sessions/epic-${options.epicNum}`,
+      logsDir: `/tmp/sessions/epic-${options.epicNum}/logs`,
+      results: [],
+      epic: options.epicNum,
+      queue: options.queue,
+    }));
+    mockProcessIssue.mockImplementation(async (issueNum: number, title: string) => ({
+      issueNum,
+      title,
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    }));
+    mockFinalizeSession.mockImplementation(async (session: any) => `https://github.com/owner/repo/pull/${session.epic}`);
+
+    await runCommand({ epics: '205,166', queueBranchMode: 'independent' });
+
+    const queueContexts = mockCreateSession.mock.calls.map((call) => (call[1] as any)?.queue);
+    expect(queueContexts).toEqual([
+      expect.objectContaining({
+        queueIndex: 1,
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        previousSessionBranch: null,
+      }),
+      expect.objectContaining({
+        queueIndex: 2,
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+        previousSessionBranch: 'session/epic-205',
+        previousSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+      }),
+    ]);
+
+    const manifest = JSON.parse(String(mockWriteFileSync.mock.calls.at(-1)?.[1]));
+    expect(manifest.branchAncestryMode).toBe('independent');
+    expect(manifest.epics.map((entry: any) => ({
+      epicNumber: entry.epicNumber,
+      branchAncestryMode: entry.branchAncestryMode,
+      branchedFromBranch: entry.branchedFromBranch,
+      dependsOnSessionBranch: entry.dependsOnSessionBranch,
+      dependsOnSessionPrUrl: entry.dependsOnSessionPrUrl,
+    }))).toEqual([
+      {
+        epicNumber: 205,
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+      },
+      {
+        epicNumber: 166,
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+      },
+    ]);
+    expect(mockFinalizeSession.mock.calls.map((call) => (call[0] as any).queue?.branchAncestryMode)).toEqual(['independent', 'independent']);
     expect(mockExit).not.toHaveBeenCalled();
   });
 

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -1,4 +1,4 @@
-import { formatEpicPickerMeta, formatMilestonePickerMeta, runCommand } from '../../src/commands/run';
+import { formatEpicPickerMeta, formatMilestonePickerMeta, runCommand, runSingleEpicExecution } from '../../src/commands/run';
 
 jest.mock('../../src/lib/shell', () => ({
   exec: jest.fn(),
@@ -37,11 +37,21 @@ jest.mock('../../src/lib/github', () => ({
 jest.mock('../../src/lib/pipeline', () => ({
   processIssue: jest.fn(),
   processBatch: jest.fn(),
+  readGateResult: jest.fn(() => ({ passed: true, summary: '', findings: [] })),
+  formatGateFindings: jest.fn(() => ''),
 }));
 
 jest.mock('../../src/lib/session', () => ({
   createSession: jest.fn(),
   finalizeSession: jest.fn(),
+}));
+
+jest.mock('../../src/lib/verify-epic', () => ({
+  verifyEpic: jest.fn().mockResolvedValue({
+    verdict: 'pass',
+    comment: 'Epic verified',
+    parsed: { verdict: 'pass', summary: 'Epic verified', findings: [] },
+  }),
 }));
 
 jest.mock('../../src/lib/worktree', () => ({
@@ -75,11 +85,14 @@ jest.mock('../../src/commands/sync', () => ({
 jest.mock('node:fs', () => ({
   existsSync: jest.fn().mockReturnValue(false),
   readFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  renameSync: jest.fn(),
+  unlinkSync: jest.fn(),
 }));
 
 import { exec } from '../../src/lib/shell';
 import { loadConfig } from '../../src/lib/config';
-import { pollIssues, listEpics, getIssueWithComments, updateEpicChecklist } from '../../src/lib/github';
+import { pollIssues, listEpics, getEpicSubIssues, getIssueWithComments, updateEpicChecklist } from '../../src/lib/github';
 import { processIssue, processBatch } from '../../src/lib/pipeline';
 import { createSession, finalizeSession } from '../../src/lib/session';
 import { repairSessionLearningArtifacts, repairSessionSummaryArtifact } from '../../src/lib/learning';
@@ -88,6 +101,7 @@ const mockExec = exec as jest.MockedFunction<typeof exec>;
 const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
 const mockPollIssues = pollIssues as jest.MockedFunction<typeof pollIssues>;
 const mockListEpics = listEpics as jest.MockedFunction<typeof listEpics>;
+const mockGetEpicSubIssues = getEpicSubIssues as jest.MockedFunction<typeof getEpicSubIssues>;
 const mockGetIssueWithComments = getIssueWithComments as jest.MockedFunction<typeof getIssueWithComments>;
 const mockUpdateEpicChecklist = updateEpicChecklist as jest.MockedFunction<typeof updateEpicChecklist>;
 const mockProcessIssue = processIssue as jest.MockedFunction<typeof processIssue>;
@@ -166,6 +180,7 @@ beforeEach(() => {
   mockFinalizeSession.mockResolvedValue(null);
   mockPollIssues.mockReturnValue([]);
   mockListEpics.mockReturnValue([]);
+  mockGetEpicSubIssues.mockReturnValue([]);
   mockGetIssueWithComments.mockReturnValue(null);
   mockProcessBatch.mockResolvedValue([]);
 });
@@ -197,6 +212,122 @@ describe('runCommand', () => {
 
     expect(formatEpicPickerMeta(epic)).toBe('1/2 done · milestone Sprint 1');
     expect(formatMilestonePickerMeta(milestone, [epic])).toBe('3 open, 2/5 done · due 2026-06-01 · 1 scheduled epic');
+  });
+
+  test('runSingleEpicExecution returns structured success with session branch and PR URL', async () => {
+    const config = makeConfig({
+      autoMerge: true,
+      skipPostSessionReview: true,
+    }) as any;
+
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => {
+      if (issueNum === 195) {
+        return { number: 195, title: 'Parent Epic', body: '- [ ] #201 Build child', labels: ['epic'] };
+      }
+      if (issueNum === 201) {
+        return { number: 201, title: 'Build child', body: 'Child body', labels: ['ready'] };
+      }
+      return null;
+    });
+    mockGetEpicSubIssues.mockReturnValue([{ number: 201, checked: true, lineIndex: 0 }]);
+    mockProcessIssue.mockResolvedValue({
+      issueNum: 201,
+      title: 'Build child',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    });
+    mockFinalizeSession.mockResolvedValue('https://github.com/owner/repo/pull/500');
+
+    const result = await runSingleEpicExecution({ config, epicNumber: 195 });
+
+    expect(result).toEqual(expect.objectContaining({
+      epicNumber: 195,
+      sessionName: 'session/20260330-143000',
+      sessionBranch: 'session/20260330-143000',
+      sessionPrUrl: 'https://github.com/owner/repo/pull/500',
+      status: 'success',
+      failures: [],
+      verificationClosedEpic: true,
+    }));
+    expect(mockUpdateEpicChecklist).toHaveBeenCalledWith('owner/repo', 195, 201, true);
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('runSingleEpicExecution returns invalid epic number failure without exiting', async () => {
+    const result = await runSingleEpicExecution({
+      config: makeConfig() as any,
+      epicNumber: 0,
+    });
+
+    expect(result.status).toBe('failure');
+    expect(result.failures).toEqual([
+      expect.objectContaining({ code: 'invalid-epic-number', exitCode: 1 }),
+    ]);
+    expect(mockGetIssueWithComments).not.toHaveBeenCalled();
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('runSingleEpicExecution returns missing epic label failure without exiting', async () => {
+    const result = await runSingleEpicExecution({
+      config: makeConfig() as any,
+      epicNumber: 195,
+      epicIssue: { number: 195, title: 'Tracker', body: '- [ ] #201', labels: ['ready'] },
+    });
+
+    expect(result.status).toBe('failure');
+    expect(result.failures).toEqual([
+      expect.objectContaining({ code: 'missing-epic-label', issueNum: 195, exitCode: 1 }),
+    ]);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('runSingleEpicExecution reports no eligible child issues without exiting', async () => {
+    const config = makeConfig({ skipPostSessionReview: true }) as any;
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => {
+      if (issueNum === 195) {
+        return { number: 195, title: 'Parent Epic', body: '- [ ] #201 Blocked child', labels: ['epic'] };
+      }
+      if (issueNum === 201) {
+        return { number: 201, title: 'Blocked child', body: 'Child body', labels: ['blocked'] };
+      }
+      return null;
+    });
+
+    const result = await runSingleEpicExecution({ config, epicNumber: 195 });
+
+    expect(result.status).toBe('failure');
+    expect(result.sessionBranch).toBe('session/20260330-143000');
+    expect(result.failures).toEqual([
+      expect.objectContaining({ code: 'no-eligible-child-issues', issueNum: 195 }),
+    ]);
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('--verify-only bypasses normal session creation and issue processing', async () => {
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => {
+      if (issueNum === 195) {
+        return { number: 195, title: 'Parent Epic', body: '- [x] #201 Build child', labels: ['epic'] };
+      }
+      if (issueNum === 201) {
+        return { number: 201, title: 'Build child', body: 'Child body', labels: ['ready'] };
+      }
+      return null;
+    });
+    mockGetEpicSubIssues.mockReturnValue([{ number: 201, checked: true, lineIndex: 0 }]);
+
+    await runCommand({ verifyOnly: 195 });
+
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+    expect(mockFinalizeSession).not.toHaveBeenCalled();
+    expect(mockGetEpicSubIssues).toHaveBeenCalledWith('owner/repo', 195);
   });
 
   test('processes all matching issues and exits', async () => {

--- a/tests/docs/epic-first-workflow.test.ts
+++ b/tests/docs/epic-first-workflow.test.ts
@@ -33,6 +33,7 @@ describe('epic-first workflow docs and help text', () => {
     expect(cli).toContain('Analyze open issues, clean up backlog noise, and propose/apply epic groups');
     expect(cli).toContain('Display cleanup findings and epic proposals without making changes');
     expect(cli).toContain('Schedule parent epics and standalone issues into milestones using AI analysis');
+    expect(cli).toContain('Recommend the next ordered epic run queue without making changes');
     expect(cli).toContain('Display proposed epic/standalone milestone assignments without making changes');
   });
 });

--- a/tests/docs/epic-first-workflow.test.ts
+++ b/tests/docs/epic-first-workflow.test.ts
@@ -14,6 +14,8 @@ describe('epic-first workflow docs and help text', () => {
     expect(readme).toContain('`alpha-loop roadmap` schedules parent epic issues into milestones');
     expect(readme).toContain('`alpha-loop run --epic <N>` ships the epic\'s child issues in checklist order');
     expect(readme).toContain('Agents working on each child issue receive the parent epic goal, acceptance criteria, and sibling checklist as context');
+    expect(readme).toContain('`alpha-loop roadmap --queue` recommends the next ordered epic queue');
+    expect(readme).toContain('`alpha-loop run --epics <A,B,C>` runs several parent epics back-to-back');
   });
 
   it('docs/epics.md explains milestone scheduling and parent context for child agents', () => {
@@ -27,6 +29,27 @@ describe('epic-first workflow docs and help text', () => {
     expect(epicsDoc).toContain('the parent goal/body summary, parent acceptance criteria, and the full ordered sibling checklist');
   });
 
+  it('documents multi-epic queue behavior and inspection workflow', () => {
+    const readme = read('README.md');
+    const epicsDoc = read('docs/epics.md');
+
+    expect(readme).toContain('`alpha-loop run --epics <ids>`');
+    expect(readme).toContain('`alpha-loop roadmap --queue`');
+    expect(readme).toContain('`alpha-loop history queue-<timestamp>`');
+    expect(readme).toContain('`.alpha-loop/sessions/queue-<timestamp>/queue.json`');
+
+    expect(epicsDoc).toContain('## Multi-Epic Queues');
+    expect(epicsDoc).toContain('Use one epic when the work has one integrated goal');
+    expect(epicsDoc).toContain('Use a multi-epic queue when you want a long unattended run');
+    expect(epicsDoc).toContain('alpha-loop roadmap --queue');
+    expect(epicsDoc).toContain('alpha-loop run --epics 205,166,214');
+    expect(epicsDoc).toContain('Queue execution is fail-stop by default');
+    expect(epicsDoc).toContain('`stacked`');
+    expect(epicsDoc).toContain('`independent`');
+    expect(epicsDoc).toContain('rebase the next stacked session branch onto the base branch');
+    expect(epicsDoc).toContain('alpha-loop history queue-<timestamp>');
+  });
+
   it('CLI descriptions mention epic grouping and epic-aware roadmap scheduling', () => {
     const cli = read('src/cli.ts');
 
@@ -35,5 +58,8 @@ describe('epic-first workflow docs and help text', () => {
     expect(cli).toContain('Schedule parent epics and standalone issues into milestones using AI analysis');
     expect(cli).toContain('Recommend the next ordered epic run queue without making changes');
     expect(cli).toContain('Display proposed epic/standalone milestone assignments without making changes');
+    expect(cli).toContain('Process multiple epics in order (comma-separated issue numbers)');
+    expect(cli).toContain('Branch mode for --epics: stacked or independent');
+    expect(cli).toContain('View session and queue history');
   });
 });

--- a/tests/lib/epic-queue.test.ts
+++ b/tests/lib/epic-queue.test.ts
@@ -1,0 +1,142 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createEpicQueueManifest,
+  createEpicQueueValidationFailureManifest,
+  findDuplicateEpicIds,
+  parseEpicQueue,
+  validateEpicQueue,
+  writeQueueManifest,
+} from '../../src/lib/epic-queue';
+import type { Issue } from '../../src/lib/github';
+
+function issue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    number: 1,
+    title: 'Epic',
+    body: '- [ ] #2',
+    labels: ['epic'],
+    state: 'OPEN',
+    ...overrides,
+  };
+}
+
+describe('epic queue helpers', () => {
+  test('parseEpicQueue preserves comma-separated order', () => {
+    expect(parseEpicQueue('205,166,214')).toEqual([205, 166, 214]);
+    expect(parseEpicQueue(' 205, 166 ,214 ')).toEqual([205, 166, 214]);
+  });
+
+  test('parseEpicQueue rejects empty and invalid tokens', () => {
+    expect(() => parseEpicQueue('')).toThrow('--epics requires');
+    expect(() => parseEpicQueue('205,,214')).toThrow('position 2');
+    expect(() => parseEpicQueue('205,abc')).toThrow('position 2');
+    expect(() => parseEpicQueue('0,214')).toThrow('position 1');
+  });
+
+  test('findDuplicateEpicIds reports each duplicate once in repeat order', () => {
+    expect(findDuplicateEpicIds([205, 166, 205, 214, 166, 166])).toEqual([205, 166]);
+  });
+
+  test('validateEpicQueue returns ordered valid entries and skips completed epics', () => {
+    const issues = new Map<number, Issue>([
+      [205, issue({ number: 205, title: 'First' })],
+      [166, issue({ number: 166, title: 'Done', state: 'CLOSED', stateReason: 'COMPLETED' })],
+      [214, issue({ number: 214, title: 'Third' })],
+    ]);
+
+    const result = validateEpicQueue('owner/repo', [205, 166, 214], (_repo, issueNum) => issues.get(issueNum) ?? null);
+
+    expect(result.errors).toEqual([]);
+    expect(result.entries.map((entry) => [entry.epicNumber, entry.status])).toEqual([
+      [205, 'pending'],
+      [166, 'already-complete'],
+      [214, 'pending'],
+    ]);
+  });
+
+  test('validateEpicQueue rejects duplicates, missing issues, non-epics, and closed incomplete epics', () => {
+    const issues = new Map<number, Issue>([
+      [166, issue({ number: 166, labels: ['ready'] })],
+      [214, issue({ number: 214, state: 'CLOSED', stateReason: 'NOT_PLANNED' })],
+    ]);
+
+    const result = validateEpicQueue('owner/repo', [205, 205, 166, 214, 999], (_repo, issueNum) => issues.get(issueNum) ?? null);
+
+    expect(result.entries).toEqual([]);
+    expect(result.errors.map((error) => error.code)).toEqual([
+      'duplicate-epic',
+      'missing-epic-label',
+      'closed-incomplete-epic',
+      'epic-not-found',
+    ]);
+  });
+
+  test('validateEpicQueue can keep non-epic issues for dry-run preview warnings', () => {
+    const issues = new Map<number, Issue>([
+      [214, issue({ number: 214, title: 'Missing label', labels: ['ready'] })],
+    ]);
+
+    const result = validateEpicQueue(
+      'owner/repo',
+      [214],
+      (_repo, issueNum) => issues.get(issueNum) ?? null,
+      { allowMissingEpicLabel: true },
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.entries).toEqual([
+      expect.objectContaining({
+        epicNumber: 214,
+        status: 'pending',
+        validationWarning: expect.stringContaining('not labeled'),
+      }),
+    ]);
+  });
+
+  test('writeQueueManifest writes queue.json under the queue session directory', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'alpha-loop-queue-'));
+    try {
+      const manifest = createEpicQueueManifest([
+        {
+          epicNumber: 205,
+          title: 'First',
+          issue: issue({ number: 205, title: 'First' }),
+          status: 'pending',
+        },
+      ], new Date('2026-05-21T10:11:12.000Z'));
+
+      const manifestPath = writeQueueManifest(projectDir, manifest);
+
+      expect(manifestPath).toBe(join(projectDir, '.alpha-loop', 'sessions', 'queue-20260521T101112Z', 'queue.json'));
+      expect(JSON.parse(readFileSync(manifestPath, 'utf-8'))).toEqual(manifest);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test('createEpicQueueValidationFailureManifest preserves requested IDs for failed attempts', () => {
+    const manifest = createEpicQueueValidationFailureManifest(
+      [205, 205, 166, 214],
+      [
+        { code: 'duplicate-epic', epicNumber: 205, message: 'Epic #205 appears more than once' },
+        { code: 'missing-epic-label', epicNumber: 166, message: 'Issue #166 is not labeled epic' },
+      ],
+      new Date('2026-05-21T10:11:12.000Z'),
+    );
+
+    expect(manifest).toEqual(expect.objectContaining({
+      queueId: 'queue-20260521T101112Z',
+      epicIds: [205, 205, 166, 214],
+      status: 'stopped',
+      stopReason: 'queue-validation-failed',
+    }));
+    expect(manifest.epics.map((entry) => [entry.epicNumber, entry.status])).toEqual([
+      [205, 'failure'],
+      [205, 'failure'],
+      [166, 'failure'],
+      [214, 'pending'],
+    ]);
+  });
+});

--- a/tests/lib/github.test.ts
+++ b/tests/lib/github.test.ts
@@ -511,7 +511,7 @@ describe('epic issue helpers', () => {
       checked: false,
     });
     expect(mockExec).toHaveBeenCalledWith(
-      'gh issue view 7 --repo "owner/repo" --json number,title,body,labels,comments',
+      'gh issue view 7 --repo "owner/repo" --json number,title,body,labels,comments,state,stateReason',
     );
   });
 
@@ -567,7 +567,7 @@ describe('epic issue helpers', () => {
 
     expect(body).toBe('## Ordered Work\n\n- [ ] #1');
     expect(mockExec).toHaveBeenCalledWith(
-      'gh issue view 99 --repo "owner/repo" --json number,title,body,labels,comments',
+      'gh issue view 99 --repo "owner/repo" --json number,title,body,labels,comments,state,stateReason',
     );
   });
 

--- a/tests/lib/github.test.ts
+++ b/tests/lib/github.test.ts
@@ -463,8 +463,24 @@ describe('epic issue helpers', () => {
       totalChildCount: 2,
       openChildCount: 1,
       children: [
-        { issueNum: 3, title: 'Set up database schema', bodySummary: 'Create tables for roadmap data.', checked: true },
-        { issueNum: 7, title: 'Create API endpoints', bodySummary: 'REST API for scheduling.', checked: false },
+        {
+          issueNum: 3,
+          title: 'Set up database schema',
+          bodySummary: 'Create tables for roadmap data.',
+          checked: true,
+          labels: [],
+          state: 'OPEN',
+          milestone: null,
+        },
+        {
+          issueNum: 7,
+          title: 'Create API endpoints',
+          bodySummary: 'REST API for scheduling.',
+          checked: false,
+          labels: [],
+          state: 'OPEN',
+          milestone: null,
+        },
       ],
     }]);
     expect(mockExec).toHaveBeenCalledWith(
@@ -509,9 +525,12 @@ describe('epic issue helpers', () => {
       title: 'Create API endpoints',
       bodySummary: 'REST API for scheduling.',
       checked: false,
+      labels: [],
+      state: 'OPEN',
+      milestone: null,
     });
     expect(mockExec).toHaveBeenCalledWith(
-      'gh issue view 7 --repo "owner/repo" --json number,title,body,labels,comments,state,stateReason',
+      'gh issue view 7 --repo "owner/repo" --json number,title,body,labels,comments,state,stateReason,milestone',
     );
   });
 
@@ -567,7 +586,7 @@ describe('epic issue helpers', () => {
 
     expect(body).toBe('## Ordered Work\n\n- [ ] #1');
     expect(mockExec).toHaveBeenCalledWith(
-      'gh issue view 99 --repo "owner/repo" --json number,title,body,labels,comments,state,stateReason',
+      'gh issue view 99 --repo "owner/repo" --json number,title,body,labels,comments,state,stateReason,milestone',
     );
   });
 

--- a/tests/lib/planning.test.ts
+++ b/tests/lib/planning.test.ts
@@ -31,11 +31,13 @@ import {
   formatIssueTable,
   formatTriageFindings,
   formatEpicGroupProposals,
+  formatEpicQueuePlan,
   formatRoadmapTable,
   normalizeMilestoneTitles,
   normalizePlanMilestones,
   normalizeRoadmapMilestones,
   normalizeRoadmapPlan,
+  planEpicQueue,
   readSeedFiles,
   buildPlanningContext,
   savePlanDraft,
@@ -45,6 +47,7 @@ import {
   type ProposedEpicGroup,
   type PlanDraft,
 } from '../../src/lib/planning';
+import type { Issue, Milestone, RoadmapEpicContext } from '../../src/lib/github';
 import { getVisionContext } from '../../src/lib/vision';
 import { getProjectContext } from '../../src/lib/context';
 import { pollIssues } from '../../src/lib/github';
@@ -685,5 +688,176 @@ describe('formatRoadmapTable', () => {
     expect(output.indexOf('#195  Epic: Scheduling')).toBeLessThan(output.indexOf('#15  User dashboard'));
     expect(output).toContain('[EXISTS]');
     expect(output).toContain('[NEW]');
+  });
+});
+
+// ── epic queue planning ─────────────────────────────────────────────────────
+
+const milestone = (title: string, number: number): Milestone => ({
+  number,
+  title,
+  description: '',
+  openIssues: 0,
+  closedIssues: 0,
+  dueOn: null,
+  state: 'open',
+});
+
+const openIssue = (number: number, labels: string[] = ['ready']): Issue => ({
+  number,
+  title: `Issue ${number}`,
+  body: '',
+  labels,
+  state: 'OPEN',
+});
+
+const epicContext = (overrides: Partial<RoadmapEpicContext> = {}): RoadmapEpicContext => ({
+  issueNum: 100,
+  title: 'Epic: Queue item',
+  bodySummary: 'Ship queue work.',
+  currentMilestone: '001 - Core',
+  completedChildCount: 0,
+  totalChildCount: 1,
+  openChildCount: 1,
+  children: [
+    {
+      issueNum: 10,
+      title: 'Ready child',
+      bodySummary: 'Implement `src/lib/queue.ts`.',
+      checked: false,
+      labels: ['ready'],
+      state: 'OPEN',
+      milestone: '001 - Core',
+    },
+  ],
+  ...overrides,
+});
+
+describe('planEpicQueue', () => {
+  it('handles no open epics', () => {
+    const plan = planEpicQueue([], { labelReady: 'ready', openIssues: [] });
+
+    expect(plan.orderedEpics).toEqual([]);
+    expect(plan.blockedEpics).toEqual([]);
+    expect(plan.command).toBeNull();
+    expect(formatEpicQueuePlan(plan)).toContain('No open epics found');
+  });
+
+  it('recommends a single ready epic and emits the run command', () => {
+    const plan = planEpicQueue([epicContext({ issueNum: 101 })], {
+      labelReady: 'ready',
+      openIssues: [openIssue(101, ['epic']), openIssue(10)],
+    });
+
+    expect(plan.orderedEpics.map((epic) => epic.issueNum)).toEqual([101]);
+    expect(plan.blockedEpics).toEqual([]);
+    expect(plan.command).toBe('alpha-loop run --epics 101');
+    expect(plan.orderedEpics[0].rationale.join('\n')).toContain('Child readiness: 1 ready');
+  });
+
+  it('orders multiple independent epics by milestone order and reports file overlap risk', () => {
+    const epics = [
+      epicContext({
+        issueNum: 205,
+        title: 'Epic: Later',
+        currentMilestone: '002 - UI',
+        children: [{
+          issueNum: 20,
+          title: 'Later child',
+          bodySummary: 'Update `src/lib/shared.ts`.',
+          checked: false,
+          labels: ['ready'],
+          state: 'OPEN',
+          milestone: '002 - UI',
+        }],
+      }),
+      epicContext({
+        issueNum: 166,
+        title: 'Epic: Earlier',
+        currentMilestone: '001 - Core',
+        children: [{
+          issueNum: 16,
+          title: 'Earlier child',
+          bodySummary: 'Update `src/lib/shared.ts`.',
+          checked: false,
+          labels: ['ready'],
+          state: 'OPEN',
+          milestone: '001 - Core',
+        }],
+      }),
+    ];
+
+    const plan = planEpicQueue(epics, {
+      labelReady: 'ready',
+      milestones: [milestone('001 - Core', 1), milestone('002 - UI', 2)],
+      openIssues: [openIssue(205, ['epic']), openIssue(166, ['epic']), openIssue(20), openIssue(16)],
+    });
+
+    expect(plan.orderedEpics.map((epic) => epic.issueNum)).toEqual([166, 205]);
+    expect(plan.command).toBe('alpha-loop run --epics 166,205');
+    expect(plan.orderedEpics[0].risks.join('\n')).toContain('Likely file overlap with #205');
+    expect(plan.orderedEpics[1].risks.join('\n')).toContain('Likely file overlap with #166');
+  });
+
+  it('orders explicit dependencies before dependents', () => {
+    const plan = planEpicQueue([
+      epicContext({ issueNum: 214, title: 'Epic: Dependent', bodySummary: 'Requires #205 first.' }),
+      epicContext({ issueNum: 205, title: 'Epic: Foundation', bodySummary: 'Foundation work.' }),
+    ], {
+      labelReady: 'ready',
+      openIssues: [openIssue(214, ['epic']), openIssue(205, ['epic']), openIssue(10)],
+    });
+
+    expect(plan.orderedEpics.map((epic) => epic.issueNum)).toEqual([205, 214]);
+    expect(plan.orderedEpics.find((epic) => epic.issueNum === 214)?.queueDependencies).toEqual([205]);
+    expect(plan.command).toBe('alpha-loop run --epics 205,214');
+  });
+
+  it('blocks epics with not-ready children or open dependencies outside the queue', () => {
+    const notReady = epicContext({
+      issueNum: 300,
+      title: 'Epic: Needs child readiness',
+      children: [{
+        issueNum: 30,
+        title: 'Missing ready label',
+        bodySummary: 'Needs grooming.',
+        checked: false,
+        labels: ['triage'],
+        state: 'OPEN',
+        milestone: '001 - Core',
+      }],
+    });
+    const externalDependency = epicContext({
+      issueNum: 301,
+      title: 'Epic: Needs outside dependency',
+      bodySummary: 'Depends on #999 before this can run.',
+    });
+
+    const plan = planEpicQueue([notReady, externalDependency], {
+      labelReady: 'ready',
+      openIssues: [openIssue(300, ['epic']), openIssue(301, ['epic']), openIssue(30, ['triage']), openIssue(999)],
+    });
+
+    expect(plan.orderedEpics).toEqual([]);
+    expect(plan.command).toBeNull();
+    expect(plan.blockedEpics.map((epic) => epic.issueNum).sort()).toEqual([300, 301]);
+    expect(plan.blockedEpics.find((epic) => epic.issueNum === 300)?.blockers.join('\n')).toContain("Missing 'ready' label");
+    expect(plan.blockedEpics.find((epic) => epic.issueNum === 301)?.blockers.join('\n')).toContain('Open dependency #999 is outside');
+  });
+
+  it('filters queue planning to a requested milestone', () => {
+    const plan = planEpicQueue([
+      epicContext({ issueNum: 400, currentMilestone: '001 - Core' }),
+      epicContext({ issueNum: 401, currentMilestone: '002 - Later' }),
+    ], {
+      labelReady: 'ready',
+      milestone: '002 - Later',
+      openIssues: [openIssue(400, ['epic']), openIssue(401, ['epic']), openIssue(10)],
+    });
+
+    expect(plan.milestoneFilter).toBe('002 - Later');
+    expect(plan.consideredEpicCount).toBe(1);
+    expect(plan.orderedEpics.map((epic) => epic.issueNum)).toEqual([401]);
+    expect(formatEpicQueuePlan(plan)).toContain('Scope: milestone "002 - Later"');
   });
 });

--- a/tests/lib/session.test.ts
+++ b/tests/lib/session.test.ts
@@ -1,5 +1,6 @@
 import { createSession, saveResult, getPreviousResult, finalizeSession } from '../../src/lib/session';
 import type { PipelineResult } from '../../src/lib/pipeline';
+import type { BranchAncestryMode, QueueSessionContext } from '../../src/lib/epic-queue';
 
 jest.mock('../../src/lib/shell', () => ({
   exec: jest.fn(),
@@ -101,6 +102,37 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
   };
 }
 
+function makeQueueContext(overrides: Partial<QueueSessionContext> = {}): QueueSessionContext {
+  const mode: BranchAncestryMode = overrides.branchAncestryMode ?? 'stacked';
+  const previousSessionBranch = overrides.previousSessionBranch ?? 'session/epic-205-first';
+  const dependsOnSessionBranch = overrides.dependsOnSessionBranch
+    ?? (mode === 'stacked' ? previousSessionBranch : null);
+
+  return {
+    queueId: 'queue-20260521T101112Z',
+    queueIndex: 2,
+    queueTotal: 3,
+    currentEpic: { number: 166, title: 'Second Epic' },
+    previousEpic: {
+      number: 205,
+      title: 'First Epic',
+      sessionBranch: 'session/epic-205-first',
+      sessionPrUrl: 'https://github.com/owner/repo/pull/205',
+    },
+    nextEpic: { number: 214, title: 'Third Epic' },
+    previousSessionBranch,
+    previousSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+    branchAncestryMode: mode,
+    branchedFromBranch: mode === 'stacked' ? 'session/epic-205-first' : 'master',
+    dependsOnSessionBranch,
+    dependsOnSessionPrUrl: mode === 'stacked' ? 'https://github.com/owner/repo/pull/205' : null,
+    rebaseOntoBranch: mode === 'stacked' ? 'master' : null,
+    dependencyWarnings: ['Epic #166 declares a dependency on queued epic #205.'],
+    overlapWarnings: ['Epics #166 and #214 both mention src/lib/session.ts.'],
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockExec.mockReturnValue({ stdout: '', stderr: '', exitCode: 0 });
@@ -193,6 +225,59 @@ describe('createSession', () => {
         title: 'Epic #165: Hybrid Routing',
       }),
     );
+  });
+
+  test('creates stacked queue session branch from the previous session branch and annotates draft PR body', () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('rev-parse --verify')) return { stdout: '', stderr: '', exitCode: 1 };
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/166');
+
+    createSession(makeConfig({ autoMerge: true }), {
+      epicNum: 166,
+      epicTitle: 'Second Epic',
+      queue: makeQueueContext(),
+    });
+
+    expect(mockExec).toHaveBeenCalledWith(
+      'git checkout -b "session/epic-166-second-epic" "origin/session/epic-205-first"',
+      expect.any(Object),
+    );
+    const body = mockCreatePR.mock.calls[0][0].body;
+    expect(body).toContain('## Execution Queue');
+    expect(body).toContain('**Position:** 2 of 3');
+    expect(body).toContain('**Previous queued epic:** #205 - First Epic ([session PR](https://github.com/owner/repo/pull/205))');
+    expect(body).toContain('Merge [the previous session PR](https://github.com/owner/repo/pull/205) first; after it lands on master, rebase `session/epic-166-second-epic` onto `master` before final review/merge.');
+  });
+
+  test('creates independent queue session branch from base branch and explains no ancestry dependency in draft PR body', () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('rev-parse --verify')) return { stdout: '', stderr: '', exitCode: 1 };
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/166');
+
+    createSession(makeConfig({ autoMerge: true }), {
+      epicNum: 166,
+      epicTitle: 'Second Epic',
+      queue: makeQueueContext({
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+        rebaseOntoBranch: null,
+      }),
+    });
+
+    expect(mockExec).toHaveBeenCalledWith(
+      'git checkout -b "session/epic-166-second-epic" "origin/master"',
+      expect.any(Object),
+    );
+    const body = mockCreatePR.mock.calls[0][0].body;
+    expect(body).toContain('**Branch ancestry:** independent');
+    expect(body).toContain('**Depends on:** None - no branch ancestry dependency was created.');
+    expect(body).toContain('No branch ancestry dependency was created; this branch starts from `master`.');
   });
 });
 
@@ -313,6 +398,91 @@ describe('finalizeSession', () => {
       title: expect.stringContaining('Session:'),
       body: expect.stringContaining('#1: First issue'),
     }));
+    expect(mockCreatePR).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.not.stringContaining('## Execution Queue'),
+    }));
+  });
+
+  test('adds merge order and queue risk notes to final stacked queue session PR body', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('diff --cached --quiet')) {
+        return { stdout: '', stderr: '', exitCode: 1 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/166');
+
+    const config = makeConfig({ autoMerge: true });
+    const session = createSession(makeConfig(), {
+      epicNum: 166,
+      epicTitle: 'Second Epic',
+      queue: makeQueueContext(),
+    });
+    session.results.push({
+      issueNum: 266,
+      title: 'Second child',
+      status: 'success',
+      prUrl: 'https://github.com/owner/repo/pull/266',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 120,
+      filesChanged: 4,
+    });
+
+    await finalizeSession(session, config);
+
+    const body = mockCreatePR.mock.calls[0][0].body;
+    expect(body).toContain('## Execution Queue');
+    expect(body).toContain('**Queue:** queue-20260521T101112Z');
+    expect(body).toContain('**Parent epic:** #166 - Second Epic');
+    expect(body).toContain('**Next queued epic:** #214 - Third Epic');
+    expect(body).toContain('Merge [the previous session PR](https://github.com/owner/repo/pull/205) first; after it lands on master, rebase `session/epic-166-second-epic` onto `master` before final review/merge.');
+    expect(body).toContain('Dependency: Epic #166 declares a dependency on queued epic #205.');
+    expect(body).toContain('File overlap: Epics #166 and #214 both mention src/lib/session.ts.');
+    expect(body).toContain('Closes #266');
+  });
+
+  test('adds independent branch guidance to final queue session PR body', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('diff --cached --quiet')) {
+        return { stdout: '', stderr: '', exitCode: 1 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/166');
+
+    const config = makeConfig({ autoMerge: true });
+    const session = createSession(makeConfig(), {
+      epicNum: 166,
+      epicTitle: 'Second Epic',
+      queue: makeQueueContext({
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+        rebaseOntoBranch: null,
+      }),
+    });
+    session.results.push({
+      issueNum: 266,
+      title: 'Second child',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 120,
+      filesChanged: 4,
+    });
+
+    await finalizeSession(session, config);
+
+    const body = mockCreatePR.mock.calls[0][0].body;
+    expect(body).toContain('**Branch ancestry:** independent');
+    expect(body).toContain('Review this PR in queue order, but it can merge independently once ready.');
+    expect(body).toContain('No branch ancestry dependency was created; this branch starts from `master`.');
   });
 
   test('puts failed issues in collapsed details section', async () => {


### PR DESCRIPTION
## Session Summary

**Epic:** #217 - Epic: Multi-epic execution queues and PR coordination
**Branch:** session/epic-217-epic-multi-epic-execution-queues-and-pr-coordination
**Issues completed:** 5 (5 succeeded, 0 failed)
**Completed:** 2026-05-21T23:28:26Z

### Issues
- #212: feat: extract reusable epic execution runner for queued workflows - SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-loop/pull/219))
- #213: feat: run explicit multi-epic queues with separate session PRs - SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-loop/pull/220))
- #214: feat: add stacked session branches and PR dependency notes for epic queues - SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-loop/pull/221))
- #215: feat: plan recommended epic run queues from roadmap context - SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-loop/pull/222))
- #216: docs: document and test multi-epic execution queues - SUCCESS ([PR](https://github.com/bradtaylorsf/alpha-loop/pull/223))

Closes #212
Closes #213
Closes #214
Closes #215
Closes #216

### Verification

- `pnpm test` - PASS (69 suites, 1216 tests)
- `pnpm build` - PASS
- `pnpm dev -- run --epics 217 --dry-run` - PASS
- `pnpm dev -- run --epic 217 --dry-run` - PASS
- `pnpm dev -- roadmap --queue --dry-run` - PASS
- Built CLI help confirms `run --epics`, `--queue-branch-mode`, `roadmap --queue`, and queue-aware history text.

### Review

**Status:** PASS

Manual recovery review found and fixed:
- Queue history/docs sync gaps for `alpha-loop history queue-<timestamp>` and generated queue manifests.
- Jest local verification could discover generated `.worktrees`; `jest.config.cjs` now ignores `.worktrees/`.
- `alpha-loop resume` crashed while updating the session PR under ESM because it used `require`; this is now fixed in `src/commands/resume.ts`.

---
This PR collects all changes from this session for final review before merging to master.

Automated by alpha-loop
