### PR TITLE
feat: feat: add stacked session branches and PR dependency notes for epic queues (closes #214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop run --dry-run` | Preview without making changes |
 | `alpha-loop run --epic <N>` | Process an epic — its sub-issues in checklist order, auto-verify on completion (see [docs/epics.md](docs/epics.md)) |
 | `alpha-loop run --epics <ids>` | Process an ordered comma-separated queue of epics, one session branch and PR per epic |
+| `alpha-loop run --epics <ids> --queue-branch-mode independent` | Run queued epics without stacking later session branches on earlier ones |
 | `alpha-loop run --verify-only <N>` | Run just the epic verification pass — evaluates merged PRs against acceptance criteria |
 | `alpha-loop scan` | Generate/refresh project context and instructions file |
 | `alpha-loop vision` | **(deprecated)** Use `alpha-loop plan` instead |
@@ -332,6 +333,7 @@ Options:
   --batch-size <n>    Issues per batch (default: 5)
   --epic <n>          Process a specific epic by issue number (skips the picker)
   --epics <ids>       Process multiple epics in order (comma-separated)
+  --queue-branch-mode <mode>  Branch mode for --epics: stacked or independent
   --skip-epic         Skip epic discovery, use flat/milestone flow
   --verify-only <n>   Run only the verification pass on an existing epic
 ```
@@ -604,7 +606,7 @@ To run several epics unattended while keeping review scope separate, pass an exp
 alpha-loop run --epics 205,166,214
 ```
 
-The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `--dry-run` prints the validated queue without mutating GitHub or git state.
+The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. By default, queue sessions use `stacked` ancestry: later epic session branches start from the previous successful session branch while their PRs still target the configured base branch. Use `--queue-branch-mode independent` for unrelated epics that should all branch from the base branch. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `--dry-run` prints the validated queue without mutating GitHub or git state.
 
 Sub-issues are processed in checklist order (not issue-number order). Each sub-issue PR gets `Part of #165` appended, and the epic body's checkboxes auto-flip from `- [ ]` to `- [x]` as PRs merge. When every sub-issue has shipped, the loop runs a verification pass against each sub-issue's acceptance criteria — on `pass` the epic is auto-closed, on `partial` or `fail` it stays open with a `needs-human-input` label and a structured comment explaining the gaps.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,7 @@ program
   .option('--verbose', 'Stream live agent output to terminal')
   .option('--epic <n>', 'Process a specific epic by issue number (skips the picker)', parseInt)
   .option('--epics <ids>', 'Process multiple epics in order (comma-separated issue numbers)')
+  .option('--queue-branch-mode <mode>', 'Branch mode for --epics: stacked or independent')
   .option('--skip-epic', 'Skip epic discovery, use flat/milestone flow')
   .option('--verify-only <n>', 'Run only the verification pass on an existing epic', parseInt)
   .action(async (options) => {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -31,15 +31,20 @@ import { spawnAgent } from '../lib/agent.js';
 import { buildSessionReviewPrompt, type EpicPromptContext } from '../lib/prompts.js';
 import { writeTraceToSubdir } from '../lib/traces.js';
 import { readFileSync, existsSync, renameSync, unlinkSync } from 'node:fs';
-import { validateIssueQueue, printValidationReport, commentOnIncompleteIssues, type ValidationReport } from '../lib/validation.js';
+import { validateIssueQueue, printValidationReport, commentOnIncompleteIssues, parseDependencies, type ValidationReport } from '../lib/validation.js';
 import {
   createEpicQueueManifest,
   createEpicQueueValidationFailureManifest,
   parseEpicQueue,
   validateEpicQueue,
   writeQueueManifest,
+  type BranchAncestryMode,
   type EpicQueueManifest,
+  type EpicQueueManifestEntry,
   type EpicQueueManifestFailure,
+  type QueueEpicLink,
+  type QueueSessionContext,
+  type ValidatedEpicQueueEntry,
 } from '../lib/epic-queue.js';
 
 export type RunOptions = {
@@ -60,6 +65,8 @@ export type RunOptions = {
   epic?: number;
   /** Process multiple epics in the provided comma-separated order. */
   epics?: string;
+  /** Branch ancestry mode for multi-epic queues. */
+  queueBranchMode?: BranchAncestryMode;
   /** Skip the epic picker entirely, use flat/milestone flow. */
   skipEpic?: boolean;
   /** Run only the verification pass on an existing epic. */
@@ -108,7 +115,7 @@ type EpicVerificationFlowResult = {
 };
 
 type SessionExecutionTarget =
-  | { type: 'epic'; epicNum: number; epicTitle?: string; epicIssue: Issue }
+  | { type: 'epic'; epicNum: number; epicTitle?: string; epicIssue: Issue; queue?: QueueSessionContext }
   | { type: 'flat'; activeMilestone: string };
 
 type SessionExecutionResult = {
@@ -611,6 +618,7 @@ async function runIssueSession(
   const activeEpic = target.type === 'epic' ? target.epicNum : undefined;
   const activeEpicTitle = target.type === 'epic' ? target.epicTitle : undefined;
   const activeEpicIssue = target.type === 'epic' ? target.epicIssue : undefined;
+  const queueContext = target.type === 'epic' ? target.queue : undefined;
   const activeMilestone = target.type === 'flat' ? target.activeMilestone : '';
   const failures: EpicExecutionFailure[] = [];
   let verificationClosedEpic = false;
@@ -626,6 +634,7 @@ async function runIssueSession(
     milestone: activeMilestone || undefined,
     epicNum: activeEpic,
     epicTitle: activeEpicTitle,
+    queue: queueContext,
   });
 
   // Print startup banner
@@ -1247,6 +1256,7 @@ export async function runSingleEpicExecution(args: {
   epicNumber: number;
   epicIssue?: Issue;
   options?: RunOptions;
+  queue?: QueueSessionContext;
 }): Promise<EpicExecutionResult> {
   const { config, epicNumber } = args;
   const options = args.options ?? {};
@@ -1283,6 +1293,7 @@ export async function runSingleEpicExecution(args: {
     epicNum: epic.number,
     epicTitle: epic.title,
     epicIssue: epic,
+    queue: args.queue,
   });
 
   return {
@@ -1347,6 +1358,12 @@ function printDryRunEpicQueue(entries: ReturnType<typeof validateEpicQueue>['ent
   }
 }
 
+function normalizeQueueBranchMode(value: BranchAncestryMode | undefined): BranchAncestryMode {
+  if (value === undefined) return 'stacked';
+  if (value === 'stacked' || value === 'independent') return value;
+  throw new Error(`Invalid queue branch mode: ${value}. Expected "stacked" or "independent".`);
+}
+
 function toManifestFailures(failures: EpicExecutionFailure[]): EpicQueueManifestFailure[] {
   return failures.map((failure) => ({
     code: failure.code,
@@ -1370,6 +1387,129 @@ function stopReasonForEpicResult(result: EpicExecutionResult): string {
   return `Epic #${result.epicNumber} stopped: ${reason}`;
 }
 
+type QueueRiskMap = Map<number, { dependencyWarnings: string[]; overlapWarnings: string[] }>;
+
+function queueEpicLink(entry: ValidatedEpicQueueEntry | EpicQueueManifestEntry | undefined): QueueEpicLink | null {
+  if (!entry) return null;
+  const link: QueueEpicLink = {
+    number: entry.epicNumber,
+    title: entry.title,
+  };
+  if ('sessionBranch' in entry) link.sessionBranch = entry.sessionBranch;
+  if ('sessionPrUrl' in entry) link.sessionPrUrl = entry.sessionPrUrl;
+  return link;
+}
+
+function addQueueDependencyNote(risks: QueueRiskMap, epicNumber: number, note: string): void {
+  const entry = risks.get(epicNumber);
+  if (!entry || entry.dependencyWarnings.includes(note)) return;
+  entry.dependencyWarnings.push(note);
+}
+
+function addQueueOverlapNote(risks: QueueRiskMap, epicNumber: number, note: string): void {
+  const entry = risks.get(epicNumber);
+  if (!entry || entry.overlapWarnings.includes(note)) return;
+  entry.overlapWarnings.push(note);
+}
+
+function buildQueueRiskMap(entries: ValidatedEpicQueueEntry[]): QueueRiskMap {
+  const risks: QueueRiskMap = new Map(entries.map((entry) => [
+    entry.epicNumber,
+    { dependencyWarnings: [], overlapWarnings: [] },
+  ]));
+  const queuedEpicNumbers = new Set(entries.map((entry) => entry.epicNumber));
+
+  for (const entry of entries) {
+    for (const dep of parseDependencies(entry.issue.body).filter((num) => queuedEpicNumbers.has(num))) {
+      addQueueDependencyNote(
+        risks,
+        entry.epicNumber,
+        `Epic #${entry.epicNumber} declares a dependency on queued epic #${dep}.`,
+      );
+      addQueueDependencyNote(
+        risks,
+        dep,
+        `Later queued epic #${entry.epicNumber} declares a dependency on this epic.`,
+      );
+    }
+  }
+
+  const report = validateIssueQueue(
+    entries.map((entry) => ({ number: entry.epicNumber, title: entry.title, body: entry.issue.body })),
+    0,
+  );
+  for (const warning of report.dependencyWarnings) {
+    const note = `Queue order warning: ${warning.reason}.`;
+    addQueueDependencyNote(risks, warning.issueNum, note);
+    addQueueDependencyNote(risks, warning.dependsOn, note);
+  }
+  for (const warning of report.overlapWarnings) {
+    const note = `Epics #${warning.issueA} and #${warning.issueB} both mention ${warning.sharedFiles.join(', ')}.`;
+    addQueueOverlapNote(risks, warning.issueA, note);
+    addQueueOverlapNote(risks, warning.issueB, note);
+  }
+
+  return risks;
+}
+
+function buildQueueSessionContext(args: {
+  manifest: EpicQueueManifest;
+  entries: ValidatedEpicQueueEntry[];
+  currentIndex: number;
+  branchAncestryMode: BranchAncestryMode;
+  baseBranch: string;
+  previousSessionBranch: string | null;
+  previousSessionPrUrl: string | null;
+  risks: QueueRiskMap;
+}): QueueSessionContext {
+  const currentEntry = args.entries[args.currentIndex];
+  const manifestEntry = args.manifest.epics.find((entry) => entry.epicNumber === currentEntry.epicNumber);
+  const previousManifestEntry = args.currentIndex > 0 ? args.manifest.epics[args.currentIndex - 1] : undefined;
+  const nextManifestEntry = args.currentIndex < args.manifest.epics.length - 1
+    ? args.manifest.epics[args.currentIndex + 1]
+    : undefined;
+  const dependsOnSessionBranch = args.branchAncestryMode === 'stacked' ? args.previousSessionBranch : null;
+  const dependsOnSessionPrUrl = dependsOnSessionBranch ? args.previousSessionPrUrl : null;
+  const risk = args.risks.get(currentEntry.epicNumber) ?? { dependencyWarnings: [], overlapWarnings: [] };
+
+  return {
+    queueId: args.manifest.queueId,
+    queueIndex: args.currentIndex + 1,
+    queueTotal: args.entries.length,
+    currentEpic: {
+      number: currentEntry.epicNumber,
+      title: currentEntry.title,
+      sessionBranch: manifestEntry?.sessionBranch ?? null,
+      sessionPrUrl: manifestEntry?.sessionPrUrl ?? null,
+    },
+    previousEpic: queueEpicLink(previousManifestEntry),
+    nextEpic: queueEpicLink(nextManifestEntry),
+    previousSessionBranch: args.previousSessionBranch,
+    previousSessionPrUrl: args.previousSessionPrUrl,
+    branchAncestryMode: args.branchAncestryMode,
+    branchedFromBranch: dependsOnSessionBranch ?? args.baseBranch,
+    dependsOnSessionBranch,
+    dependsOnSessionPrUrl,
+    rebaseOntoBranch: dependsOnSessionBranch ? args.baseBranch : null,
+    dependencyWarnings: risk.dependencyWarnings,
+    overlapWarnings: risk.overlapWarnings,
+  };
+}
+
+function applyQueueContextToManifestEntry(entry: EpicQueueManifestEntry, queue: QueueSessionContext): void {
+  entry.queueIndex = queue.queueIndex;
+  entry.queueTotal = queue.queueTotal;
+  entry.previousEpic = queue.previousEpic;
+  entry.nextEpic = queue.nextEpic;
+  entry.branchAncestryMode = queue.branchAncestryMode;
+  entry.branchedFromBranch = queue.branchedFromBranch;
+  entry.dependsOnSessionBranch = queue.dependsOnSessionBranch;
+  entry.dependsOnSessionPrUrl = queue.dependsOnSessionPrUrl;
+  entry.rebaseOntoBranch = queue.rebaseOntoBranch;
+  entry.dependencyWarnings = queue.dependencyWarnings;
+  entry.overlapWarnings = queue.overlapWarnings;
+}
+
 function writeQueueManifestUpdate(manifest: EpicQueueManifest): void {
   const manifestPath = writeQueueManifest(process.cwd(), manifest);
   log.info(`Queue manifest saved: ${manifestPath}`);
@@ -1387,6 +1527,15 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     return;
   }
 
+  let branchAncestryMode: BranchAncestryMode;
+  try {
+    branchAncestryMode = normalizeQueueBranchMode(options.queueBranchMode);
+  } catch (err) {
+    log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+    return;
+  }
+
   const validation = validateEpicQueue(config.repo, epicNumbers, undefined, {
     allowMissingEpicLabel: config.dryRun,
   });
@@ -1395,7 +1544,7 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
       log.error(error.message);
     }
     if (!config.dryRun) {
-      writeQueueManifestUpdate(createEpicQueueValidationFailureManifest(epicNumbers, validation.errors));
+      writeQueueManifestUpdate(createEpicQueueValidationFailureManifest(epicNumbers, validation.errors, new Date(), branchAncestryMode));
     }
     process.exit(1);
     return;
@@ -1406,7 +1555,8 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     return;
   }
 
-  const manifest = createEpicQueueManifest(validation.entries);
+  const manifest = createEpicQueueManifest(validation.entries, new Date(), branchAncestryMode);
+  const queueRisks = buildQueueRiskMap(validation.entries);
   writeQueueManifestUpdate(manifest);
 
   const queueConfig: Config = {
@@ -1422,7 +1572,12 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     stopOnPartialEpic: true,
   };
 
-  for (const validatedEntry of validation.entries) {
+  let previousSessionBranch: string | null = null;
+  let previousSessionPrUrl: string | null = null;
+  let previousSessionManifestEntry: EpicQueueManifestEntry | null = null;
+
+  for (let index = 0; index < validation.entries.length; index++) {
+    const validatedEntry = validation.entries[index];
     const manifestEntry = manifest.epics.find((entry) => entry.epicNumber === validatedEntry.epicNumber);
     if (!manifestEntry) continue;
 
@@ -1431,6 +1586,17 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
       continue;
     }
 
+    const queueContext = buildQueueSessionContext({
+      manifest,
+      entries: validation.entries,
+      currentIndex: index,
+      branchAncestryMode,
+      baseBranch: config.baseBranch,
+      previousSessionBranch,
+      previousSessionPrUrl,
+      risks: queueRisks,
+    });
+    applyQueueContextToManifestEntry(manifestEntry, queueContext);
     manifestEntry.status = 'running';
     manifestEntry.startedAt = new Date().toISOString();
     writeQueueManifestUpdate(manifest);
@@ -1442,6 +1608,7 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
           epicNumber: validatedEntry.epicNumber,
           epicIssue: validatedEntry.issue,
           options: queueOptions,
+          queue: queueContext,
         });
       } catch (err) {
         return buildEpicFailureResult(validatedEntry.epicNumber, {
@@ -1470,6 +1637,13 @@ async function runEpicQueue(config: Config, options: RunOptions): Promise<void> 
     }
 
     writeQueueManifestUpdate(manifest);
+    if (previousSessionManifestEntry) {
+      previousSessionManifestEntry.nextSessionBranch = result.sessionBranch;
+      previousSessionManifestEntry.nextSessionPrUrl = result.sessionPrUrl;
+    }
+    previousSessionBranch = result.sessionBranch;
+    previousSessionPrUrl = result.sessionPrUrl;
+    previousSessionManifestEntry = manifestEntry;
   }
 
   manifest.status = 'success';

--- a/src/lib/epic-queue.ts
+++ b/src/lib/epic-queue.ts
@@ -2,6 +2,33 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getIssueWithComments, type Issue } from './github.js';
 
+export type BranchAncestryMode = 'stacked' | 'independent';
+
+export type QueueEpicLink = {
+  number: number;
+  title: string;
+  sessionBranch?: string | null;
+  sessionPrUrl?: string | null;
+};
+
+export type QueueSessionContext = {
+  queueId: string;
+  queueIndex: number;
+  queueTotal: number;
+  currentEpic: QueueEpicLink;
+  previousEpic: QueueEpicLink | null;
+  nextEpic: QueueEpicLink | null;
+  previousSessionBranch: string | null;
+  previousSessionPrUrl: string | null;
+  branchAncestryMode: BranchAncestryMode;
+  branchedFromBranch: string;
+  dependsOnSessionBranch: string | null;
+  dependsOnSessionPrUrl: string | null;
+  rebaseOntoBranch: string | null;
+  dependencyWarnings: string[];
+  overlapWarnings: string[];
+};
+
 export type EpicQueueValidationErrorCode =
   | 'duplicate-epic'
   | 'epic-not-found'
@@ -47,10 +74,23 @@ export type EpicQueueManifestFailure = {
 export type EpicQueueManifestEntry = {
   epicNumber: number;
   title: string;
+  queueIndex: number;
+  queueTotal: number;
+  previousEpic: QueueEpicLink | null;
+  nextEpic: QueueEpicLink | null;
   status: EpicQueueManifestEntryStatus;
   sessionName: string | null;
   sessionBranch: string | null;
   sessionPrUrl: string | null;
+  nextSessionBranch: string | null;
+  nextSessionPrUrl: string | null;
+  branchAncestryMode: BranchAncestryMode;
+  branchedFromBranch: string | null;
+  dependsOnSessionBranch: string | null;
+  dependsOnSessionPrUrl: string | null;
+  rebaseOntoBranch: string | null;
+  dependencyWarnings: string[];
+  overlapWarnings: string[];
   startedAt: string | null;
   endedAt: string | null;
   skipReason?: string;
@@ -60,6 +100,7 @@ export type EpicQueueManifestEntry = {
 export type EpicQueueManifest = {
   queueId: string;
   epicIds: number[];
+  branchAncestryMode: BranchAncestryMode;
   status: EpicQueueManifestStatus;
   startedAt: string;
   endedAt: string | null;
@@ -209,23 +250,43 @@ export function validateEpicQueue(
 export function createEpicQueueManifest(
   entries: ValidatedEpicQueueEntry[],
   now: Date = new Date(),
+  branchAncestryMode: BranchAncestryMode = 'stacked',
 ): EpicQueueManifest {
   const startedAt = now.toISOString();
+  const queueTotal = entries.length;
 
   return {
     queueId: `queue-${formatQueueTimestamp(now)}`,
     epicIds: entries.map((entry) => entry.epicNumber),
+    branchAncestryMode,
     status: 'running',
     startedAt,
     endedAt: null,
     stopReason: null,
-    epics: entries.map((entry) => ({
+    epics: entries.map((entry, index) => ({
       epicNumber: entry.epicNumber,
       title: entry.title,
+      queueIndex: index + 1,
+      queueTotal,
+      previousEpic: index > 0
+        ? { number: entries[index - 1].epicNumber, title: entries[index - 1].title }
+        : null,
+      nextEpic: index < entries.length - 1
+        ? { number: entries[index + 1].epicNumber, title: entries[index + 1].title }
+        : null,
       status: entry.status === 'already-complete' ? 'skipped' : 'pending',
       sessionName: null,
       sessionBranch: null,
       sessionPrUrl: null,
+      nextSessionBranch: null,
+      nextSessionPrUrl: null,
+      branchAncestryMode,
+      branchedFromBranch: null,
+      dependsOnSessionBranch: null,
+      dependsOnSessionPrUrl: null,
+      rebaseOntoBranch: null,
+      dependencyWarnings: [],
+      overlapWarnings: [],
       startedAt: null,
       endedAt: entry.status === 'already-complete' ? startedAt : null,
       skipReason: entry.skipReason,
@@ -238,27 +299,43 @@ export function createEpicQueueValidationFailureManifest(
   epicNumbers: number[],
   errors: EpicQueueValidationError[],
   now: Date = new Date(),
+  branchAncestryMode: BranchAncestryMode = 'stacked',
 ): EpicQueueManifest {
   const startedAt = now.toISOString();
+  const queueTotal = epicNumbers.length;
 
   return {
     queueId: `queue-${formatQueueTimestamp(now)}`,
     epicIds: epicNumbers,
+    branchAncestryMode,
     status: 'stopped',
     startedAt,
     endedAt: startedAt,
     stopReason: 'queue-validation-failed',
-    epics: epicNumbers.map((epicNumber) => {
+    epics: epicNumbers.map((epicNumber, index) => {
       const failures = errors
         .filter((error) => error.epicNumber === epicNumber)
         .map((error) => ({ code: error.code, message: error.message }));
       return {
         epicNumber,
         title: '',
+        queueIndex: index + 1,
+        queueTotal,
+        previousEpic: index > 0 ? { number: epicNumbers[index - 1], title: '' } : null,
+        nextEpic: index < epicNumbers.length - 1 ? { number: epicNumbers[index + 1], title: '' } : null,
         status: failures.length > 0 ? 'failure' : 'pending',
         sessionName: null,
         sessionBranch: null,
         sessionPrUrl: null,
+        nextSessionBranch: null,
+        nextSessionPrUrl: null,
+        branchAncestryMode,
+        branchedFromBranch: null,
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+        rebaseOntoBranch: null,
+        dependencyWarnings: [],
+        overlapWarnings: [],
         startedAt: null,
         endedAt: failures.length > 0 ? startedAt : null,
         failures,

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -12,6 +12,7 @@ import { readStageTelemetry } from './telemetry.js';
 import { runDir } from './traces.js';
 import type { Config } from './config.js';
 import type { PipelineResult, GateResult } from './pipeline.js';
+import type { QueueEpicLink, QueueSessionContext } from './epic-queue.js';
 
 export type SessionContext = {
   name: string;
@@ -23,6 +24,8 @@ export type SessionContext = {
   sessionPrUrl?: string;
   /** When set, this session processes sub-issues of the given epic. */
   epic?: number;
+  /** Queue metadata for multi-epic queue sessions. */
+  queue?: QueueSessionContext;
 };
 
 export type CreateSessionOptions = {
@@ -31,10 +34,130 @@ export type CreateSessionOptions = {
   epicNum?: number;
   /** Title of the epic, used to form a human-readable session slug. */
   epicTitle?: string;
+  /** Queue metadata when this session belongs to an ordered epic queue. */
+  queue?: QueueSessionContext;
 };
 
 function slugify(text: string): string {
   return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+function draftSessionPrTitle(name: string, milestone: string | undefined, epicNum: number | undefined, epicTitle: string | undefined): string {
+  if (epicNum !== undefined) {
+    return `Epic #${epicNum}${epicTitle ? `: ${epicTitle}` : ''}`;
+  }
+  return milestone ? `Milestone: ${milestone}` : `Session: ${name}`;
+}
+
+function formatEpicLink(epic: QueueEpicLink | null): string {
+  if (!epic) return 'None';
+  const title = epic.title ? ` - ${epic.title}` : '';
+  const pr = epic.sessionPrUrl ? ` ([session PR](${epic.sessionPrUrl}))` : '';
+  const branch = !epic.sessionPrUrl && epic.sessionBranch ? ` (${epic.sessionBranch})` : '';
+  return `#${epic.number}${title}${pr}${branch}`;
+}
+
+function previousPrLabel(queue: QueueSessionContext): string {
+  if (queue.dependsOnSessionPrUrl) {
+    return `[the previous session PR](${queue.dependsOnSessionPrUrl})`;
+  }
+  if (queue.previousSessionPrUrl) {
+    return `[the previous session PR](${queue.previousSessionPrUrl})`;
+  }
+  if (queue.previousEpic) {
+    return `the previous session PR for #${queue.previousEpic.number}`;
+  }
+  return 'the previous session PR';
+}
+
+function buildQueueSection(queue: QueueSessionContext, branch: string, baseBranch: string): string[] {
+  const lines: string[] = [
+    '## Execution Queue',
+    '',
+    `**Queue:** ${queue.queueId}`,
+    `**Position:** ${queue.queueIndex} of ${queue.queueTotal}`,
+    `**Parent epic:** ${formatEpicLink(queue.currentEpic)}`,
+    `**Previous queued epic:** ${formatEpicLink(queue.previousEpic)}`,
+    `**Next queued epic:** ${formatEpicLink(queue.nextEpic)}`,
+    `**Branch ancestry:** ${queue.branchAncestryMode}`,
+  ];
+
+  if (queue.branchAncestryMode === 'stacked') {
+    if (queue.dependsOnSessionBranch) {
+      lines.push(`**Branched from:** ${queue.dependsOnSessionBranch}`);
+      lines.push(`**Depends on:** ${queue.dependsOnSessionPrUrl ? `[${queue.dependsOnSessionBranch}](${queue.dependsOnSessionPrUrl})` : queue.dependsOnSessionBranch}`);
+    } else {
+      lines.push(`**Branched from:** ${queue.branchedFromBranch}`);
+      lines.push('**Depends on:** None - this is the first queued session branch.');
+    }
+  } else {
+    lines.push(`**Branched from:** ${queue.branchedFromBranch}`);
+    lines.push('**Depends on:** None - no branch ancestry dependency was created.');
+  }
+
+  lines.push('');
+  lines.push('### Merge Order');
+  lines.push('');
+
+  if (queue.branchAncestryMode === 'stacked' && queue.dependsOnSessionBranch) {
+    const rebaseTarget = queue.rebaseOntoBranch ?? baseBranch;
+    lines.push(`- Merge ${previousPrLabel(queue)} first; after it lands on ${rebaseTarget}, rebase \`${branch}\` onto \`${rebaseTarget}\` before final review/merge.`);
+    lines.push(`- This PR still targets \`${baseBranch}\`, but its branch was created from \`${queue.dependsOnSessionBranch}\`.`);
+  } else if (queue.branchAncestryMode === 'stacked') {
+    lines.push(`- This is the first queued session PR. Merge it before later queued session PRs.`);
+    if (queue.nextEpic) {
+      lines.push(`- Later queued sessions may be branched from \`${branch}\`; review ${formatEpicLink(queue.nextEpic)} after this PR.`);
+    }
+  } else {
+    lines.push(`- Review this PR in queue order, but it can merge independently once ready.`);
+    lines.push(`- No branch ancestry dependency was created; this branch starts from \`${queue.branchedFromBranch}\`.`);
+  }
+
+  lines.push('');
+  lines.push('### Dependency And Overlap Notes');
+  lines.push('');
+  const riskLines = [
+    ...queue.dependencyWarnings.map((warning) => `- Dependency: ${warning}`),
+    ...queue.overlapWarnings.map((warning) => `- File overlap: ${warning}`),
+  ];
+  if (riskLines.length > 0) {
+    lines.push(...riskLines);
+  } else {
+    lines.push('- No queued dependency or file-overlap risks detected.');
+  }
+
+  return lines;
+}
+
+function buildDraftSessionPrBody(args: {
+  branch: string;
+  startedAt: string;
+  milestone?: string;
+  epicNum?: number;
+  epicTitle?: string;
+  queue?: QueueSessionContext;
+  baseBranch: string;
+}): string {
+  const lines: string[] = ['## Session In Progress', ''];
+  if (args.epicNum !== undefined) {
+    lines.push(`**Epic:** #${args.epicNum}${args.epicTitle ? ` — ${args.epicTitle}` : ''}`);
+  } else if (args.milestone) {
+    lines.push(`**Milestone:** ${args.milestone}`);
+  }
+  lines.push(`**Branch:** ${args.branch}`);
+  lines.push(`**Started:** ${args.startedAt}`);
+  lines.push('');
+
+  if (args.queue) {
+    lines.push(...buildQueueSection(args.queue, args.branch, args.baseBranch));
+    lines.push('');
+  }
+
+  lines.push('This PR will be updated as issues are processed.');
+  lines.push('');
+  lines.push('---');
+  lines.push('*Automated by alpha-loop*');
+  return lines.join('\n');
 }
 
 /**
@@ -47,6 +170,7 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
   const milestone = options?.milestone;
   const epicNum = options?.epicNum;
   const epicTitle = options?.epicTitle;
+  const queue = options?.queue;
 
   let slug: string;
   if (epicNum !== undefined) {
@@ -64,6 +188,7 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
   const resultsDir = join(projectDir, '.alpha-loop', 'sessions', name);
   const logsDir = join(resultsDir, 'logs');
   let sessionPrUrl: string | undefined;
+  const branchSource = queue?.branchedFromBranch ?? config.baseBranch;
 
   mkdirSync(resultsDir, { recursive: true });
   mkdirSync(logsDir, { recursive: true });
@@ -75,13 +200,13 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
 
     const branchExists = exec(`git rev-parse --verify "${branch}"`, { cwd: projectDir });
     if (branchExists.exitCode !== 0) {
-      // Create from remote base branch first, fall back to local
+      // Create from the queue ancestry branch (or base branch) first, fall back to local.
       const fromRemote = exec(
-        `git checkout -b "${branch}" "origin/${config.baseBranch}"`,
+        `git checkout -b "${branch}" "origin/${branchSource}"`,
         { cwd: projectDir },
       );
       if (fromRemote.exitCode !== 0) {
-        exec(`git checkout -b "${branch}" "${config.baseBranch}"`, { cwd: projectDir });
+        exec(`git checkout -b "${branch}" "${branchSource}"`, { cwd: projectDir });
       }
       // Create an initial commit so the branch has a diff from base (required for PR creation)
       exec(`git commit --allow-empty -m "chore: start session ${name}"`, { cwd: projectDir });
@@ -97,14 +222,16 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
           repo: config.repo,
           base: config.baseBranch,
           head: branch,
-          title: epicNum !== undefined
-            ? `Epic #${epicNum}${epicTitle ? `: ${epicTitle}` : ''}`
-            : milestone ? `Milestone: ${milestone}` : `Session: ${name}`,
-          body: `## Session In Progress\n\n${
-            epicNum !== undefined
-              ? `**Epic:** #${epicNum}${epicTitle ? ` — ${epicTitle}` : ''}\n`
-              : milestone ? `**Milestone:** ${milestone}\n` : ''
-          }**Branch:** ${branch}\n**Started:** ${new Date().toISOString()}\n\nThis PR will be updated as issues are processed.\n\n---\n*Automated by alpha-loop*`,
+          title: draftSessionPrTitle(name, milestone, epicNum, epicTitle),
+          body: buildDraftSessionPrBody({
+            branch,
+            startedAt: new Date().toISOString(),
+            milestone,
+            epicNum,
+            epicTitle,
+            queue,
+            baseBranch: config.baseBranch,
+          }),
           cwd: projectDir,
         });
         sessionPrUrl = draftPR;
@@ -117,17 +244,17 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
       // Ensure session branch exists on remote (may have been deleted after a previous merge)
       const remoteCheck = exec(`git ls-remote --heads origin "${branch}"`, { cwd: projectDir });
       if (!remoteCheck.stdout.trim()) {
-        log.warn(`Session branch "${branch}" exists locally but not on remote — recreating from ${config.baseBranch}`);
+        log.warn(`Session branch "${branch}" exists locally but not on remote — recreating from ${branchSource}`);
         // Ensure we're not on the branch we're about to delete
-        exec(`git checkout "${config.baseBranch}"`, { cwd: projectDir });
+        exec(`git checkout "${branchSource}"`, { cwd: projectDir });
         // Delete stale local branch and recreate from current base (the old one is behind after merge)
         exec(`git branch -D "${branch}"`, { cwd: projectDir });
         const fromRemote = exec(
-          `git checkout -b "${branch}" "origin/${config.baseBranch}"`,
+          `git checkout -b "${branch}" "origin/${branchSource}"`,
           { cwd: projectDir },
         );
         if (fromRemote.exitCode !== 0) {
-          exec(`git checkout -b "${branch}" "${config.baseBranch}"`, { cwd: projectDir });
+          exec(`git checkout -b "${branch}" "${branchSource}"`, { cwd: projectDir });
         }
         exec(`git commit --allow-empty -m "chore: start session ${name}"`, { cwd: projectDir });
         const pushResult = exec(`git push origin "${branch}"`, { cwd: projectDir });
@@ -143,8 +270,16 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
             repo: config.repo,
             base: config.baseBranch,
             head: branch,
-            title: milestone ? `Milestone: ${milestone}` : `Session: ${name}`,
-            body: `## Session In Progress\n\n${milestone ? `**Milestone:** ${milestone}\n` : ''}**Branch:** ${branch}\n**Started:** ${new Date().toISOString()}\n\nThis PR will be updated as issues are processed.\n\n---\n*Automated by alpha-loop*`,
+            title: draftSessionPrTitle(name, milestone, epicNum, epicTitle),
+            body: buildDraftSessionPrBody({
+              branch,
+              startedAt: new Date().toISOString(),
+              milestone,
+              epicNum,
+              epicTitle,
+              queue,
+              baseBranch: config.baseBranch,
+            }),
             cwd: projectDir,
           });
           sessionPrUrl = draftPR;
@@ -158,7 +293,7 @@ export function createSession(config: Config, options?: CreateSessionOptions): S
     }
   }
 
-  return { name, branch, resultsDir, logsDir, results: [], sessionPrUrl, epic: epicNum };
+  return { name, branch, resultsDir, logsDir, results: [], sessionPrUrl, epic: epicNum, queue };
 }
 
 /**
@@ -267,6 +402,9 @@ export async function finalizeSession(
       filesChanged: r.filesChanged,
     })),
   };
+  if (session.queue) {
+    manifest.queue = session.queue;
+  }
   if (stageEntries.length > 0) {
     manifest.stages = stageEntries;
   }
@@ -306,6 +444,11 @@ export async function finalizeSession(
     `**Completed:** ${new Date().toISOString()}`,
     '',
   ];
+
+  if (session.queue) {
+    prLines.push(...buildQueueSection(session.queue, session.branch, config.baseBranch));
+    prLines.push('');
+  }
 
   // Successes — the main content
   if (successes.length > 0) {

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -416,6 +416,7 @@ describe('runCommand', () => {
       logsDir: `/tmp/sessions/epic-${options.epicNum}/logs`,
       results: [],
       epic: options.epicNum,
+      queue: options.queue,
     }));
     mockProcessIssue.mockImplementation(async (issueNum: number, title: string) => ({
       issueNum,
@@ -432,6 +433,37 @@ describe('runCommand', () => {
     await runCommand({ epics: '205,166,214' });
 
     expect(mockCreateSession.mock.calls.map((call) => call[1]?.epicNum)).toEqual([205, 166, 214]);
+    const queueContexts = mockCreateSession.mock.calls.map((call) => (call[1] as any)?.queue);
+    expect(queueContexts).toEqual([
+      expect.objectContaining({
+        queueIndex: 1,
+        queueTotal: 3,
+        currentEpic: expect.objectContaining({ number: 205, title: 'First Epic' }),
+        nextEpic: expect.objectContaining({ number: 166, title: 'Second Epic' }),
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+      }),
+      expect.objectContaining({
+        queueIndex: 2,
+        previousEpic: expect.objectContaining({ number: 205, title: 'First Epic', sessionPrUrl: 'https://github.com/owner/repo/pull/205' }),
+        nextEpic: expect.objectContaining({ number: 214, title: 'Third Epic' }),
+        previousSessionBranch: 'session/epic-205',
+        previousSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'session/epic-205',
+        dependsOnSessionBranch: 'session/epic-205',
+        rebaseOntoBranch: 'master',
+      }),
+      expect.objectContaining({
+        queueIndex: 3,
+        previousSessionBranch: 'session/epic-166',
+        previousSessionPrUrl: 'https://github.com/owner/repo/pull/166',
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'session/epic-166',
+        dependsOnSessionBranch: 'session/epic-166',
+      }),
+    ]);
     expect(mockCreateSession.mock.calls.map((call) => call[0])).toEqual([
       expect.objectContaining({ autoMerge: true, mergeTo: '' }),
       expect.objectContaining({ autoMerge: true, mergeTo: '' }),
@@ -451,11 +483,138 @@ describe('runCommand', () => {
       status: entry.status,
       sessionBranch: entry.sessionBranch,
       sessionPrUrl: entry.sessionPrUrl,
+      branchAncestryMode: entry.branchAncestryMode,
+      branchedFromBranch: entry.branchedFromBranch,
+      dependsOnSessionBranch: entry.dependsOnSessionBranch,
+      dependsOnSessionPrUrl: entry.dependsOnSessionPrUrl,
+      nextSessionPrUrl: entry.nextSessionPrUrl,
     }))).toEqual([
-      { epicNumber: 205, status: 'success', sessionBranch: 'session/epic-205', sessionPrUrl: 'https://github.com/owner/repo/pull/205' },
-      { epicNumber: 166, status: 'success', sessionBranch: 'session/epic-166', sessionPrUrl: 'https://github.com/owner/repo/pull/166' },
-      { epicNumber: 214, status: 'success', sessionBranch: 'session/epic-214', sessionPrUrl: 'https://github.com/owner/repo/pull/214' },
+      {
+        epicNumber: 205,
+        status: 'success',
+        sessionBranch: 'session/epic-205',
+        sessionPrUrl: 'https://github.com/owner/repo/pull/205',
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+        nextSessionPrUrl: 'https://github.com/owner/repo/pull/166',
+      },
+      {
+        epicNumber: 166,
+        status: 'success',
+        sessionBranch: 'session/epic-166',
+        sessionPrUrl: 'https://github.com/owner/repo/pull/166',
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'session/epic-205',
+        dependsOnSessionBranch: 'session/epic-205',
+        dependsOnSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+        nextSessionPrUrl: 'https://github.com/owner/repo/pull/214',
+      },
+      {
+        epicNumber: 214,
+        status: 'success',
+        sessionBranch: 'session/epic-214',
+        sessionPrUrl: 'https://github.com/owner/repo/pull/214',
+        branchAncestryMode: 'stacked',
+        branchedFromBranch: 'session/epic-166',
+        dependsOnSessionBranch: 'session/epic-166',
+        dependsOnSessionPrUrl: 'https://github.com/owner/repo/pull/166',
+        nextSessionPrUrl: null,
+      },
     ]);
+    expect(mockFinalizeSession.mock.calls.map((call) => (call[0] as any).queue?.queueIndex)).toEqual([1, 2, 3]);
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  test('--epics can run independent queue branches without ancestry dependencies', async () => {
+    mockLoadConfig.mockImplementation((overrides: any = {}) => makeConfig({
+      skipPostSessionReview: true,
+      autoMerge: false,
+      ...overrides,
+    }) as any);
+
+    const issues = new Map([
+      [205, { number: 205, title: 'First Epic', body: '- [ ] #305 First child', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
+      [305, { number: 305, title: 'First child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+      [266, { number: 266, title: 'Second child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
+    ]);
+    const childByEpic = new Map([[205, 305], [166, 266]]);
+    mockGetIssueWithComments.mockImplementation((_repo: string, issueNum: number) => (issues.get(issueNum) as any) ?? null);
+    mockGetEpicSubIssues.mockImplementation((_repo: string, epicNum: number) => [{
+      number: childByEpic.get(epicNum) ?? 0,
+      checked: true,
+      lineIndex: 0,
+    }]);
+    mockCreateSession.mockImplementation((_config: any, options: any = {}) => ({
+      name: `session/epic-${options.epicNum}`,
+      branch: `session/epic-${options.epicNum}`,
+      resultsDir: `/tmp/sessions/epic-${options.epicNum}`,
+      logsDir: `/tmp/sessions/epic-${options.epicNum}/logs`,
+      results: [],
+      epic: options.epicNum,
+      queue: options.queue,
+    }));
+    mockProcessIssue.mockImplementation(async (issueNum: number, title: string) => ({
+      issueNum,
+      title,
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    }));
+    mockFinalizeSession.mockImplementation(async (session: any) => `https://github.com/owner/repo/pull/${session.epic}`);
+
+    await runCommand({ epics: '205,166', queueBranchMode: 'independent' });
+
+    const queueContexts = mockCreateSession.mock.calls.map((call) => (call[1] as any)?.queue);
+    expect(queueContexts).toEqual([
+      expect.objectContaining({
+        queueIndex: 1,
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        previousSessionBranch: null,
+      }),
+      expect.objectContaining({
+        queueIndex: 2,
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+        previousSessionBranch: 'session/epic-205',
+        previousSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+      }),
+    ]);
+
+    const manifest = JSON.parse(String(mockWriteFileSync.mock.calls.at(-1)?.[1]));
+    expect(manifest.branchAncestryMode).toBe('independent');
+    expect(manifest.epics.map((entry: any) => ({
+      epicNumber: entry.epicNumber,
+      branchAncestryMode: entry.branchAncestryMode,
+      branchedFromBranch: entry.branchedFromBranch,
+      dependsOnSessionBranch: entry.dependsOnSessionBranch,
+      dependsOnSessionPrUrl: entry.dependsOnSessionPrUrl,
+    }))).toEqual([
+      {
+        epicNumber: 205,
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+      },
+      {
+        epicNumber: 166,
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+      },
+    ]);
+    expect(mockFinalizeSession.mock.calls.map((call) => (call[0] as any).queue?.branchAncestryMode)).toEqual(['independent', 'independent']);
     expect(mockExit).not.toHaveBeenCalled();
   });
 

--- a/tests/lib/session.test.ts
+++ b/tests/lib/session.test.ts
@@ -1,5 +1,6 @@
 import { createSession, saveResult, getPreviousResult, finalizeSession } from '../../src/lib/session';
 import type { PipelineResult } from '../../src/lib/pipeline';
+import type { BranchAncestryMode, QueueSessionContext } from '../../src/lib/epic-queue';
 
 jest.mock('../../src/lib/shell', () => ({
   exec: jest.fn(),
@@ -101,6 +102,37 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
   };
 }
 
+function makeQueueContext(overrides: Partial<QueueSessionContext> = {}): QueueSessionContext {
+  const mode: BranchAncestryMode = overrides.branchAncestryMode ?? 'stacked';
+  const previousSessionBranch = overrides.previousSessionBranch ?? 'session/epic-205-first';
+  const dependsOnSessionBranch = overrides.dependsOnSessionBranch
+    ?? (mode === 'stacked' ? previousSessionBranch : null);
+
+  return {
+    queueId: 'queue-20260521T101112Z',
+    queueIndex: 2,
+    queueTotal: 3,
+    currentEpic: { number: 166, title: 'Second Epic' },
+    previousEpic: {
+      number: 205,
+      title: 'First Epic',
+      sessionBranch: 'session/epic-205-first',
+      sessionPrUrl: 'https://github.com/owner/repo/pull/205',
+    },
+    nextEpic: { number: 214, title: 'Third Epic' },
+    previousSessionBranch,
+    previousSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+    branchAncestryMode: mode,
+    branchedFromBranch: mode === 'stacked' ? 'session/epic-205-first' : 'master',
+    dependsOnSessionBranch,
+    dependsOnSessionPrUrl: mode === 'stacked' ? 'https://github.com/owner/repo/pull/205' : null,
+    rebaseOntoBranch: mode === 'stacked' ? 'master' : null,
+    dependencyWarnings: ['Epic #166 declares a dependency on queued epic #205.'],
+    overlapWarnings: ['Epics #166 and #214 both mention src/lib/session.ts.'],
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockExec.mockReturnValue({ stdout: '', stderr: '', exitCode: 0 });
@@ -193,6 +225,59 @@ describe('createSession', () => {
         title: 'Epic #165: Hybrid Routing',
       }),
     );
+  });
+
+  test('creates stacked queue session branch from the previous session branch and annotates draft PR body', () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('rev-parse --verify')) return { stdout: '', stderr: '', exitCode: 1 };
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/166');
+
+    createSession(makeConfig({ autoMerge: true }), {
+      epicNum: 166,
+      epicTitle: 'Second Epic',
+      queue: makeQueueContext(),
+    });
+
+    expect(mockExec).toHaveBeenCalledWith(
+      'git checkout -b "session/epic-166-second-epic" "origin/session/epic-205-first"',
+      expect.any(Object),
+    );
+    const body = mockCreatePR.mock.calls[0][0].body;
+    expect(body).toContain('## Execution Queue');
+    expect(body).toContain('**Position:** 2 of 3');
+    expect(body).toContain('**Previous queued epic:** #205 - First Epic ([session PR](https://github.com/owner/repo/pull/205))');
+    expect(body).toContain('Merge [the previous session PR](https://github.com/owner/repo/pull/205) first; after it lands on master, rebase `session/epic-166-second-epic` onto `master` before final review/merge.');
+  });
+
+  test('creates independent queue session branch from base branch and explains no ancestry dependency in draft PR body', () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('rev-parse --verify')) return { stdout: '', stderr: '', exitCode: 1 };
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/166');
+
+    createSession(makeConfig({ autoMerge: true }), {
+      epicNum: 166,
+      epicTitle: 'Second Epic',
+      queue: makeQueueContext({
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+        rebaseOntoBranch: null,
+      }),
+    });
+
+    expect(mockExec).toHaveBeenCalledWith(
+      'git checkout -b "session/epic-166-second-epic" "origin/master"',
+      expect.any(Object),
+    );
+    const body = mockCreatePR.mock.calls[0][0].body;
+    expect(body).toContain('**Branch ancestry:** independent');
+    expect(body).toContain('**Depends on:** None - no branch ancestry dependency was created.');
+    expect(body).toContain('No branch ancestry dependency was created; this branch starts from `master`.');
   });
 });
 
@@ -313,6 +398,91 @@ describe('finalizeSession', () => {
       title: expect.stringContaining('Session:'),
       body: expect.stringContaining('#1: First issue'),
     }));
+    expect(mockCreatePR).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.not.stringContaining('## Execution Queue'),
+    }));
+  });
+
+  test('adds merge order and queue risk notes to final stacked queue session PR body', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('diff --cached --quiet')) {
+        return { stdout: '', stderr: '', exitCode: 1 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/166');
+
+    const config = makeConfig({ autoMerge: true });
+    const session = createSession(makeConfig(), {
+      epicNum: 166,
+      epicTitle: 'Second Epic',
+      queue: makeQueueContext(),
+    });
+    session.results.push({
+      issueNum: 266,
+      title: 'Second child',
+      status: 'success',
+      prUrl: 'https://github.com/owner/repo/pull/266',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 120,
+      filesChanged: 4,
+    });
+
+    await finalizeSession(session, config);
+
+    const body = mockCreatePR.mock.calls[0][0].body;
+    expect(body).toContain('## Execution Queue');
+    expect(body).toContain('**Queue:** queue-20260521T101112Z');
+    expect(body).toContain('**Parent epic:** #166 - Second Epic');
+    expect(body).toContain('**Next queued epic:** #214 - Third Epic');
+    expect(body).toContain('Merge [the previous session PR](https://github.com/owner/repo/pull/205) first; after it lands on master, rebase `session/epic-166-second-epic` onto `master` before final review/merge.');
+    expect(body).toContain('Dependency: Epic #166 declares a dependency on queued epic #205.');
+    expect(body).toContain('File overlap: Epics #166 and #214 both mention src/lib/session.ts.');
+    expect(body).toContain('Closes #266');
+  });
+
+  test('adds independent branch guidance to final queue session PR body', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('diff --cached --quiet')) {
+        return { stdout: '', stderr: '', exitCode: 1 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/166');
+
+    const config = makeConfig({ autoMerge: true });
+    const session = createSession(makeConfig(), {
+      epicNum: 166,
+      epicTitle: 'Second Epic',
+      queue: makeQueueContext({
+        branchAncestryMode: 'independent',
+        branchedFromBranch: 'master',
+        dependsOnSessionBranch: null,
+        dependsOnSessionPrUrl: null,
+        rebaseOntoBranch: null,
+      }),
+    });
+    session.results.push({
+      issueNum: 266,
+      title: 'Second child',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 120,
+      filesChanged: 4,
+    });
+
+    await finalizeSession(session, config);
+
+    const body = mockCreatePR.mock.calls[0][0].body;
+    expect(body).toContain('**Branch ancestry:** independent');
+    expect(body).toContain('Review this PR in queue order, but it can merge independently once ready.');
+    expect(body).toContain('No branch ancestry dependency was created; this branch starts from `master`.');
   });
 
   test('puts failed issues in collapsed details section', async () => {


### PR DESCRIPTION
Closes #214
Part of #217

## Summary

Automated implementation of **feat: add stacked session branches and PR dependency notes for epic queues**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Review passed: queue session branch metadata and PR guidance are wired and covered by tests.

## Test Requirements

- Unit tests for session PR body sections.
- Command/session tests proving queue metadata is passed from the queue runner into `createSession` and `finalizeSession`.
- Regression tests for existing non-queue session PR bodies.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*