### PR TITLE
feat: feat: run explicit multi-epic queues with separate session PRs (closes #213)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ alpha-loop run           # Run the loop continuously
 alpha-loop run --once    # Process one issue and exit
 alpha-loop run --dry-run # Dry run (preview, no changes)
 alpha-loop run --epic <N>        # Process an epic (sub-issues in checklist order, auto-verify on completion)
+alpha-loop run --epics <ids>     # Process multiple epics in order, one session PR per epic
 alpha-loop run --verify-only <N> # Run just the epic verification pass
 alpha-loop scan          # Generate/refresh project context
 alpha-loop plan          # Generate project scope (milestones + issues) from seed inputs

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ For planned feature work, use epics as the unit you schedule and ship:
 1. `alpha-loop triage` reviews open issues, proposes cleanup, and groups related ready issues into parent epics with ordered child checklists.
 2. `alpha-loop roadmap` schedules parent epic issues into milestones, while still scheduling standalone issues that are not part of an epic.
 3. `alpha-loop run --epic <N>` ships the epic's child issues in checklist order. Agents working on each child issue receive the parent epic goal, acceptance criteria, and sibling checklist as context.
-4. `alpha-loop run --verify-only <N>` re-runs the epic verification pass when you need to re-check shipped child issues against the parent acceptance criteria.
+4. `alpha-loop run --epics <A,B,C>` runs several parent epics back-to-back in that exact order, with a separate session branch and PR for each epic.
+5. `alpha-loop run --verify-only <N>` re-runs the epic verification pass when you need to re-check shipped child issues against the parent acceptance criteria.
 
 Milestones answer "when should this epic ship?" The epic checklist answers "what child issues ship, and in what order?"
 
@@ -269,6 +270,7 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop run` | Fetch matching issues, process them all, then exit |
 | `alpha-loop run --dry-run` | Preview without making changes |
 | `alpha-loop run --epic <N>` | Process an epic — its sub-issues in checklist order, auto-verify on completion (see [docs/epics.md](docs/epics.md)) |
+| `alpha-loop run --epics <ids>` | Process an ordered comma-separated queue of epics, one session branch and PR per epic |
 | `alpha-loop run --verify-only <N>` | Run just the epic verification pass — evaluates merged PRs against acceptance criteria |
 | `alpha-loop scan` | Generate/refresh project context and instructions file |
 | `alpha-loop vision` | **(deprecated)** Use `alpha-loop plan` instead |
@@ -329,6 +331,7 @@ Options:
   --batch             Batch mode: process multiple issues per agent call (faster, fewer tokens)
   --batch-size <n>    Issues per batch (default: 5)
   --epic <n>          Process a specific epic by issue number (skips the picker)
+  --epics <ids>       Process multiple epics in order (comma-separated)
   --skip-epic         Skip epic discovery, use flat/milestone flow
   --verify-only <n>   Run only the verification pass on an existing epic
 ```
@@ -594,6 +597,14 @@ alpha-loop run --epic 165
 ```
 
 `alpha-loop run --milestone "v1.0"` checks for open epics assigned to that milestone before fetching flat issues. One scheduled epic is processed automatically, multiple scheduled epics require `--epic <N>`, and no scheduled epics falls back to ready non-epic issues in that milestone. `--epic` always wins over `--milestone`; `--skip-epic` disables epic discovery and preserves the flat milestone flow.
+
+To run several epics unattended while keeping review scope separate, pass an explicit queue:
+
+```bash
+alpha-loop run --epics 205,166,214
+```
+
+The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `--dry-run` prints the validated queue without mutating GitHub or git state.
 
 Sub-issues are processed in checklist order (not issue-number order). Each sub-issue PR gets `Part of #165` appended, and the epic body's checkboxes auto-flip from `- [ ]` to `- [x]` as PRs merge. When every sub-issue has shipped, the loop runs a verification pass against each sub-issue's acceptance criteria — on `pass` the epic is auto-closed, on `partial` or `fail` it stays open with a `needs-human-input` label and a structured comment explaining the gaps.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ program
   .option('--fix', 'Auto-fix validation issues (reorder deps, comment on incomplete issues)')
   .option('--verbose', 'Stream live agent output to terminal')
   .option('--epic <n>', 'Process a specific epic by issue number (skips the picker)', parseInt)
+  .option('--epics <ids>', 'Process multiple epics in order (comma-separated issue numbers)')
   .option('--skip-epic', 'Skip epic discovery, use flat/milestone flow')
   .option('--verify-only <n>', 'Run only the verification pass on an existing epic', parseInt)
   .action(async (options) => {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -32,6 +32,15 @@ import { buildSessionReviewPrompt, type EpicPromptContext } from '../lib/prompts
 import { writeTraceToSubdir } from '../lib/traces.js';
 import { readFileSync, existsSync, renameSync, unlinkSync } from 'node:fs';
 import { validateIssueQueue, printValidationReport, commentOnIncompleteIssues, type ValidationReport } from '../lib/validation.js';
+import {
+  createEpicQueueManifest,
+  createEpicQueueValidationFailureManifest,
+  parseEpicQueue,
+  validateEpicQueue,
+  writeQueueManifest,
+  type EpicQueueManifest,
+  type EpicQueueManifestFailure,
+} from '../lib/epic-queue.js';
 
 export type RunOptions = {
   dryRun?: boolean;
@@ -49,6 +58,8 @@ export type RunOptions = {
   fix?: boolean;
   /** Force a specific epic by number, skip picker. */
   epic?: number;
+  /** Process multiple epics in the provided comma-separated order. */
+  epics?: string;
   /** Skip the epic picker entirely, use flat/milestone flow. */
   skipEpic?: boolean;
   /** Run only the verification pass on an existing epic. */
@@ -64,6 +75,7 @@ export type EpicExecutionFailureCode =
   | 'issue-processing-error'
   | 'batch-processing-error'
   | 'pipeline-failure'
+  | 'transient-stop'
   | 'epic-verification-failed';
 
 export type EpicExecutionFailure = {
@@ -1003,9 +1015,12 @@ async function runIssueSession(
 
   for (const result of session.results) {
     if (result.status === 'failure') {
+      const transient = result.failureReason === 'transient';
       failures.push({
-        code: 'pipeline-failure',
-        message: `Issue #${result.issueNum} failed during processing`,
+        code: transient ? 'transient-stop' : 'pipeline-failure',
+        message: transient
+          ? `Issue #${result.issueNum} stopped due to a transient agent or rate-limit failure`
+          : `Issue #${result.issueNum} failed during processing`,
         issueNum: result.issueNum,
       });
     }
@@ -1287,6 +1302,147 @@ function buildConfigOverrides(options: RunOptions): Partial<Config> {
   return overrides;
 }
 
+function rejectIncompatibleEpicQueueOptions(options: RunOptions): boolean {
+  const incompatible: string[] = [];
+  if (options.epic !== undefined) incompatible.push('--epic');
+  if (options.verifyOnly !== undefined) incompatible.push('--verify-only');
+  if (options.milestone) incompatible.push('--milestone');
+  if (options.skipEpic) incompatible.push('--skip-epic');
+  if (options.mergeTo) incompatible.push('--merge-to');
+
+  if (incompatible.length === 0) return false;
+
+  log.error(`--epics cannot be combined with ${incompatible.join(', ')}`);
+  process.exit(1);
+  return true;
+}
+
+function printDryRunEpicQueue(entries: ReturnType<typeof validateEpicQueue>['entries']): void {
+  log.dry(`Validated epic queue (${entries.length} epic${entries.length === 1 ? '' : 's'}):`);
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index];
+    const suffix = entry.status === 'already-complete' ? ' (already complete; will skip)' : '';
+    log.dry(`  ${index + 1}. #${entry.epicNumber} ${entry.title}${suffix}`);
+  }
+}
+
+function toManifestFailures(failures: EpicExecutionFailure[]): EpicQueueManifestFailure[] {
+  return failures.map((failure) => ({
+    code: failure.code,
+    message: failure.message,
+    ...(failure.issueNum !== undefined ? { issueNum: failure.issueNum } : {}),
+    ...(failure.exitCode !== undefined ? { exitCode: failure.exitCode } : {}),
+  }));
+}
+
+function stopReasonForEpicResult(result: EpicExecutionResult): string {
+  const firstFailure = result.failures[0];
+  if (!firstFailure) return `Epic #${result.epicNumber} stopped without a reported failure`;
+
+  const reasonByCode: Partial<Record<EpicExecutionFailureCode, string>> = {
+    'checklist-update-failed': 'checklist-consistency-error',
+    'epic-verification-failed': 'epic-verification-failed',
+    'transient-stop': 'transient-agent-stop',
+  };
+  const reason = reasonByCode[firstFailure.code] ?? firstFailure.code;
+  return `Epic #${result.epicNumber} stopped: ${reason}`;
+}
+
+function writeQueueManifestUpdate(manifest: EpicQueueManifest): void {
+  const manifestPath = writeQueueManifest(process.cwd(), manifest);
+  log.info(`Queue manifest saved: ${manifestPath}`);
+}
+
+async function runEpicQueue(config: Config, options: RunOptions): Promise<void> {
+  if (rejectIncompatibleEpicQueueOptions(options)) return;
+
+  let epicNumbers: number[];
+  try {
+    epicNumbers = parseEpicQueue(options.epics ?? '');
+  } catch (err) {
+    log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+    return;
+  }
+
+  const validation = validateEpicQueue(config.repo, epicNumbers);
+  if (validation.errors.length > 0) {
+    for (const error of validation.errors) {
+      log.error(error.message);
+    }
+    if (!config.dryRun) {
+      writeQueueManifestUpdate(createEpicQueueValidationFailureManifest(epicNumbers, validation.errors));
+    }
+    process.exit(1);
+    return;
+  }
+
+  if (config.dryRun) {
+    printDryRunEpicQueue(validation.entries);
+    return;
+  }
+
+  const manifest = createEpicQueueManifest(validation.entries);
+  writeQueueManifestUpdate(manifest);
+
+  const queueConfig: Config = {
+    ...config,
+    autoMerge: true,
+    mergeTo: '',
+  };
+  const queueOptions: RunOptions = {
+    ...options,
+    autoMerge: true,
+    mergeTo: undefined,
+    epics: undefined,
+  };
+
+  for (const validatedEntry of validation.entries) {
+    const manifestEntry = manifest.epics.find((entry) => entry.epicNumber === validatedEntry.epicNumber);
+    if (!manifestEntry) continue;
+
+    if (manifestEntry.status === 'skipped') {
+      log.info(`Skipping epic #${validatedEntry.epicNumber}: ${manifestEntry.skipReason}`);
+      continue;
+    }
+
+    manifestEntry.status = 'running';
+    manifestEntry.startedAt = new Date().toISOString();
+    writeQueueManifestUpdate(manifest);
+
+    const result = await runSingleEpicExecution({
+      config: queueConfig,
+      epicNumber: validatedEntry.epicNumber,
+      epicIssue: validatedEntry.issue,
+      options: queueOptions,
+    });
+
+    manifestEntry.sessionName = result.sessionName;
+    manifestEntry.sessionBranch = result.sessionBranch;
+    manifestEntry.sessionPrUrl = result.sessionPrUrl;
+    manifestEntry.failures = toManifestFailures(result.failures);
+    manifestEntry.endedAt = new Date().toISOString();
+    manifestEntry.status = result.status === 'success' ? 'success' : 'failure';
+
+    if (result.status === 'failure') {
+      manifest.status = 'stopped';
+      manifest.stopReason = stopReasonForEpicResult(result);
+      manifest.endedAt = manifestEntry.endedAt;
+      writeQueueManifestUpdate(manifest);
+      log.error(manifest.stopReason);
+      process.exit(1);
+      return;
+    }
+
+    writeQueueManifestUpdate(manifest);
+  }
+
+  manifest.status = 'success';
+  manifest.endedAt = new Date().toISOString();
+  writeQueueManifestUpdate(manifest);
+  log.success(`Epic queue complete: ${manifest.epics.length} epic${manifest.epics.length === 1 ? '' : 's'}`);
+}
+
 /**
  * Run the main loop: poll issues, process them, finalize session.
  */
@@ -1296,6 +1452,11 @@ export async function runCommand(options: RunOptions): Promise<void> {
   if (!config.repo) {
     log.error('No repository configured. Run "alpha-loop init" or set repo in .alpha-loop.yaml');
     process.exit(1);
+    return;
+  }
+
+  if (options.epics !== undefined) {
+    await runEpicQueue(config, options);
     return;
   }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -64,6 +64,8 @@ export type RunOptions = {
   skipEpic?: boolean;
   /** Run only the verification pass on an existing epic. */
   verifyOnly?: number;
+  /** Internal queue mode: treat an unfinished epic as a queue-stopping failure. */
+  stopOnPartialEpic?: boolean;
 };
 
 export type EpicExecutionFailureCode =
@@ -76,7 +78,9 @@ export type EpicExecutionFailureCode =
   | 'batch-processing-error'
   | 'pipeline-failure'
   | 'transient-stop'
-  | 'epic-verification-failed';
+  | 'epic-verification-failed'
+  | 'epic-incomplete'
+  | 'epic-run-error';
 
 export type EpicExecutionFailure = {
   code: EpicExecutionFailureCode;
@@ -666,8 +670,10 @@ async function runIssueSession(
     process.exit(0);
   };
 
-  process.on('SIGINT', () => { void cleanup(); });
-  process.on('SIGTERM', () => { void cleanup(); });
+  const handleSigint = () => { void cleanup(); };
+  const handleSigterm = () => { void cleanup(); };
+  process.on('SIGINT', handleSigint);
+  process.on('SIGTERM', handleSigterm);
 
   // Sync agent assets to all configured harnesses before starting the loop
   const syncResult = syncAgentAssets(resolveHarnesses(config.harnesses, config.agent));
@@ -1004,7 +1010,16 @@ async function runIssueSession(
           });
         }
       } else {
-        log.info(`Epic #${activeEpic}: ${remaining.length} sub-issue(s) still open — verification deferred`);
+        const message = `Epic #${activeEpic}: ${remaining.length} sub-issue(s) still open — verification deferred`;
+        log.info(message);
+        const hasFailedIssueResult = session.results.some((result) => result.status === 'failure');
+        if (options.stopOnPartialEpic && !hasFailedIssueResult) {
+          failures.push({
+            code: 'epic-incomplete',
+            message,
+            issueNum: activeEpic,
+          });
+        }
       }
     } catch (err) {
       const message = `Epic completion check failed: ${err instanceof Error ? err.message : err}`;
@@ -1204,6 +1219,8 @@ async function runIssueSession(
 
   const successCount = session.results.filter((r) => r.status === 'success').length;
   log.info(`Session complete: ${successCount}/${session.results.length} issues succeeded`);
+  process.off('SIGINT', handleSigint);
+  process.off('SIGTERM', handleSigterm);
 
   return {
     session,
@@ -1321,7 +1338,11 @@ function printDryRunEpicQueue(entries: ReturnType<typeof validateEpicQueue>['ent
   log.dry(`Validated epic queue (${entries.length} epic${entries.length === 1 ? '' : 's'}):`);
   for (let index = 0; index < entries.length; index++) {
     const entry = entries[index];
-    const suffix = entry.status === 'already-complete' ? ' (already complete; will skip)' : '';
+    const suffixes = [
+      entry.status === 'already-complete' ? 'already complete; will skip' : '',
+      entry.validationWarning ? `warning: ${entry.validationWarning}` : '',
+    ].filter(Boolean);
+    const suffix = suffixes.length > 0 ? ` (${suffixes.join('; ')})` : '';
     log.dry(`  ${index + 1}. #${entry.epicNumber} ${entry.title}${suffix}`);
   }
 }
@@ -1342,6 +1363,7 @@ function stopReasonForEpicResult(result: EpicExecutionResult): string {
   const reasonByCode: Partial<Record<EpicExecutionFailureCode, string>> = {
     'checklist-update-failed': 'checklist-consistency-error',
     'epic-verification-failed': 'epic-verification-failed',
+    'epic-incomplete': 'epic-incomplete',
     'transient-stop': 'transient-agent-stop',
   };
   const reason = reasonByCode[firstFailure.code] ?? firstFailure.code;
@@ -1365,7 +1387,9 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     return;
   }
 
-  const validation = validateEpicQueue(config.repo, epicNumbers);
+  const validation = validateEpicQueue(config.repo, epicNumbers, undefined, {
+    allowMissingEpicLabel: config.dryRun,
+  });
   if (validation.errors.length > 0) {
     for (const error of validation.errors) {
       log.error(error.message);
@@ -1395,6 +1419,7 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     autoMerge: true,
     mergeTo: undefined,
     epics: undefined,
+    stopOnPartialEpic: true,
   };
 
   for (const validatedEntry of validation.entries) {
@@ -1410,12 +1435,22 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     manifestEntry.startedAt = new Date().toISOString();
     writeQueueManifestUpdate(manifest);
 
-    const result = await runSingleEpicExecution({
-      config: queueConfig,
-      epicNumber: validatedEntry.epicNumber,
-      epicIssue: validatedEntry.issue,
-      options: queueOptions,
-    });
+    const result = await (async (): Promise<EpicExecutionResult> => {
+      try {
+        return await runSingleEpicExecution({
+          config: queueConfig,
+          epicNumber: validatedEntry.epicNumber,
+          epicIssue: validatedEntry.issue,
+          options: queueOptions,
+        });
+      } catch (err) {
+        return buildEpicFailureResult(validatedEntry.epicNumber, {
+          code: 'epic-run-error',
+          message: `Epic #${validatedEntry.epicNumber} failed with an unhandled error: ${err instanceof Error ? err.message : err}`,
+          issueNum: validatedEntry.epicNumber,
+        });
+      }
+    })();
 
     manifestEntry.sessionName = result.sessionName;
     manifestEntry.sessionBranch = result.sessionBranch;

--- a/src/lib/epic-queue.ts
+++ b/src/lib/epic-queue.ts
@@ -22,11 +22,16 @@ export type ValidatedEpicQueueEntry = {
   issue: Issue;
   status: EpicQueueEntryStatus;
   skipReason?: string;
+  validationWarning?: string;
 };
 
 export type EpicQueueValidationResult = {
   entries: ValidatedEpicQueueEntry[];
   errors: EpicQueueValidationError[];
+};
+
+export type EpicQueueValidationOptions = {
+  allowMissingEpicLabel?: boolean;
 };
 
 export type EpicQueueManifestStatus = 'running' | 'success' | 'stopped';
@@ -126,6 +131,7 @@ export function validateEpicQueue(
   repo: string,
   epicNumbers: number[],
   fetchIssue: FetchIssue = getIssueWithComments,
+  options: EpicQueueValidationOptions = {},
 ): EpicQueueValidationResult {
   const entries: ValidatedEpicQueueEntry[] = [];
   const errors: EpicQueueValidationError[] = [];
@@ -153,7 +159,8 @@ export function validateEpicQueue(
       continue;
     }
 
-    if (!hasEpicLabel(issue)) {
+    const missingEpicLabel = !hasEpicLabel(issue);
+    if (missingEpicLabel && !options.allowMissingEpicLabel) {
       errors.push({
         code: 'missing-epic-label',
         epicNumber,
@@ -161,6 +168,10 @@ export function validateEpicQueue(
       });
       continue;
     }
+
+    const validationWarning = missingEpicLabel
+      ? `Issue #${epicNumber} is not labeled 'epic'; non-dry-run queue execution will reject it`
+      : undefined;
 
     if (isClosed(issue) && !isCompleted(issue)) {
       errors.push({
@@ -178,6 +189,7 @@ export function validateEpicQueue(
         issue,
         status: 'already-complete',
         skipReason: 'Epic is already closed as completed',
+        validationWarning,
       });
       continue;
     }
@@ -187,6 +199,7 @@ export function validateEpicQueue(
       title: issue.title,
       issue,
       status: 'pending',
+      validationWarning,
     });
   }
 

--- a/src/lib/epic-queue.ts
+++ b/src/lib/epic-queue.ts
@@ -1,0 +1,263 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getIssueWithComments, type Issue } from './github.js';
+
+export type EpicQueueValidationErrorCode =
+  | 'duplicate-epic'
+  | 'epic-not-found'
+  | 'missing-epic-label'
+  | 'closed-incomplete-epic';
+
+export type EpicQueueValidationError = {
+  code: EpicQueueValidationErrorCode;
+  epicNumber: number;
+  message: string;
+};
+
+export type EpicQueueEntryStatus = 'pending' | 'already-complete';
+
+export type ValidatedEpicQueueEntry = {
+  epicNumber: number;
+  title: string;
+  issue: Issue;
+  status: EpicQueueEntryStatus;
+  skipReason?: string;
+};
+
+export type EpicQueueValidationResult = {
+  entries: ValidatedEpicQueueEntry[];
+  errors: EpicQueueValidationError[];
+};
+
+export type EpicQueueManifestStatus = 'running' | 'success' | 'stopped';
+export type EpicQueueManifestEntryStatus = 'pending' | 'running' | 'success' | 'failure' | 'skipped';
+
+export type EpicQueueManifestFailure = {
+  code: string;
+  message: string;
+  issueNum?: number;
+  exitCode?: number;
+};
+
+export type EpicQueueManifestEntry = {
+  epicNumber: number;
+  title: string;
+  status: EpicQueueManifestEntryStatus;
+  sessionName: string | null;
+  sessionBranch: string | null;
+  sessionPrUrl: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  skipReason?: string;
+  failures: EpicQueueManifestFailure[];
+};
+
+export type EpicQueueManifest = {
+  queueId: string;
+  epicIds: number[];
+  status: EpicQueueManifestStatus;
+  startedAt: string;
+  endedAt: string | null;
+  stopReason: string | null;
+  epics: EpicQueueManifestEntry[];
+};
+
+export type FetchIssue = (repo: string, issueNum: number) => Issue | null;
+
+function formatQueueTimestamp(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function normalizeIssueState(value: string | undefined): string {
+  return (value ?? 'OPEN').toLowerCase();
+}
+
+function normalizeIssueStateReason(value: string | null | undefined): string {
+  return (value ?? '').toLowerCase().replace(/_/g, '-');
+}
+
+function hasEpicLabel(issue: Issue): boolean {
+  return issue.labels.some((label) => label.toLowerCase() === 'epic');
+}
+
+function isClosed(issue: Issue): boolean {
+  return normalizeIssueState(issue.state) === 'closed';
+}
+
+function isCompleted(issue: Issue): boolean {
+  return isClosed(issue) && normalizeIssueStateReason(issue.stateReason) === 'completed';
+}
+
+export function parseEpicQueue(raw: string): number[] {
+  if (raw.trim() === '') {
+    throw new Error('--epics requires a comma-separated list of epic issue numbers');
+  }
+
+  return raw.split(',').map((part, index) => {
+    const token = part.trim();
+    if (!/^[1-9]\d*$/.test(token)) {
+      throw new Error(`Invalid epic issue number at position ${index + 1}: ${token || '(empty)'}`);
+    }
+    const epicNumber = Number(token);
+    if (!Number.isSafeInteger(epicNumber)) {
+      throw new Error(`Epic issue number at position ${index + 1} is too large: ${token}`);
+    }
+    return epicNumber;
+  });
+}
+
+export function findDuplicateEpicIds(epicNumbers: number[]): number[] {
+  const seen = new Set<number>();
+  const duplicates: number[] = [];
+  const duplicateSet = new Set<number>();
+
+  for (const epicNumber of epicNumbers) {
+    if (seen.has(epicNumber) && !duplicateSet.has(epicNumber)) {
+      duplicates.push(epicNumber);
+      duplicateSet.add(epicNumber);
+    }
+    seen.add(epicNumber);
+  }
+
+  return duplicates;
+}
+
+export function validateEpicQueue(
+  repo: string,
+  epicNumbers: number[],
+  fetchIssue: FetchIssue = getIssueWithComments,
+): EpicQueueValidationResult {
+  const entries: ValidatedEpicQueueEntry[] = [];
+  const errors: EpicQueueValidationError[] = [];
+  const duplicateIds = findDuplicateEpicIds(epicNumbers);
+  const duplicateSet = new Set(duplicateIds);
+
+  for (const epicNumber of duplicateIds) {
+    errors.push({
+      code: 'duplicate-epic',
+      epicNumber,
+      message: `Epic #${epicNumber} appears more than once in the queue`,
+    });
+  }
+
+  for (const epicNumber of epicNumbers) {
+    if (duplicateSet.has(epicNumber)) continue;
+
+    const issue = fetchIssue(repo, epicNumber);
+    if (!issue) {
+      errors.push({
+        code: 'epic-not-found',
+        epicNumber,
+        message: `Could not fetch queued epic #${epicNumber}`,
+      });
+      continue;
+    }
+
+    if (!hasEpicLabel(issue)) {
+      errors.push({
+        code: 'missing-epic-label',
+        epicNumber,
+        message: `Issue #${epicNumber} is not labeled 'epic'`,
+      });
+      continue;
+    }
+
+    if (isClosed(issue) && !isCompleted(issue)) {
+      errors.push({
+        code: 'closed-incomplete-epic',
+        epicNumber,
+        message: `Issue #${epicNumber} is closed but not marked completed`,
+      });
+      continue;
+    }
+
+    if (isCompleted(issue)) {
+      entries.push({
+        epicNumber,
+        title: issue.title,
+        issue,
+        status: 'already-complete',
+        skipReason: 'Epic is already closed as completed',
+      });
+      continue;
+    }
+
+    entries.push({
+      epicNumber,
+      title: issue.title,
+      issue,
+      status: 'pending',
+    });
+  }
+
+  return { entries, errors };
+}
+
+export function createEpicQueueManifest(
+  entries: ValidatedEpicQueueEntry[],
+  now: Date = new Date(),
+): EpicQueueManifest {
+  const startedAt = now.toISOString();
+
+  return {
+    queueId: `queue-${formatQueueTimestamp(now)}`,
+    epicIds: entries.map((entry) => entry.epicNumber),
+    status: 'running',
+    startedAt,
+    endedAt: null,
+    stopReason: null,
+    epics: entries.map((entry) => ({
+      epicNumber: entry.epicNumber,
+      title: entry.title,
+      status: entry.status === 'already-complete' ? 'skipped' : 'pending',
+      sessionName: null,
+      sessionBranch: null,
+      sessionPrUrl: null,
+      startedAt: null,
+      endedAt: entry.status === 'already-complete' ? startedAt : null,
+      skipReason: entry.skipReason,
+      failures: [],
+    })),
+  };
+}
+
+export function createEpicQueueValidationFailureManifest(
+  epicNumbers: number[],
+  errors: EpicQueueValidationError[],
+  now: Date = new Date(),
+): EpicQueueManifest {
+  const startedAt = now.toISOString();
+
+  return {
+    queueId: `queue-${formatQueueTimestamp(now)}`,
+    epicIds: epicNumbers,
+    status: 'stopped',
+    startedAt,
+    endedAt: startedAt,
+    stopReason: 'queue-validation-failed',
+    epics: epicNumbers.map((epicNumber) => {
+      const failures = errors
+        .filter((error) => error.epicNumber === epicNumber)
+        .map((error) => ({ code: error.code, message: error.message }));
+      return {
+        epicNumber,
+        title: '',
+        status: failures.length > 0 ? 'failure' : 'pending',
+        sessionName: null,
+        sessionBranch: null,
+        sessionPrUrl: null,
+        startedAt: null,
+        endedAt: failures.length > 0 ? startedAt : null,
+        failures,
+      };
+    }),
+  };
+}
+
+export function writeQueueManifest(projectDir: string, manifest: EpicQueueManifest): string {
+  const queueDir = join(projectDir, '.alpha-loop', 'sessions', manifest.queueId);
+  mkdirSync(queueDir, { recursive: true });
+  const manifestPath = join(queueDir, 'queue.json');
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+  return manifestPath;
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -30,6 +30,8 @@ export type Issue = {
   labels: string[];
   comments?: Comment[];
   milestone?: string | null;
+  state?: string;
+  stateReason?: string | null;
 };
 
 export type RoadmapEpicChildContext = {
@@ -815,7 +817,7 @@ export function getIssueComments(repo: string, issueNum: number): Comment[] {
  */
 export function getIssueWithComments(repo: string, issueNum: number): Issue | null {
   const result = ghExec(
-    `gh issue view ${issueNum} --repo "${repo}" --json number,title,body,labels,comments`,
+    `gh issue view ${issueNum} --repo "${repo}" --json number,title,body,labels,comments,state,stateReason`,
   );
   if (result.exitCode !== 0) {
     log.warn(`Failed to fetch issue #${issueNum}: ${result.stderr}`);
@@ -828,8 +830,10 @@ export function getIssueWithComments(repo: string, issueNum: number): Issue | nu
       body: string;
       labels: Array<{ name: string }>;
       comments: Array<{ author: { login: string }; body: string; createdAt: string }>;
+      state?: string;
+      stateReason?: string | null;
     };
-    return {
+    const issue: Issue = {
       number: data.number,
       title: data.title,
       body: data.body ?? '',
@@ -840,6 +844,9 @@ export function getIssueWithComments(repo: string, issueNum: number): Issue | nu
         createdAt: c.createdAt ?? '',
       })),
     };
+    if (data.state !== undefined) issue.state = data.state;
+    if (data.stateReason !== undefined) issue.stateReason = data.stateReason;
+    return issue;
   } catch {
     log.warn(`Failed to parse issue #${issueNum}`);
     return null;

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -19,6 +19,7 @@ jest.mock('../../src/lib/logger', () => ({
 jest.mock('../../src/lib/config', () => ({
   loadConfig: jest.fn(),
   assertSafeShellArg: jest.fn((value: string) => value),
+  resolveStepConfig: jest.fn((config: any) => ({ agent: config.agent, model: config.model })),
 }));
 
 jest.mock('../../src/lib/github', () => ({
@@ -77,6 +78,11 @@ jest.mock('../../src/lib/preflight', () => ({
   runPortCheck: jest.fn().mockReturnValue([]),
 }));
 
+jest.mock('../../src/lib/eval', () => ({
+  saveCapturedCase: jest.fn(),
+  detectFailureStep: jest.fn(() => 'implement'),
+}));
+
 jest.mock('../../src/commands/sync', () => ({
   syncAgentAssets: jest.fn().mockReturnValue({ synced: false, docSynced: false, skillsDirs: [] }),
   resolveHarnesses: jest.fn((harnesses: string[], _agent: string) => harnesses),
@@ -85,19 +91,23 @@ jest.mock('../../src/commands/sync', () => ({
 jest.mock('node:fs', () => ({
   existsSync: jest.fn().mockReturnValue(false),
   readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
   mkdirSync: jest.fn(),
   renameSync: jest.fn(),
   unlinkSync: jest.fn(),
 }));
 
 import { exec } from '../../src/lib/shell';
+import { log } from '../../src/lib/logger';
 import { loadConfig } from '../../src/lib/config';
 import { pollIssues, listEpics, getEpicSubIssues, getIssueWithComments, updateEpicChecklist } from '../../src/lib/github';
 import { processIssue, processBatch } from '../../src/lib/pipeline';
 import { createSession, finalizeSession } from '../../src/lib/session';
 import { repairSessionLearningArtifacts, repairSessionSummaryArtifact } from '../../src/lib/learning';
+import { writeFileSync } from 'node:fs';
 
 const mockExec = exec as jest.MockedFunction<typeof exec>;
+const mockLog = log as jest.Mocked<typeof log>;
 const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
 const mockPollIssues = pollIssues as jest.MockedFunction<typeof pollIssues>;
 const mockListEpics = listEpics as jest.MockedFunction<typeof listEpics>;
@@ -110,6 +120,7 @@ const mockCreateSession = createSession as jest.MockedFunction<typeof createSess
 const mockFinalizeSession = finalizeSession as jest.MockedFunction<typeof finalizeSession>;
 const mockRepairSessionLearningArtifacts = repairSessionLearningArtifacts as jest.MockedFunction<typeof repairSessionLearningArtifacts>;
 const mockRepairSessionSummaryArtifact = repairSessionSummaryArtifact as jest.MockedFunction<typeof repairSessionSummaryArtifact>;
+const mockWriteFileSync = writeFileSync as jest.MockedFunction<typeof writeFileSync>;
 
 function makeConfig(overrides: Record<string, unknown> = {}) {
   return {
@@ -308,6 +319,182 @@ describe('runCommand', () => {
     ]);
     expect(mockProcessIssue).not.toHaveBeenCalled();
     expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('--epics dry-run validates the full queue in order without creating sessions or manifests', async () => {
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266', labels: ['epic'], state: 'OPEN' }],
+      [214, { number: 214, title: 'Third Epic', body: '- [ ] #314', labels: ['epic'], state: 'OPEN' }],
+    ]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+
+    await runCommand({ epics: '205,166,214', dryRun: true });
+
+    expect(mockGetIssueWithComments.mock.calls.map((call) => call[1])).toEqual([205, 166, 214]);
+    expect(mockLog.dry).toHaveBeenCalledWith('Validated epic queue (3 epics):');
+    expect(mockLog.dry).toHaveBeenCalledWith('  1. #205 First Epic');
+    expect(mockLog.dry).toHaveBeenCalledWith('  2. #166 Second Epic');
+    expect(mockLog.dry).toHaveBeenCalledWith('  3. #214 Third Epic');
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+    expect(mockUpdateEpicChecklist).not.toHaveBeenCalled();
+    expect(mockFinalizeSession).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('--epics rejects incompatible targeting flags before processing', async () => {
+    await runCommand({ epics: '205,166', epic: 205, dryRun: true });
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockGetIssueWithComments).not.toHaveBeenCalled();
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  test('--epics rejects invalid queued issues before processing the first epic', async () => {
+    mockGetIssueWithComments.mockReturnValue({
+      number: 205,
+      title: 'Not an epic',
+      body: '- [ ] #305',
+      labels: ['ready'],
+      state: 'OPEN',
+    });
+
+    await runCommand({ epics: '205' });
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+  });
+
+  test('--epics processes each epic sequentially and writes a successful queue manifest', async () => {
+    mockLoadConfig.mockImplementation((overrides: any = {}) => makeConfig({
+      skipPostSessionReview: true,
+      autoMerge: false,
+      ...overrides,
+    }) as any);
+
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305 First child', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
+      [214, { number: 214, title: 'Third Epic', body: '- [ ] #314 Third child', labels: ['epic'], state: 'OPEN' }],
+      [305, { number: 305, title: 'First child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [266, { number: 266, title: 'Second child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [314, { number: 314, title: 'Third child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+    ]);
+    const childByEpic = new Map([[205, 305], [166, 266], [214, 314]]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+    mockGetEpicSubIssues.mockImplementation((_repo: string, epicNum: number) => [{
+      number: childByEpic.get(epicNum) ?? 0,
+      checked: true,
+      lineIndex: 0,
+    }]);
+    mockCreateSession.mockImplementation((_config: any, options: any = {}) => ({
+      name: `session/epic-${options.epicNum}`,
+      branch: `session/epic-${options.epicNum}`,
+      resultsDir: `/tmp/sessions/epic-${options.epicNum}`,
+      logsDir: `/tmp/sessions/epic-${options.epicNum}/logs`,
+      results: [],
+      epic: options.epicNum,
+    }));
+    mockProcessIssue.mockImplementation(async (issueNum: number, title: string) => ({
+      issueNum,
+      title,
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    }));
+    mockFinalizeSession.mockImplementation(async (session: any) => `https://github.com/owner/repo/pull/${session.epic}`);
+
+    await runCommand({ epics: '205,166,214' });
+
+    expect(mockCreateSession.mock.calls.map((call) => call[1]?.epicNum)).toEqual([205, 166, 214]);
+    expect(mockCreateSession.mock.calls.map((call) => call[0])).toEqual([
+      expect.objectContaining({ autoMerge: true, mergeTo: '' }),
+      expect.objectContaining({ autoMerge: true, mergeTo: '' }),
+      expect.objectContaining({ autoMerge: true, mergeTo: '' }),
+    ]);
+    expect(mockProcessIssue.mock.calls.map((call) => call[0])).toEqual([305, 266, 314]);
+    expect(mockFinalizeSession).toHaveBeenCalledTimes(3);
+
+    const manifest = JSON.parse(String(mockWriteFileSync.mock.calls.at(-1)?.[1]));
+    expect(manifest).toEqual(expect.objectContaining({
+      epicIds: [205, 166, 214],
+      status: 'success',
+      stopReason: null,
+    }));
+    expect(manifest.epics.map((entry: any) => ({
+      epicNumber: entry.epicNumber,
+      status: entry.status,
+      sessionBranch: entry.sessionBranch,
+      sessionPrUrl: entry.sessionPrUrl,
+    }))).toEqual([
+      { epicNumber: 205, status: 'success', sessionBranch: 'session/epic-205', sessionPrUrl: 'https://github.com/owner/repo/pull/205' },
+      { epicNumber: 166, status: 'success', sessionBranch: 'session/epic-166', sessionPrUrl: 'https://github.com/owner/repo/pull/166' },
+      { epicNumber: 214, status: 'success', sessionBranch: 'session/epic-214', sessionPrUrl: 'https://github.com/owner/repo/pull/214' },
+    ]);
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('--epics stops on the first failed epic and records the stop reason in the manifest', async () => {
+    mockLoadConfig.mockImplementation((overrides: any = {}) => makeConfig({
+      skipPostSessionReview: true,
+      autoCapture: false,
+      ...overrides,
+    }) as any);
+
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305 First child', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
+      [214, { number: 214, title: 'Third Epic', body: '- [ ] #314 Third child', labels: ['epic'], state: 'OPEN' }],
+      [305, { number: 305, title: 'First child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [266, { number: 266, title: 'Second child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [314, { number: 314, title: 'Third child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+    ]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+    mockGetEpicSubIssues.mockReturnValue([{ number: 305, checked: true, lineIndex: 0 }]);
+    mockCreateSession.mockImplementation((_config: any, options: any = {}) => ({
+      name: `session/epic-${options.epicNum}`,
+      branch: `session/epic-${options.epicNum}`,
+      resultsDir: `/tmp/sessions/epic-${options.epicNum}`,
+      logsDir: `/tmp/sessions/epic-${options.epicNum}/logs`,
+      results: [],
+      epic: options.epicNum,
+    }));
+    mockProcessIssue.mockImplementation(async (issueNum: number, title: string) => ({
+      issueNum,
+      title,
+      status: issueNum === 266 ? 'failure' : 'success',
+      testsPassing: issueNum !== 266,
+      verifyPassing: issueNum !== 266,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+      ...(issueNum === 266 ? { failureReason: 'transient' as const } : {}),
+    }));
+    mockFinalizeSession.mockImplementation(async (session: any) => `https://github.com/owner/repo/pull/${session.epic}`);
+
+    await runCommand({ epics: '205,166,214' });
+
+    expect(mockProcessIssue.mock.calls.map((call) => call[0])).toEqual([305, 266]);
+    expect(mockCreateSession.mock.calls.map((call) => call[1]?.epicNum)).toEqual([205, 166]);
+    expect(mockExit).toHaveBeenCalledWith(1);
+
+    const manifest = JSON.parse(String(mockWriteFileSync.mock.calls.at(-1)?.[1]));
+    expect(manifest.status).toBe('stopped');
+    expect(manifest.stopReason).toBe('Epic #166 stopped: transient-agent-stop');
+    expect(manifest.epics.map((entry: any) => [entry.epicNumber, entry.status])).toEqual([
+      [205, 'success'],
+      [166, 'failure'],
+      [214, 'pending'],
+    ]);
+    expect(manifest.epics[1].failures).toEqual([
+      expect.objectContaining({ code: 'transient-stop', issueNum: 266 }),
+    ]);
   });
 
   test('--verify-only bypasses normal session creation and issue processing', async () => {

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -344,6 +344,25 @@ describe('runCommand', () => {
     expect(mockExit).not.toHaveBeenCalled();
   });
 
+  test('--epics dry-run previews non-epic labels as warnings without mutating', async () => {
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305', labels: ['epic'], state: 'OPEN' }],
+      [214, { number: 214, title: 'Not Yet Labeled', body: '- [ ] #314', labels: ['ready'], state: 'OPEN' }],
+    ]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+
+    await runCommand({ epics: '205,214', dryRun: true });
+
+    expect(mockLog.dry).toHaveBeenCalledWith('  1. #205 First Epic');
+    expect(mockLog.dry).toHaveBeenCalledWith(expect.stringContaining('  2. #214 Not Yet Labeled (warning: Issue #214 is not labeled'));
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+    expect(mockUpdateEpicChecklist).not.toHaveBeenCalled();
+    expect(mockFinalizeSession).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
   test('--epics rejects incompatible targeting flags before processing', async () => {
     await runCommand({ epics: '205,166', epic: 205, dryRun: true });
 
@@ -494,6 +513,58 @@ describe('runCommand', () => {
     ]);
     expect(manifest.epics[1].failures).toEqual([
       expect.objectContaining({ code: 'transient-stop', issueNum: 266 }),
+    ]);
+  });
+
+  test('--epics stops when an epic remains incomplete after processing eligible children', async () => {
+    mockLoadConfig.mockImplementation((overrides: any = {}) => makeConfig({
+      skipPostSessionReview: true,
+      ...overrides,
+    }) as any);
+
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305 Ready child\n- [ ] #306 Blocked child', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
+      [305, { number: 305, title: 'Ready child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [306, { number: 306, title: 'Blocked child', body: 'Body', labels: ['blocked'], state: 'OPEN' }],
+      [266, { number: 266, title: 'Second child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+    ]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+    mockCreateSession.mockImplementation((_config: any, options: any = {}) => ({
+      name: `session/epic-${options.epicNum}`,
+      branch: `session/epic-${options.epicNum}`,
+      resultsDir: `/tmp/sessions/epic-${options.epicNum}`,
+      logsDir: `/tmp/sessions/epic-${options.epicNum}/logs`,
+      results: [],
+      epic: options.epicNum,
+    }));
+    mockProcessIssue.mockResolvedValue({
+      issueNum: 305,
+      title: 'Ready child',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    });
+    mockFinalizeSession.mockImplementation(async (session: any) => `https://github.com/owner/repo/pull/${session.epic}`);
+
+    await runCommand({ epics: '205,166' });
+
+    expect(mockProcessIssue.mock.calls.map((call) => call[0])).toEqual([305]);
+    expect(mockCreateSession.mock.calls.map((call) => call[1]?.epicNum)).toEqual([205]);
+    expect(mockExit).toHaveBeenCalledWith(1);
+
+    const manifest = JSON.parse(String(mockWriteFileSync.mock.calls.at(-1)?.[1]));
+    expect(manifest.status).toBe('stopped');
+    expect(manifest.stopReason).toBe('Epic #205 stopped: epic-incomplete');
+    expect(manifest.epics.map((entry: any) => [entry.epicNumber, entry.status])).toEqual([
+      [205, 'failure'],
+      [166, 'pending'],
+    ]);
+    expect(manifest.epics[0].failures).toEqual([
+      expect.objectContaining({ code: 'epic-incomplete', issueNum: 205 }),
     ]);
   });
 

--- a/tests/lib/epic-queue.test.ts
+++ b/tests/lib/epic-queue.test.ts
@@ -73,6 +73,28 @@ describe('epic queue helpers', () => {
     ]);
   });
 
+  test('validateEpicQueue can keep non-epic issues for dry-run preview warnings', () => {
+    const issues = new Map<number, Issue>([
+      [214, issue({ number: 214, title: 'Missing label', labels: ['ready'] })],
+    ]);
+
+    const result = validateEpicQueue(
+      'owner/repo',
+      [214],
+      (_repo, issueNum) => issues.get(issueNum) ?? null,
+      { allowMissingEpicLabel: true },
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.entries).toEqual([
+      expect.objectContaining({
+        epicNumber: 214,
+        status: 'pending',
+        validationWarning: expect.stringContaining('not labeled'),
+      }),
+    ]);
+  });
+
   test('writeQueueManifest writes queue.json under the queue session directory', () => {
     const projectDir = mkdtempSync(join(tmpdir(), 'alpha-loop-queue-'));
     try {

--- a/tests/lib/epic-queue.test.ts
+++ b/tests/lib/epic-queue.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createEpicQueueManifest,
+  createEpicQueueValidationFailureManifest,
+  findDuplicateEpicIds,
+  parseEpicQueue,
+  validateEpicQueue,
+  writeQueueManifest,
+} from '../../src/lib/epic-queue';
+import type { Issue } from '../../src/lib/github';
+
+function issue(overrides: Partial<Issue> = {}): Issue {
+  return {
+    number: 1,
+    title: 'Epic',
+    body: '- [ ] #2',
+    labels: ['epic'],
+    state: 'OPEN',
+    ...overrides,
+  };
+}
+
+describe('epic queue helpers', () => {
+  test('parseEpicQueue preserves comma-separated order', () => {
+    expect(parseEpicQueue('205,166,214')).toEqual([205, 166, 214]);
+    expect(parseEpicQueue(' 205, 166 ,214 ')).toEqual([205, 166, 214]);
+  });
+
+  test('parseEpicQueue rejects empty and invalid tokens', () => {
+    expect(() => parseEpicQueue('')).toThrow('--epics requires');
+    expect(() => parseEpicQueue('205,,214')).toThrow('position 2');
+    expect(() => parseEpicQueue('205,abc')).toThrow('position 2');
+    expect(() => parseEpicQueue('0,214')).toThrow('position 1');
+  });
+
+  test('findDuplicateEpicIds reports each duplicate once in repeat order', () => {
+    expect(findDuplicateEpicIds([205, 166, 205, 214, 166, 166])).toEqual([205, 166]);
+  });
+
+  test('validateEpicQueue returns ordered valid entries and skips completed epics', () => {
+    const issues = new Map<number, Issue>([
+      [205, issue({ number: 205, title: 'First' })],
+      [166, issue({ number: 166, title: 'Done', state: 'CLOSED', stateReason: 'COMPLETED' })],
+      [214, issue({ number: 214, title: 'Third' })],
+    ]);
+
+    const result = validateEpicQueue('owner/repo', [205, 166, 214], (_repo, issueNum) => issues.get(issueNum) ?? null);
+
+    expect(result.errors).toEqual([]);
+    expect(result.entries.map((entry) => [entry.epicNumber, entry.status])).toEqual([
+      [205, 'pending'],
+      [166, 'already-complete'],
+      [214, 'pending'],
+    ]);
+  });
+
+  test('validateEpicQueue rejects duplicates, missing issues, non-epics, and closed incomplete epics', () => {
+    const issues = new Map<number, Issue>([
+      [166, issue({ number: 166, labels: ['ready'] })],
+      [214, issue({ number: 214, state: 'CLOSED', stateReason: 'NOT_PLANNED' })],
+    ]);
+
+    const result = validateEpicQueue('owner/repo', [205, 205, 166, 214, 999], (_repo, issueNum) => issues.get(issueNum) ?? null);
+
+    expect(result.entries).toEqual([]);
+    expect(result.errors.map((error) => error.code)).toEqual([
+      'duplicate-epic',
+      'missing-epic-label',
+      'closed-incomplete-epic',
+      'epic-not-found',
+    ]);
+  });
+
+  test('writeQueueManifest writes queue.json under the queue session directory', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'alpha-loop-queue-'));
+    try {
+      const manifest = createEpicQueueManifest([
+        {
+          epicNumber: 205,
+          title: 'First',
+          issue: issue({ number: 205, title: 'First' }),
+          status: 'pending',
+        },
+      ], new Date('2026-05-21T10:11:12.000Z'));
+
+      const manifestPath = writeQueueManifest(projectDir, manifest);
+
+      expect(manifestPath).toBe(join(projectDir, '.alpha-loop', 'sessions', 'queue-20260521T101112Z', 'queue.json'));
+      expect(JSON.parse(readFileSync(manifestPath, 'utf-8'))).toEqual(manifest);
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test('createEpicQueueValidationFailureManifest preserves requested IDs for failed attempts', () => {
+    const manifest = createEpicQueueValidationFailureManifest(
+      [205, 205, 166, 214],
+      [
+        { code: 'duplicate-epic', epicNumber: 205, message: 'Epic #205 appears more than once' },
+        { code: 'missing-epic-label', epicNumber: 166, message: 'Issue #166 is not labeled epic' },
+      ],
+      new Date('2026-05-21T10:11:12.000Z'),
+    );
+
+    expect(manifest).toEqual(expect.objectContaining({
+      queueId: 'queue-20260521T101112Z',
+      epicIds: [205, 205, 166, 214],
+      status: 'stopped',
+      stopReason: 'queue-validation-failed',
+    }));
+    expect(manifest.epics.map((entry) => [entry.epicNumber, entry.status])).toEqual([
+      [205, 'failure'],
+      [205, 'failure'],
+      [166, 'failure'],
+      [214, 'pending'],
+    ]);
+  });
+});

--- a/tests/lib/github.test.ts
+++ b/tests/lib/github.test.ts
@@ -511,7 +511,7 @@ describe('epic issue helpers', () => {
       checked: false,
     });
     expect(mockExec).toHaveBeenCalledWith(
-      'gh issue view 7 --repo "owner/repo" --json number,title,body,labels,comments',
+      'gh issue view 7 --repo "owner/repo" --json number,title,body,labels,comments,state,stateReason',
     );
   });
 
@@ -567,7 +567,7 @@ describe('epic issue helpers', () => {
 
     expect(body).toBe('## Ordered Work\n\n- [ ] #1');
     expect(mockExec).toHaveBeenCalledWith(
-      'gh issue view 99 --repo "owner/repo" --json number,title,body,labels,comments',
+      'gh issue view 99 --repo "owner/repo" --json number,title,body,labels,comments,state,stateReason',
     );
   });
 


### PR DESCRIPTION
Closes #213
Part of #217

## Summary

Automated implementation of **feat: run explicit multi-epic queues with separate session PRs**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Review passed after fixing queue stop handling for incomplete epic runs.

- **CRITICAL** [FIXED] `src/commands/run.ts`: Queued epic execution could continue to the next epic after processing only the eligible child issues while leaving unchecked checklist items behind.
- **WARNING** [FIXED] `src/commands/run.ts`: Repeated queued epic sessions registered signal handlers without removing them after normal completion.
- **WARNING** [FIXED] `src/commands/run.ts`: Unhandled errors during one queued epic could leave the queue manifest stuck in running state instead of recording a stopped epic.

## Test Requirements

- Unit tests for queue parser and validation.
- Command tests with mocked GitHub/session operations proving epics execute sequentially.
- Manifest snapshot/assertion coverage for successful and stopped queues.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*