### PR TITLE
feat: docs: document and test multi-epic execution queues (closes #216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,9 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop scan` | Generate/refresh project context and instructions file |
 | `alpha-loop vision` | **(deprecated)** Use `alpha-loop plan` instead |
 | `alpha-loop auth` | Save authenticated browser state for verification |
-| `alpha-loop history` | View session history |
+| `alpha-loop history` | View session and queue history |
 | `alpha-loop history <name>` | View a specific session |
+| `alpha-loop history queue-<timestamp>` | Inspect a multi-epic queue manifest, including stopped/pending epics |
 | `alpha-loop history <name> --qa` | Show QA checklist for session |
 | `alpha-loop history <name> --telemetry` | Show per-stage telemetry table (see [docs/telemetry.md](docs/telemetry.md)) |
 | `alpha-loop history --clean` | Remove old session data |
@@ -618,7 +619,7 @@ To run several epics unattended while keeping review scope separate, pass an exp
 alpha-loop run --epics 205,166,214
 ```
 
-The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. By default, queue sessions use `stacked` ancestry: later epic session branches start from the previous successful session branch while their PRs still target the configured base branch. Use `--queue-branch-mode independent` for unrelated epics that should all branch from the base branch. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `--dry-run` prints the validated queue without mutating GitHub or git state.
+The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. By default, queue sessions use `stacked` ancestry: later epic session branches start from the previous successful session branch while their PRs still target the configured base branch. Use `--queue-branch-mode independent` for unrelated epics that should all branch from the base branch. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `alpha-loop history` lists those manifests and `alpha-loop history queue-<timestamp>` prints stopped/pending epics, session PRs, and rebase notes. `--dry-run` prints the validated queue without mutating GitHub or git state.
 
 Sub-issues are processed in checklist order (not issue-number order). Each sub-issue PR gets `Part of #165` appended, and the epic body's checkboxes auto-flip from `- [ ]` to `- [x]` as PRs merge. When every sub-issue has shipped, the loop runs a verification pass against each sub-issue's acceptance criteria — on `pass` the epic is auto-closed, on `partial` or `fail` it stays open with a `needs-human-input` label and a structured comment explaining the gaps.
 
@@ -664,6 +665,7 @@ What needs to be done.
 | `.alpha-loop/evals/` | Yes | Eval cases (YAML) and score history (`scores.jsonl`) |
 | `.alpha-loop/traces/` | No (gitignored) | Meta-Harness style execution traces per session |
 | `.alpha-loop/sessions/` | No (gitignored) | Local session logs, results JSON, screenshots |
+| `.alpha-loop/sessions/queue-<timestamp>/queue.json` | No (gitignored) | Multi-epic queue manifest with status, session PRs, merge order, and stop reason |
 | `.alpha-loop/auth/` | No (gitignored) | Saved browser auth state for verification |
 | `.worktrees/` | No (gitignored) | Temporary git worktrees during processing |
 

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -121,6 +121,58 @@ alpha-loop run --skip-epic --milestone "v1.1"
 
 Skips epic discovery entirely and uses the flat milestone issue flow. Useful when you want to work on standalone issues in a milestone that also has scheduled parent epics.
 
+## Multi-Epic Queues
+
+Use one epic when the work has one integrated goal, one parent acceptance-criteria set, and one verification pass. Use a multi-epic queue when you want a long unattended run across several parent epics while keeping review scope separate. Each epic in the queue still produces its own session branch and session PR.
+
+There are two ways to build a queue:
+
+```bash
+alpha-loop roadmap --queue
+alpha-loop roadmap --queue --milestone "v1.1"
+```
+
+`roadmap --queue` is read-only. It inspects open epics, milestone order, child readiness, dependency phrases such as `depends on #N`, and likely file overlap. When at least one epic is runnable, it prints a command like:
+
+```bash
+alpha-loop run --epics 205,166,214
+```
+
+You can also provide the queue explicitly:
+
+```bash
+alpha-loop run --epics 205,166,214
+```
+
+Explicit queues are processed exactly in the order provided. Before any session starts, Alpha Loop validates that each issue exists, is labeled `epic`, is not duplicated, and is open unless already closed as completed. `--dry-run` performs the same validation and prints the queue without creating branches, PRs, GitHub comments, or queue manifests.
+
+### Execution Model
+
+For a non-dry-run queue, Alpha Loop writes:
+
+```text
+.alpha-loop/sessions/queue-<timestamp>/queue.json
+```
+
+The manifest records queue status, epic order, branch ancestry mode, per-epic session branch/PR URLs, dependency and overlap notes, failures, and the stop reason if the queue halts. `alpha-loop history` lists queue manifests alongside sessions, and `alpha-loop history queue-<timestamp>` prints the manifest details. If a queue stops, inspect that detail view to find the failed epic and the still-pending epics.
+
+Queue execution is fail-stop by default. Alpha Loop stops at the first epic that fails, remains incomplete after eligible children run, hits an epic checklist consistency error, fails verification, or encounters a transient agent/rate-limit stop. Earlier successful epic PRs stay available for review. Pending epics remain `pending` in `queue.json`; rerun them with a new explicit queue once the failure is resolved.
+
+If the process crashes inside a child issue before its branch has a PR, run `alpha-loop resume` to recover stranded `agent/issue-*` branches. Then inspect the queue manifest and continue with the remaining epic IDs.
+
+### Branch Ancestry Modes
+
+Queued epics always create separate session PRs that target the configured base branch. The branch ancestry controls where later session branches start.
+
+| Mode | Command | Branch behavior | When to use |
+|------|---------|-----------------|-------------|
+| `stacked` | `alpha-loop run --epics 205,166,214` | The first session branch starts from the base branch. Each later session branch starts from the previous successful session branch. | Related epics where later work may build on earlier queue changes. This is the default. |
+| `independent` | `alpha-loop run --epics 205,166,214 --queue-branch-mode independent` | Every session branch starts from the base branch. | Unrelated epics that only need queue order for scheduling or review coordination. |
+
+Stacked queue PRs include merge and rebase guidance. Merge the first session PR first. After it lands on the base branch, rebase the next stacked session branch onto the base branch before final review/merge, then repeat for the rest of the queue. Independent queue PRs should still be reviewed in queue order, but they can merge independently once ready because no branch ancestry dependency was created.
+
+Session PR bodies include an `Execution Queue` section with the queue ID, position, parent epic, previous/next epic, branch ancestry mode, dependency PR link, and risk notes. Dependency notes come from queued epic references such as `depends on #205`; overlap notes come from likely shared file paths mentioned in epic context.
+
 ## Sub-Issue Ordering
 
 Sub-issues are processed in the order they appear in the epic's task-list — **not** by issue number. To reorder, edit the epic body and rearrange the `- [ ] #N` lines.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ program
 
 program
   .command('history [session]')
-  .description('View session history')
+  .description('View session and queue history')
   .option('--qa', 'Show QA checklist for session')
   .option('--clean', 'Remove old session data')
   .option('--telemetry', 'Show per-stage telemetry for a session')

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -5,13 +5,22 @@ import { readStageTelemetry } from '../lib/telemetry.js';
 import type { StageTelemetry } from '../lib/telemetry.js';
 import type { PipelineResult } from '../lib/pipeline.js';
 import type { EscalationEvent } from '../lib/escalation.js';
+import type { EpicQueueManifest, QueueSessionContext } from '../lib/epic-queue.js';
 
 type SessionManifest = {
   name: string;
   branch: string;
   completed: string;
   results: PipelineResult[];
+  queue?: QueueSessionContext;
   stages?: StageTelemetry[];
+};
+
+type QueueManifestRef = {
+  dir: string;
+  name: string;
+  timestamp: string;
+  manifest: EpicQueueManifest;
 };
 
 function formatDuration(seconds: number | undefined): string {
@@ -71,6 +80,55 @@ function findSessionDirs(sessionsRoot: string): Array<{ dir: string; name: strin
   return sessions;
 }
 
+function loadQueueManifest(filePath: string): EpicQueueManifest | null {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as EpicQueueManifest;
+    if (!manifest.queueId || !Array.isArray(manifest.epics)) return null;
+    return manifest;
+  } catch {
+    return null;
+  }
+}
+
+function queueTimestamp(queueId: string): string {
+  return queueId.startsWith('queue-') ? queueId.slice('queue-'.length) : queueId;
+}
+
+/**
+ * Find multi-epic queue manifests under .alpha-loop/sessions/queue-<timestamp>/queue.json.
+ */
+function findQueueManifests(sessionsRoot: string): QueueManifestRef[] {
+  if (!fs.existsSync(sessionsRoot)) return [];
+
+  const queues: QueueManifestRef[] = [];
+  for (const entry of fs.readdirSync(sessionsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith('queue-')) continue;
+    const dir = path.join(sessionsRoot, entry.name);
+    const manifest = loadQueueManifest(path.join(dir, 'queue.json'));
+    if (!manifest) continue;
+    const name = manifest.queueId || entry.name;
+    queues.push({
+      dir,
+      name,
+      timestamp: queueTimestamp(name),
+      manifest,
+    });
+  }
+
+  queues.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return queues;
+}
+
+function findQueueManifest(sessionsRoot: string, name: string): QueueManifestRef | undefined {
+  const wanted = name.trim();
+  if (!wanted) return undefined;
+  return findQueueManifests(sessionsRoot).find((queue) => (
+    queue.name === wanted ||
+    queue.timestamp === wanted ||
+    queue.name.endsWith(wanted)
+  ));
+}
+
 /**
  * Load session manifests from the learnings directory (checked into git, shared with team).
  * These are created during session finalization.
@@ -96,6 +154,7 @@ function loadManifests(projectDir?: string): Map<string, SessionManifest> {
 export function historyList(sessionsDir: string, projectDir?: string): void {
   const localSessions = findSessionDirs(sessionsDir);
   const manifests = loadManifests(projectDir);
+  const queues = findQueueManifests(sessionsDir);
 
   // Build a unified list: local sessions + manifests not covered by local data
   const seenNames = new Set(localSessions.map((s) => s.name));
@@ -129,42 +188,130 @@ export function historyList(sessionsDir: string, projectDir?: string): void {
   // Sort newest first
   entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 
-  if (entries.length === 0) {
+  if (entries.length === 0 && queues.length === 0) {
     console.log('No sessions found.');
     return;
   }
 
-  console.log('Sessions:');
-  console.log('');
+  if (entries.length > 0) {
+    console.log('Sessions:');
+    console.log('');
 
-  for (const entry of entries) {
-    const issueCount = entry.results.length;
-    const successCount = entry.results.filter((r) => r.status === 'success').length;
-    const failedCount = issueCount - successCount;
-    const totalDuration = entry.results.reduce((sum, r) => sum + r.duration, 0);
-    const durStr = formatDuration(totalDuration);
+    for (const entry of entries) {
+      const issueCount = entry.results.length;
+      const successCount = entry.results.filter((r) => r.status === 'success').length;
+      const failedCount = issueCount - successCount;
+      const totalDuration = entry.results.reduce((sum, r) => sum + r.duration, 0);
+      const durStr = formatDuration(totalDuration);
 
-    // Parse date from timestamp (YYYYMMDD-HHMMSS)
-    const ts = entry.timestamp;
-    const date = ts.length >= 8
-      ? `${ts.slice(0, 4)}-${ts.slice(4, 6)}-${ts.slice(6, 8)}`
-      : ts;
+      // Parse date from timestamp (YYYYMMDD-HHMMSS)
+      const ts = entry.timestamp;
+      const date = ts.length >= 8
+        ? `${ts.slice(0, 4)}-${ts.slice(4, 6)}-${ts.slice(6, 8)}`
+        : ts;
 
-    const issueWord = issueCount === 1 ? 'issue' : 'issues';
-    let statusParts = '';
-    if (successCount > 0) statusParts += `${successCount} \u2713`;
-    if (failedCount > 0) statusParts += ` ${failedCount} \u2717`;
-    if (issueCount === 0) statusParts = '(empty)';
+      const issueWord = issueCount === 1 ? 'issue' : 'issues';
+      let statusParts = '';
+      if (successCount > 0) statusParts += `${successCount} \u2713`;
+      if (failedCount > 0) statusParts += ` ${failedCount} \u2717`;
+      if (issueCount === 0) statusParts = '(empty)';
 
-    console.log(
-      `  ${entry.name.padEnd(30)} ${date}  ${String(issueCount).padStart(2)} ${issueWord.padEnd(7)} ${statusParts.padEnd(10)} ${durStr}`,
-    );
+      console.log(
+        `  ${entry.name.padEnd(30)} ${date}  ${String(issueCount).padStart(2)} ${issueWord.padEnd(7)} ${statusParts.padEnd(10)} ${durStr}`,
+      );
+    }
+  }
+
+  if (queues.length > 0) {
+    if (entries.length > 0) console.log('');
+    console.log('Queues:');
+    console.log('');
+    for (const queue of queues) {
+      const manifest = queue.manifest;
+      const epicCount = manifest.epics.length;
+      const successCount = manifest.epics.filter((entry) => entry.status === 'success').length;
+      const failedCount = manifest.epics.filter((entry) => entry.status === 'failure').length;
+      const pendingCount = manifest.epics.filter((entry) => entry.status === 'pending' || entry.status === 'running').length;
+      const startedAt = manifest.startedAt ?? '';
+      const date = startedAt.length >= 10 ? startedAt.slice(0, 10) : queue.timestamp;
+      const epicWord = epicCount === 1 ? 'epic' : 'epics';
+      const status = `${manifest.status}${manifest.stopReason ? `: ${manifest.stopReason}` : ''}`;
+      console.log(
+        `  ${queue.name.padEnd(30)} ${date}  ${String(epicCount).padStart(2)} ${epicWord.padEnd(6)} ${successCount} ok, ${failedCount} failed, ${pendingCount} pending  ${status}`,
+      );
+    }
   }
 }
 
-export function historyDetail(sessionsDir: string, sessionName: string): void {
+function formatQueueEpicStatus(status: string): string {
+  if (status === 'success') return 'success';
+  if (status === 'failure') return 'failed';
+  if (status === 'skipped') return 'skipped';
+  if (status === 'running') return 'running';
+  return 'pending';
+}
+
+function printQueueManifestDetail(queue: QueueManifestRef, projectDir?: string): void {
+  const root = projectDir ?? process.cwd();
+  const manifest = queue.manifest;
+  const manifestPath = path.relative(root, path.join(queue.dir, 'queue.json'));
+
+  console.log(`Queue:       ${manifest.queueId}`);
+  console.log(`Status:      ${manifest.status}`);
+  console.log(`Branch mode: ${manifest.branchAncestryMode}`);
+  console.log(`Started:     ${manifest.startedAt}`);
+  if (manifest.endedAt) console.log(`Ended:       ${manifest.endedAt}`);
+  if (manifest.stopReason) console.log(`Stop reason: ${manifest.stopReason}`);
+  console.log(`Manifest:    ${manifestPath}`);
+  console.log('');
+
+  console.log('Epics:');
+  for (const entry of manifest.epics) {
+    console.log(`  ${entry.queueIndex}/${entry.queueTotal} #${entry.epicNumber} ${entry.title} — ${formatQueueEpicStatus(entry.status)}`);
+    if (entry.sessionName) console.log(`           Session: ${entry.sessionName}`);
+    if (entry.sessionBranch) console.log(`           Branch:  ${entry.sessionBranch}`);
+    if (entry.sessionPrUrl) console.log(`           PR:      ${entry.sessionPrUrl}`);
+    if (entry.branchedFromBranch) console.log(`           From:    ${entry.branchedFromBranch}`);
+    if (entry.dependsOnSessionBranch) {
+      const pr = entry.dependsOnSessionPrUrl ? ` (${entry.dependsOnSessionPrUrl})` : '';
+      console.log(`           Depends: ${entry.dependsOnSessionBranch}${pr}`);
+    }
+    if (entry.rebaseOntoBranch) console.log(`           Rebase:  ${entry.sessionBranch ?? 'this branch'} onto ${entry.rebaseOntoBranch} after the dependency PR lands`);
+    for (const warning of entry.dependencyWarnings ?? []) console.log(`           Dependency: ${warning}`);
+    for (const warning of entry.overlapWarnings ?? []) console.log(`           File overlap: ${warning}`);
+    for (const failure of entry.failures ?? []) console.log(`           Failure: ${failure.code} — ${failure.message}`);
+  }
+}
+
+function printSessionQueueSummary(queue: QueueSessionContext): void {
+  console.log('');
+  console.log('Queue:');
+  console.log(`  ID:        ${queue.queueId}`);
+  console.log(`  Position:  ${queue.queueIndex} of ${queue.queueTotal}`);
+  console.log(`  Epic:      #${queue.currentEpic.number} ${queue.currentEpic.title}`);
+  console.log(`  Mode:      ${queue.branchAncestryMode}`);
+  console.log(`  From:      ${queue.branchedFromBranch}`);
+  if (queue.dependsOnSessionBranch) {
+    const pr = queue.dependsOnSessionPrUrl ? ` (${queue.dependsOnSessionPrUrl})` : '';
+    console.log(`  Depends:   ${queue.dependsOnSessionBranch}${pr}`);
+  }
+  if (queue.rebaseOntoBranch) {
+    console.log(`  Rebase:    onto ${queue.rebaseOntoBranch} after the dependency PR lands`);
+  }
+}
+
+export function historyDetail(sessionsDir: string, sessionName: string, projectDir?: string): void {
+  const queue = findQueueManifest(sessionsDir, sessionName);
+  if (queue) {
+    printQueueManifestDetail(queue, projectDir);
+    return;
+  }
+
   let results: PipelineResult[] = [];
   let sessionDir: string | undefined;
+  let manifest: SessionManifest | undefined;
+  const root = projectDir ?? process.cwd();
+  const manifests = loadManifests(root);
 
   // Try local session directories first
   const localDir = path.join(sessionsDir, sessionName);
@@ -182,14 +329,16 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
 
   // Fall back to manifest from learnings (checked-in data from teammates)
   if (results.length === 0) {
-    const manifests = loadManifests();
-    const manifest = manifests.get(sessionName)
+    manifest = manifests.get(sessionName)
       ?? [...manifests.values()].find((m) => m.name.endsWith(sessionName));
     if (manifest) {
       results = manifest.results;
       sessionName = manifest.name;
     }
   }
+
+  manifest ??= manifests.get(sessionName)
+    ?? [...manifests.values()].find((m) => m.name === sessionName || m.name.endsWith(sessionName));
 
   if (results.length === 0) {
     log.error(`Session not found: ${sessionName}`);
@@ -204,6 +353,11 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
   console.log(`Issues:   ${results.length} (${successCount} succeeded, ${results.length - successCount} failed)`);
   console.log(`Duration: ${formatDuration(totalDuration)}`);
   console.log('');
+
+  if (manifest?.queue) {
+    printSessionQueueSummary(manifest.queue);
+    console.log('');
+  }
 
   // Stage-revert banner: if any issue in this session has an active revert event, flag it.
   const activeReverts = new Set<string>();
@@ -284,7 +438,7 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
   }
 
   // Check for session summary in learnings
-  const learningsDir = path.join(process.cwd(), '.alpha-loop', 'learnings');
+  const learningsDir = path.join(root, '.alpha-loop', 'learnings');
   const summaryName = `session-summary-${sessionName.replace(/\//g, '-')}.md`;
   const summaryPath = path.join(learningsDir, summaryName);
   if (fs.existsSync(summaryPath)) {

--- a/tests/commands/history.test.ts
+++ b/tests/commands/history.test.ts
@@ -35,6 +35,97 @@ function createSession(
   }
 }
 
+function createQueueManifest(sessionsDir: string): void {
+  const queueDir = path.join(sessionsDir, 'queue-20260521T101112Z');
+  fs.mkdirSync(queueDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(queueDir, 'queue.json'),
+    JSON.stringify({
+      queueId: 'queue-20260521T101112Z',
+      epicIds: [205, 166, 214],
+      branchAncestryMode: 'stacked',
+      status: 'stopped',
+      startedAt: '2026-05-21T10:11:12.000Z',
+      endedAt: '2026-05-21T10:45:00.000Z',
+      stopReason: 'Epic #166 stopped: transient-agent-stop',
+      epics: [
+        {
+          epicNumber: 205,
+          title: 'First Epic',
+          queueIndex: 1,
+          queueTotal: 3,
+          previousEpic: null,
+          nextEpic: { number: 166, title: 'Second Epic' },
+          status: 'success',
+          sessionName: 'session/epic-205-first-epic',
+          sessionBranch: 'session/epic-205-first-epic',
+          sessionPrUrl: 'https://github.com/owner/repo/pull/205',
+          nextSessionBranch: 'session/epic-166-second-epic',
+          nextSessionPrUrl: null,
+          branchAncestryMode: 'stacked',
+          branchedFromBranch: 'master',
+          dependsOnSessionBranch: null,
+          dependsOnSessionPrUrl: null,
+          rebaseOntoBranch: null,
+          dependencyWarnings: ['Later queued epic #166 declares a dependency on this epic.'],
+          overlapWarnings: [],
+          startedAt: '2026-05-21T10:11:12.000Z',
+          endedAt: '2026-05-21T10:30:00.000Z',
+          failures: [],
+        },
+        {
+          epicNumber: 166,
+          title: 'Second Epic',
+          queueIndex: 2,
+          queueTotal: 3,
+          previousEpic: { number: 205, title: 'First Epic', sessionPrUrl: 'https://github.com/owner/repo/pull/205' },
+          nextEpic: { number: 214, title: 'Third Epic' },
+          status: 'failure',
+          sessionName: 'session/epic-166-second-epic',
+          sessionBranch: 'session/epic-166-second-epic',
+          sessionPrUrl: 'https://github.com/owner/repo/pull/166',
+          nextSessionBranch: null,
+          nextSessionPrUrl: null,
+          branchAncestryMode: 'stacked',
+          branchedFromBranch: 'session/epic-205-first-epic',
+          dependsOnSessionBranch: 'session/epic-205-first-epic',
+          dependsOnSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+          rebaseOntoBranch: 'master',
+          dependencyWarnings: ['Epic #166 declares a dependency on queued epic #205.'],
+          overlapWarnings: ['Epics #166 and #214 both mention src/lib/session.ts.'],
+          startedAt: '2026-05-21T10:30:00.000Z',
+          endedAt: '2026-05-21T10:45:00.000Z',
+          failures: [{ code: 'transient-stop', message: 'Agent rate limit', issueNum: 266 }],
+        },
+        {
+          epicNumber: 214,
+          title: 'Third Epic',
+          queueIndex: 3,
+          queueTotal: 3,
+          previousEpic: { number: 166, title: 'Second Epic' },
+          nextEpic: null,
+          status: 'pending',
+          sessionName: null,
+          sessionBranch: null,
+          sessionPrUrl: null,
+          nextSessionBranch: null,
+          nextSessionPrUrl: null,
+          branchAncestryMode: 'stacked',
+          branchedFromBranch: null,
+          dependsOnSessionBranch: null,
+          dependsOnSessionPrUrl: null,
+          rebaseOntoBranch: null,
+          dependencyWarnings: [],
+          overlapWarnings: [],
+          startedAt: null,
+          endedAt: null,
+          failures: [],
+        },
+      ],
+    }, null, 2),
+  );
+}
+
 describe('history', () => {
   let tmpDir: string;
   let consoleSpy: jest.SpyInstance;
@@ -98,6 +189,20 @@ describe('history', () => {
       expect(output).toContain('\u2717');
       expect(output).toContain('5m 00s');
     });
+
+    it('lists multi-epic queue manifests with status and pending counts', () => {
+      const sessionsDir = path.join(tmpDir, '.alpha-loop', 'sessions');
+      createQueueManifest(sessionsDir);
+
+      historyList(sessionsDir, tmpDir);
+
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('Queues:');
+      expect(output).toContain('queue-20260521T101112Z');
+      expect(output).toContain('3 epics');
+      expect(output).toContain('1 ok, 1 failed, 1 pending');
+      expect(output).toContain('Epic #166 stopped: transient-agent-stop');
+    });
   });
 
   describe('historyDetail', () => {
@@ -125,6 +230,78 @@ describe('history', () => {
       const errorOutput = errorSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
       expect(errorOutput).toContain('Session not found');
       errorSpy.mockRestore();
+    });
+
+    it('shows queue manifest detail for stopped multi-epic queues', () => {
+      const sessionsDir = path.join(tmpDir, '.alpha-loop', 'sessions');
+      createQueueManifest(sessionsDir);
+
+      historyDetail(sessionsDir, 'queue-20260521T101112Z', tmpDir);
+
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('Queue:       queue-20260521T101112Z');
+      expect(output).toContain('Status:      stopped');
+      expect(output).toContain('Branch mode: stacked');
+      expect(output).toContain('Manifest:    .alpha-loop/sessions/queue-20260521T101112Z/queue.json');
+      expect(output).toContain('Stop reason: Epic #166 stopped: transient-agent-stop');
+      expect(output).toContain('2/3 #166 Second Epic');
+      expect(output).toContain('Depends: session/epic-205-first-epic (https://github.com/owner/repo/pull/205)');
+      expect(output).toContain('Rebase:  session/epic-166-second-epic onto master after the dependency PR lands');
+      expect(output).toContain('Dependency: Epic #166 declares a dependency on queued epic #205.');
+      expect(output).toContain('File overlap: Epics #166 and #214 both mention src/lib/session.ts.');
+      expect(output).toContain('Failure: transient-stop');
+      expect(output).toContain('3/3 #214 Third Epic');
+      expect(output).toContain('pending');
+    });
+
+    it('shows queue metadata from checked-in session manifests', () => {
+      const sessionsDir = path.join(tmpDir, '.alpha-loop', 'sessions');
+      const learningsDir = path.join(tmpDir, '.alpha-loop', 'learnings');
+      fs.mkdirSync(learningsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(learningsDir, 'session-session-epic-166-second-epic.json'),
+        JSON.stringify({
+          name: 'session/epic-166-second-epic',
+          branch: 'session/epic-166-second-epic',
+          completed: '2026-05-21T10:45:00.000Z',
+          results: [{
+            issueNum: 266,
+            title: 'Second child',
+            status: 'success',
+            testsPassing: true,
+            verifyPassing: true,
+            duration: 60,
+            filesChanged: 2,
+          }],
+          queue: {
+            queueId: 'queue-20260521T101112Z',
+            queueIndex: 2,
+            queueTotal: 3,
+            currentEpic: { number: 166, title: 'Second Epic' },
+            previousEpic: { number: 205, title: 'First Epic' },
+            nextEpic: { number: 214, title: 'Third Epic' },
+            previousSessionBranch: 'session/epic-205-first-epic',
+            previousSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+            branchAncestryMode: 'stacked',
+            branchedFromBranch: 'session/epic-205-first-epic',
+            dependsOnSessionBranch: 'session/epic-205-first-epic',
+            dependsOnSessionPrUrl: 'https://github.com/owner/repo/pull/205',
+            rebaseOntoBranch: 'master',
+            dependencyWarnings: [],
+            overlapWarnings: [],
+          },
+        }, null, 2),
+      );
+
+      historyDetail(sessionsDir, 'session/epic-166-second-epic', tmpDir);
+
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('Session:  session/epic-166-second-epic');
+      expect(output).toContain('Queue:');
+      expect(output).toContain('ID:        queue-20260521T101112Z');
+      expect(output).toContain('Position:  2 of 3');
+      expect(output).toContain('Depends:   session/epic-205-first-epic (https://github.com/owner/repo/pull/205)');
+      expect(output).toContain('Rebase:    onto master after the dependency PR lands');
     });
   });
 

--- a/tests/commands/roadmap.test.ts
+++ b/tests/commands/roadmap.test.ts
@@ -164,6 +164,15 @@ describe('roadmap command', () => {
     jest.clearAllMocks();
     mockBuildRoadmapPrompt.mockReturnValue('ROADMAP PROMPT');
     mockListRoadmapEpics.mockReturnValue([]);
+    mockFormatEpicQueuePlan.mockReturnValue('FORMATTED QUEUE PLAN');
+    mockPlanEpicQueue.mockReturnValue({
+      milestoneFilter: null,
+      totalEpicCount: 0,
+      consideredEpicCount: 0,
+      orderedEpics: [],
+      blockedEpics: [],
+      command: null,
+    });
   });
 
   afterEach(() => {
@@ -218,6 +227,85 @@ describe('roadmap command', () => {
     expect(mockCreateMilestone).not.toHaveBeenCalled();
     expect(mockSetIssueMilestone).not.toHaveBeenCalled();
     expect(mockAddIssueToProject).not.toHaveBeenCalled();
+  });
+
+  it('prints runnable command text and blocked epic notes for planned queue output', async () => {
+    const actualPlanning = jest.requireActual('../../src/lib/planning');
+    mockFormatEpicQueuePlan.mockImplementation(actualPlanning.formatEpicQueuePlan);
+    mockListOpenIssues.mockReturnValue([
+      { number: 205, title: 'Epic: Foundation', body: 'Epic body', labels: ['epic'], milestone: '001 - Existing Core' },
+      { number: 214, title: 'Epic: Follow-up', body: 'Depends on #205', labels: ['epic'], milestone: '001 - Existing Core' },
+      { number: 300, title: 'Epic: Blocked', body: 'Depends on #999', labels: ['epic'], milestone: '001 - Existing Core' },
+      { number: 305, title: 'Ready child', body: 'Child body', labels: ['ready'] },
+    ]);
+    mockListRoadmapEpics.mockReturnValue(SAMPLE_EPIC_CONTEXT);
+    mockListMilestones.mockReturnValue([
+      { number: 4, title: '001 - Existing Core', description: 'Core', openIssues: 0, closedIssues: 0, dueOn: null, state: 'open' },
+    ]);
+    mockPlanEpicQueue.mockReturnValue({
+      milestoneFilter: '001 - Existing Core',
+      totalEpicCount: 3,
+      consideredEpicCount: 3,
+      orderedEpics: [
+        {
+          issueNum: 205,
+          title: 'Epic: Foundation',
+          status: 'runnable',
+          readyChildCount: 1,
+          completedChildCount: 0,
+          blockedChildCount: 0,
+          totalChildCount: 1,
+          queueDependencies: [],
+          rationale: ['Child readiness: 1 ready'],
+          blockers: [],
+          risks: ['Likely file overlap with #214: src/lib/session.ts'],
+        },
+        {
+          issueNum: 214,
+          title: 'Epic: Follow-up',
+          status: 'runnable',
+          readyChildCount: 1,
+          completedChildCount: 0,
+          blockedChildCount: 0,
+          totalChildCount: 1,
+          queueDependencies: [205],
+          rationale: ['Queue dependencies: #205'],
+          blockers: [],
+          risks: ['Likely file overlap with #205: src/lib/session.ts'],
+        },
+      ],
+      blockedEpics: [
+        {
+          issueNum: 300,
+          title: 'Epic: Blocked',
+          status: 'blocked',
+          readyChildCount: 0,
+          completedChildCount: 0,
+          blockedChildCount: 1,
+          totalChildCount: 1,
+          queueDependencies: [],
+          rationale: [],
+          blockers: ['Open dependency #999 is outside the planned epic queue'],
+          risks: [],
+        },
+      ],
+      command: 'alpha-loop run --epics 205,214',
+    } as any);
+
+    await roadmapCommand({ queue: true, milestone: '001 - Existing Core' });
+
+    const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+    expect(output).toContain('Epic Queue Recommendation');
+    expect(output).toContain('Scope: milestone "001 - Existing Core"');
+    expect(output).toContain('Runnable Queue (2)');
+    expect(output).toContain('#205 Epic: Foundation');
+    expect(output).toContain('#214 Epic: Follow-up');
+    expect(output).toContain('Blocked Epics (1)');
+    expect(output).toContain('Open dependency #999 is outside the planned epic queue');
+    expect(output).toContain('alpha-loop run --epics 205,214');
+    expect(mockBuildRoadmapPrompt).not.toHaveBeenCalled();
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(mockSetIssueMilestone).not.toHaveBeenCalled();
   });
 
   it('creates milestones and assigns issues on happy path', async () => {

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -395,8 +395,8 @@ describe('runCommand', () => {
     }) as any);
 
     const issues = new Map([
-      [205, { number: 205, title: 'First Epic', body: '- [ ] #305 First child', labels: ['epic'], state: 'OPEN' }],
-      [166, { number: 166, title: 'Second Epic', body: '- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
+      [205, { number: 205, title: 'First Epic', body: 'Touches `src/lib/session.ts`.\n- [ ] #305 First child', labels: ['epic'], state: 'OPEN' }],
+      [166, { number: 166, title: 'Second Epic', body: 'Depends on #205. Also touches `src/lib/session.ts`.\n- [ ] #266 Second child', labels: ['epic'], state: 'OPEN' }],
       [214, { number: 214, title: 'Third Epic', body: '- [ ] #314 Third child', labels: ['epic'], state: 'OPEN' }],
       [305, { number: 305, title: 'First child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
       [266, { number: 266, title: 'Second child', body: 'Body', labels: ['ready'], state: 'OPEN' }],
@@ -443,6 +443,8 @@ describe('runCommand', () => {
         branchAncestryMode: 'stacked',
         branchedFromBranch: 'master',
         dependsOnSessionBranch: null,
+        dependencyWarnings: expect.arrayContaining(['Later queued epic #166 declares a dependency on this epic.']),
+        overlapWarnings: expect.arrayContaining(['Epics #205 and #166 both mention src/lib/session.ts.']),
       }),
       expect.objectContaining({
         queueIndex: 2,
@@ -454,6 +456,8 @@ describe('runCommand', () => {
         branchedFromBranch: 'session/epic-205',
         dependsOnSessionBranch: 'session/epic-205',
         rebaseOntoBranch: 'master',
+        dependencyWarnings: expect.arrayContaining(['Epic #166 declares a dependency on queued epic #205.']),
+        overlapWarnings: expect.arrayContaining(['Epics #205 and #166 both mention src/lib/session.ts.']),
       }),
       expect.objectContaining({
         queueIndex: 3,
@@ -523,6 +527,15 @@ describe('runCommand', () => {
         nextSessionPrUrl: null,
       },
     ]);
+    expect(manifest.epics[0].dependencyWarnings).toEqual(expect.arrayContaining([
+      'Later queued epic #166 declares a dependency on this epic.',
+    ]));
+    expect(manifest.epics[1].dependencyWarnings).toEqual(expect.arrayContaining([
+      'Epic #166 declares a dependency on queued epic #205.',
+    ]));
+    expect(manifest.epics[1].overlapWarnings).toEqual(expect.arrayContaining([
+      'Epics #205 and #166 both mention src/lib/session.ts.',
+    ]));
     expect(mockFinalizeSession.mock.calls.map((call) => (call[0] as any).queue?.queueIndex)).toEqual([1, 2, 3]);
     expect(mockExit).not.toHaveBeenCalled();
   });

--- a/tests/docs/epic-first-workflow.test.ts
+++ b/tests/docs/epic-first-workflow.test.ts
@@ -14,6 +14,8 @@ describe('epic-first workflow docs and help text', () => {
     expect(readme).toContain('`alpha-loop roadmap` schedules parent epic issues into milestones');
     expect(readme).toContain('`alpha-loop run --epic <N>` ships the epic\'s child issues in checklist order');
     expect(readme).toContain('Agents working on each child issue receive the parent epic goal, acceptance criteria, and sibling checklist as context');
+    expect(readme).toContain('`alpha-loop roadmap --queue` recommends the next ordered epic queue');
+    expect(readme).toContain('`alpha-loop run --epics <A,B,C>` runs several parent epics back-to-back');
   });
 
   it('docs/epics.md explains milestone scheduling and parent context for child agents', () => {
@@ -27,6 +29,27 @@ describe('epic-first workflow docs and help text', () => {
     expect(epicsDoc).toContain('the parent goal/body summary, parent acceptance criteria, and the full ordered sibling checklist');
   });
 
+  it('documents multi-epic queue behavior and inspection workflow', () => {
+    const readme = read('README.md');
+    const epicsDoc = read('docs/epics.md');
+
+    expect(readme).toContain('`alpha-loop run --epics <ids>`');
+    expect(readme).toContain('`alpha-loop roadmap --queue`');
+    expect(readme).toContain('`alpha-loop history queue-<timestamp>`');
+    expect(readme).toContain('`.alpha-loop/sessions/queue-<timestamp>/queue.json`');
+
+    expect(epicsDoc).toContain('## Multi-Epic Queues');
+    expect(epicsDoc).toContain('Use one epic when the work has one integrated goal');
+    expect(epicsDoc).toContain('Use a multi-epic queue when you want a long unattended run');
+    expect(epicsDoc).toContain('alpha-loop roadmap --queue');
+    expect(epicsDoc).toContain('alpha-loop run --epics 205,166,214');
+    expect(epicsDoc).toContain('Queue execution is fail-stop by default');
+    expect(epicsDoc).toContain('`stacked`');
+    expect(epicsDoc).toContain('`independent`');
+    expect(epicsDoc).toContain('rebase the next stacked session branch onto the base branch');
+    expect(epicsDoc).toContain('alpha-loop history queue-<timestamp>');
+  });
+
   it('CLI descriptions mention epic grouping and epic-aware roadmap scheduling', () => {
     const cli = read('src/cli.ts');
 
@@ -35,5 +58,8 @@ describe('epic-first workflow docs and help text', () => {
     expect(cli).toContain('Schedule parent epics and standalone issues into milestones using AI analysis');
     expect(cli).toContain('Recommend the next ordered epic run queue without making changes');
     expect(cli).toContain('Display proposed epic/standalone milestone assignments without making changes');
+    expect(cli).toContain('Process multiple epics in order (comma-separated issue numbers)');
+    expect(cli).toContain('Branch mode for --epics: stacked or independent');
+    expect(cli).toContain('View session and queue history');
   });
 });


### PR DESCRIPTION
## Code Review

warning: `--full-auto` is deprecated; use `--sandbox workspace-write` instead.
Reading prompt from stdin...
2026-05-21T23:12:06.472747Z ERROR codex_core::session: failed to load skill /Users/bradtaylor/Documents/GitHub/alpha-loop/.agents/skills/playwright-testing/SKILL.md: missing YAML frontmatter delimited by ---
OpenAI Codex v0.130.0
--------
workdir: /Users/bradtaylor/Documents/GitHub/alpha-loop
model: gpt-5.5
provider: openai
approval: never
sandbox: workspace-write [workdir, /tmp, $TMPDIR, /Users/bradtaylor/.codex/memories]
reasoning effort: xhigh
reasoning summaries: none
session id: 019e4ccf-7c34-7563-9649-0eee2d7d3f00
--------
user
Review the code changes for issue #216: docs: document and test multi-epic execution queues

Run git diff origin/master...HEAD to see what changed. Then read the actual files that were modified.

Original requirements:
## Diff
```diff
diff --git a/CLAUDE.md b/CLAUDE.md
index b43c5ce..d33bdcd 100644
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,14 @@ alpha-loop run           # Run the loop continuously
 alpha-loop run --once    # Process one issue and exit
 alpha-loop run --dry-run # Dry run (preview, no changes)
 alpha-loop run --epic <N>        # Process an epic (sub-issues in checklist order, auto-verify on completion)
+alpha-loop run --epics <ids>     # Process multiple epics in order, one session PR per epic
 alpha-loop run --verify-only <N> # Run just the epic verification pass
 alpha-loop scan          # Generate/refresh project context
 alpha-loop plan          # Generate project scope (milestones + issues) from seed inputs
 alpha-loop add           # Create a new issue from a free-form description using AI
 alpha-loop triage        # Analyze and improve existing issues
 alpha-loop roadmap       # Organize open issues into milestones
+alpha-loop roadmap --queue       # Recommend the next ordered epic run queue
 alpha-loop vision        # (deprecated) Use "alpha-loop plan" instead
 alpha-loop auth          # Save authenticated browser state
 alpha-loop resume        # Resume stranded work from crashed sessions
diff --git a/README.md b/README.md
index e936c6d..65ef019 100644
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ For planned feature work, use epics as the unit you schedule and ship:
 1. `alpha-loop triage` reviews open issues, proposes cleanup, and groups related ready issues into parent epics with ordered child checklists.
 2. `alpha-loop roadmap` schedules parent epic issues into milestones, while still scheduling standalone issues that are not part of an epic.
 3. `alpha-loop run --epic <N>` ships the epic's child issues in checklist order. Agents working on each child issue receive the parent epic goal, acceptance criteria, and sibling checklist as context.
-4. `alpha-loop run --verify-only <N>` re-runs the epic verification pass when you need to re-check shipped child issues against the parent acceptance criteria.
+4. `alpha-loop roadmap --queue` recommends the next ordered epic queue, explains blockers and risks, and prints the exact `alpha-loop run --epics ...` command.
+5. `alpha-loop run --epics <A,B,C>` runs several parent epics back-to-back in that exact order, with a separate session branch and PR for each epic.
+6. `alpha-loop run --verify-only <N>` re-runs the epic verification pass when you need to re-check shipped child issues against the parent acceptance criteria.
 
 Milestones answer "when should this epic ship?" The epic checklist answers "what child issues ship, and in what order?"
 
@@ -269,12 +271,15 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop run` | Fetch matching issues, process them all, then exit |
 | `alpha-loop run --dry-run` | Preview without making changes |
 | `alpha-loop run --epic <N>` | Process an epic — its sub-issues in checklist order, auto-verify on completion (see [docs/epics.md](docs/epics.md)) |
+| `alpha-loop run --epics <ids>` | Process an ordered comma-separated queue of epics, one session branch and PR per epic |
+| `alpha-loop run --epics <ids> --queue-branch-mode independent` | Run queued epics without stacking later session branches on earlier ones |
 | `alpha-loop run --verify-only <N>` | Run just the epic verification pass — evaluates merged PRs against acceptance criteria |
 | `alpha-loop scan` | Generate/refresh project context and instructions file |
 | `alpha-loop vision` | **(deprecated)** Use `alpha-loop plan` instead |
 | `alpha-loop auth` | Save authenticated browser state for verification |
-| `alpha-loop history` | View session history |
+| `alpha-loop history` | View session and queue history |
 | `alpha-loop history <name>` | View a specific session |
+| `alpha-loop history queue-<timestamp>` | Inspect a multi-epic queue manifest, including stopped/pending epics |
 | `alpha-loop history <name> --qa` | Show QA checklist for session |
 | `alpha-loop history <name> --telemetry` | Show per-stage telemetry table (see [docs/telemetry.md](docs/telemetry.md)) |
 | `alpha-loop history --clean` | Remove old session data |
@@ -308,6 +313,8 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop triage --dry-run` | Display cleanup findings and epic proposals without making changes |
 | `alpha-loop triage --yes` | Non-interactive mode: apply AI-selected cleanup actions and epic proposals |
 | `alpha-loop roadmap` | Schedule parent epics and standalone issues into milestones using AI analysis |
+| `alpha-loop roadmap --queue` | Recommend the next ordered epic run queue without making changes |
+| `alpha-loop roadmap --queue --milestone <name>` | Recommend an epic run queue within a release or sprint milestone |
 | `alpha-loop roadmap --dry-run` | Display proposed epic/standalone milestone assignments without making changes |
 | `alpha-loop roadmap --yes` | Non-interactive mode: apply all AI-recommended epic and standalone assignments |
 
@@ -329,6 +336,8 @@ Options:
   --batch             Batch mode: process multiple issues per agent call (faster, fewer tokens)
   --batch-size <n>    Issues per batch (default: 5)
   --epic <n>          Process a specific epic by issue number (skips the picker)
+  --epics <ids>       Process multiple epics in order (comma-separated)
+  --queue-branch-mode <mode>  Branch mode for --epics: stacked or independent
   --skip-epic         Skip epic discovery, use flat/milestone flow
   --verify-only <n>   Run only the verification pass on an existing epic
 ```
@@ -595,6 +604,23 @@ alpha-loop run --epic 165
 
 `alpha-loop run --milestone "v1.0"` checks for open epics assigned to that milestone before fetching flat issues. One scheduled epic is processed automatically, multiple scheduled epics require `--epic <N>`, and no scheduled epics falls back to ready non-epic issues in that milestone. `--epic` always wins over `--milestone`; `--skip-epic` disables epic discovery and preserves the flat milestone flow.
 
+To ask Alpha Loop what to run next, use queue planning:
+
+```bash
+alpha-loop roadmap --queue
+alpha-loop roadmap --queue --milestone "v1.0"
+```
+
+Queue planning is read-only. It inspects open `epic` issues, milestone assignments, checklist progress, child readiness labels, dependency phrases such as `depends on #N`, and likely file overlap. When a runnable queue exists, it prints an executable command like `alpha-loop run --epics 205,166,214`; blocked epics stay out of the command and are listed with their blockers.
+
+To run several epics unattended while keeping review scope separate, pass an explicit queue:
+
+```bash
+alpha-loop run --epics 205,166,214
+```
+
+The queue is validated before any work starts. Each listed issue must exist, be labeled `epic`, not be duplicated, and be open unless it is already closed as completed. Alpha Loop processes the epics in the given order, creates/finalizes one session branch and PR per epic, and stops on the first epic failure, verification gap, checklist consistency error, or transient agent/rate-limit stop. By default, queue sessions use `stacked` ancestry: later epic session branches start from the previous successful session branch while their PRs still target the configured base branch. Use `--queue-branch-mode independent` for unrelated epics that should all branch from the base branch. Non-dry-run queue attempts write `.alpha-loop/sessions/queue-<timestamp>/queue.json`; `alpha-loop history` lists those manifests and `alpha-loop history queue-<timestamp>` prints stopped/pending epics, session PRs, and rebase notes. `--dry-run` prints the validated queue without mutating GitHub or git state.
+
 Sub-issues are processed in checklist order (not issue-number order). Each sub-issue PR gets `Part of #165` appended, and the epic body's checkboxes auto-flip from `- [ ]` to `- [x]` as PRs merge. When every sub-issue has shipped, the loop runs a verification pass against each sub-issue's acceptance criteria — on `pass` the epic is auto-closed, on `partial` or `fail` it stays open with a `needs-human-input` label and a structured comment explaining the gaps.
 
 See [docs/epics.md](docs/epics.md) for the full feature reference, including `--verify-only`, the `prefer_epics` config option, skip rules, and safety rails.
@@ -639,6 +665,7 @@ What needs to be done.
 | `.alpha-loop/evals/` | Yes | Eval cases (YAML) and score history (`scores.jsonl`) |
 | `.alpha-loop/traces/` | No (gitignored) | Meta-Harness style execution traces per session |
 | `.alpha-loop/sessions/` | No (gitignored) | Local session logs, results JSON, screenshots |
+| `.alpha-loop/sessions/queue-<timestamp>/queue.json` | No (gitignored) | Multi-epic queue manifest with status, session PRs, merge order, and stop reason |
 | `.alpha-loop/auth/` | No (gitignored) | Saved browser auth state for verification |
 | `.worktrees/` | No (gitignored) | Temporary git worktrees during processing |
 
diff --git a/docs/epics.md b/docs/epics.md
index ad1f5bf..5a28311 100644
--- a/docs/epics.md
+++ b/docs/epics.md
@@ -121,6 +121,58 @@ alpha-loop run --skip-epic --milestone "v1.1"
 
 Skips epic discovery entirely and uses the flat milestone issue flow. Useful when you want to work on standalone issues in a milestone that also has scheduled parent epics.
 
+## Multi-Epic Queues
+
+Use one epic when the work has one integrated goal, one parent acceptance-criteria set, and one verification pass. Use a multi-epic queue when you want a long unattended run across several parent epics while keeping review scope separate. Each epic in the queue still produces its own session branch and session PR.
+
+There are two ways to build a queue:
+
+```bash
+alpha-loop roadmap --queue
+alpha-loop roadmap --queue --milestone "v1.1"
+```
+
+`roadmap --queue` is read-only. It inspects open epics, milestone order, child readiness, dependency phrases such as `depends on #N`, and likely file overlap. When at least one epic is runnable, it prints a command like:
+
+```bash
+alpha-loop run --epics 205,166,214
+```
+
+You can also provide the queue explicitly:
+
+```bash
+alpha-loop run --epics 205,166,214
+```
+
+Explicit queues are processed exactly in the order provided. Before any session starts, Alpha Loop validates that each issue exists, is labeled `epic`, is not duplicated, and is open unless already closed as completed. `--dry-run` performs the same validation and prints the queue without creating branches, PRs, GitHub comments, or queue manifests.
+
+### Execution Model
+
+For a non-dry-run queue, Alpha Loop writes:
+
+```text
+.alpha-loop/sessions/queue-<timestamp>/queue.json
+```
+
+The manifest records queue status, epic order, branch ancestry mode, per-epic session branch/PR URLs, dependency and overlap notes, failures, and the stop reason if the queue halts. `alpha-loop history` lists queue manifests alongside sessions, and `alpha-loop history queue-<timestamp>` prints the manifest details. If a queue stops, inspect that detail view to find the failed epic and the still-pending epics.
+
+Queue execution is fail-stop by default. Alpha Loop stops at the first epic that fails, remains incomplete after eligible children run, hits an epic checklist consistency error, fails verification, or encounters a transient agent/rate-limit stop. Earlier successful epic PRs stay available for review. Pending epics remain `pending` in `queue.json`; rerun them with a new explicit queue once the failure is resolved.
+
+If the process crashes inside a child issue before its branch has a PR, run `alpha-loop resume` to recover stranded `agent/issue-*` branches. Then inspect the queue manifest and continue with the remaining epic IDs.
+
+### Branch Ancestry Modes
+
+Queued epics always create separate session PRs that target the configured base branch. The branch ancestry controls where later session branches start.
+
+| Mode | Command | Branch behavior | When to use |
+|------|---------|-----------------|-------------|
+| `stacked` | `alpha-loop run --epics 205,166,214` | The first session branch starts from the base branch. Each later session branch starts from the previous successful session branch. | Related epics where later work may build on earlier queue changes. This is the default. |
+| `independent` | `alpha-loop run --epics 205,166,214 --queue-branch-mode independent` | Every session branch starts from the base branch. | Unrelated epics that only need queue order for scheduling or review coordination. |
+
+Stacked queue PRs include merge and rebase guidance. Merge the first session PR first. After it lands on the base branch, rebase the next stacked session branch onto the base branch before final review/merge, then repeat for the rest of the queue. Independent queue PRs should still be reviewed in queue order, but they can merge independently once ready because no branch ancestry dependency was created.
+
+Session PR bodies include an `Execution Queue` section with the queue ID, position, parent epic, previous/next epic, branch ancestry mode, dependency PR link, and risk notes. Dependency notes come from queued epic references such as `depends on #205`; overlap notes come from likely shared file paths mentioned in epic context.
+
 ## Sub-Issue Ordering
 
 Sub-issues are processed in the order they appear in the epic's task-list — **not** by issue number. To reorder, edit the epic body and rearrange the `- [ ] #N` lines.
diff --git a/src/cli.ts b/src/cli.ts
index c6bd916..8e2b7c0 100644
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,8 @@ program
   .option('--fix', 'Auto-fix validation issues (reorder deps, comment on incomplete issues)')
   .option('--verbose', 'Stream live agent output to terminal')
   .option('--epic <n>', 'Process a specific epic by issue number (skips the picker)', parseInt)
+  .option('--epics <ids>', 'Process multiple epics in order (comma-separated issue numbers)')
+  .option('--queue-branch-mode <mode>', 'Branch mode for --epics: stacked or independent')
   .option('--skip-epic', 'Skip epic discovery, use flat/milestone flow')
   .option('--verify-only <n>', 'Run only the verification pass on an existing epic', parseInt)
   .action(async (options) => {
@@ -49,7 +51,7 @@ program
 
 program
   .command('history [session]')
-  .description('View session history')
+  .description('View session and queue history')
   .option('--qa', 'Show QA checklist for session')
   .option('--clean', 'Remove old session data')
   .option('--telemetry', 'Show per-stage telemetry for a session')
@@ -130,6 +132,8 @@ program
 program
   .command('roadmap')
   .description('Schedule parent epics and standalone issues into milestones using AI analysis')
+  .option('--queue', 'Recommend the next ordered epic run queue without making changes')
+  .option('--milestone <name>', 'Limit queue recommendations to epics in a milestone')
   .option('--dry-run', 'Display proposed epic/standalone milestone assignments without making changes')
   .option('-y, --yes', 'Skip interactive prompts, accept all AI recommendations')
   .action(async (options) => {
diff --git a/src/commands/history.ts b/src/commands/history.ts
index 7032da4..d80937f 100644
--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -5,15 +5,24 @@ import { readStageTelemetry } from '../lib/telemetry.js';
 import type { StageTelemetry } from '../lib/telemetry.js';
 import type { PipelineResult } from '../lib/pipeline.js';
 import type { EscalationEvent } from '../lib/escalation.js';
+import type { EpicQueueManifest, QueueSessionContext } from '../lib/epic-queue.js';
 
 type SessionManifest = {
   name: string;
   branch: string;
   completed: string;
   results: PipelineResult[];
+  queue?: QueueSessionContext;
   stages?: StageTelemetry[];
 };
 
+type QueueManifestRef = {
+  dir: string;
+  name: string;
+  timestamp: string;
+  manifest: EpicQueueManifest;
+};
+
 function formatDuration(seconds: number | undefined): string {
   if (!seconds || seconds <= 0) return '';
   const mins = Math.floor(seconds / 60);
@@ -71,6 +80,55 @@ function findSessionDirs(sessionsRoot: string): Array<{ dir: string; name: strin
   return sessions;
 }
 
+function loadQueueManifest(filePath: string): EpicQueueManifest | null {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as EpicQueueManifest;
+    if (!manifest.queueId || !Array.isArray(manifest.epics)) return null;
+    return manifest;
+  } catch {
+    return null;
+  }
+}
+
+function queueTimestamp(queueId: string): string {
+  return queueId.startsWith('queue-') ? queueId.slice('queue-'.length) : queueId;
+}
+
+/**
+ * Find multi-epic queue manifests under .alpha-loop/sessions/queue-<timestamp>/queue.json.
+ */
+function findQueueManifests(sessionsRoot: string): QueueManifestRef[] {
+  if (!fs.existsSync(sessionsRoot)) return [];
+
+  const queues: QueueManifestRef[] = [];
+  for (const entry of fs.readdirSync(sessionsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith('queue-')) continue;
+    const dir = path.join(sessionsRoot, entry.name);
+    const manifest = loadQueueManifest(path.join(dir, 'queue.json'));
+    if (!manifest) continue;
+    const name = manifest.queueId || entry.name;
+    queues.push({
+      dir,
+      name,
+      timestamp: queueTimestamp(name),
+      manifest,
+    });
+  }
+
+  queues.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return queues;
+}
+
+function findQueueManifest(sessionsRoot: string, name: string): QueueManifestRef | undefined {
+  const wanted = name.trim();
+  if (!wanted) return undefined;
+  return findQueueManifests(sessionsRoot).find((queue) => (
+    queue.name === wanted ||
+    queue.timestamp === wanted ||
+    queue.name.endsWith(wanted)
+  ));
+}
+
 /**
  * Load session manifests from the learnings directory (checked into git, shared with team).
  * These are created during session finalization.
@@ -96,6 +154,7 @@ function loadManifests(projectDir?: string): Map<string, SessionManifest> {
 export function historyList(sessionsDir: string, projectDir?: string): void {
   const localSessions = findSessionDirs(sessionsDir);
   const manifests = loadManifests(projectDir);
+  const queues = findQueueManifests(sessionsDir);
 
   // Build a unified list: local sessions + manifests not covered by local data
   const seenNames = new Set(localSessions.map((s) => s.name));
@@ -129,42 +188,130 @@ export function historyList(sessionsDir: string, projectDir?: string): void {
   // Sort newest first
   entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 
-  if (entries.length === 0) {
+  if (entries.length === 0 && queues.length === 0) {
     console.log('No sessions found.');
     return;
   }
 
-  console.log('Sessions:');
+  if (entries.length > 0) {
+    console.log('Sessions:');
+    console.log('');
+
+    for (const entry of entries) {
+      const issueCount = entry.results.length;
+      const successCount = entry.results.filter((r) => r.status === 'success').length;
+      const failedCount = issueCount - successCount;
+      const totalDuration = entry.results.reduce((sum, r) => sum + r.duration, 0);
+      const durStr = formatDuration(totalDuration);
+
+      // Parse date from timestamp (YYYYMMDD-HHMMSS)
+      const ts = entry.timestamp;
+      const date = ts.length >= 8
+        ? `${ts.slice(0, 4)}-${ts.slice(4, 6)}-${ts.slice(6, 8)}`
+        : ts;
+
+      const issueWord = issueCount === 1 ? 'issue' : 'issues';
+      let statusParts = '';
+      if (successCount > 0) statusParts += `${successCount} \u2713`;
+      if (failedCount > 0) statusParts += ` ${failedCount} \u2717`;
+      if (issueCount === 0) statusParts = '(empty)';
+
+      console.log(
+        `  ${entry.name.padEnd(30)} ${date}  ${String(issueCount).padStart(2)} ${issueWord.padEnd(7)} ${statusParts.padEnd(10)} ${durStr}`,
+      );
+    }
+  }
+
+  if (queues.length > 0) {
+    if (entries.length > 0) console.log('');
+    console.log('Queues:');
+    console.log('');
+    for (const queue of queues) {
+      const manifest = queue.manifest;
+      const epicCount = manifest.epics.length;
+      const successCount = manifest.epics.filter((entry) => entry.status === 'success').length;
+      const failedCount = manifest.epics.filter((entry) => entry.status === 'failure').length;
+      const pendingCount = manifest.epics.filter((entry) => entry.status === 'pending' || entry.status === 'running').length;
+      const startedAt = manifest.startedAt ?? '';
+      const date = startedAt.length >= 10 ? startedAt.slice(0, 10) : queue.timestamp;
+      const epicWord = epicCount === 1 ? 'epic' : 'epics';
+      const status = `${manifest.status}${manifest.stopReason ? `: ${manifest.stopReason}` : ''}`;
+      console.log(
+        `  ${queue.name.padEnd(30)} ${date}  ${String(epicCount).padStart(2)} ${epicWord.padEnd(6)} ${successCount} ok, ${failedCount} failed, ${pendingCount} pending  ${status}`,
+      );
+    }
+  }
+}
+
+function formatQueueEpicStatus(status: string): string {
+  if (status === 'success') return 'success';
+  if (status === 'failure') return 'failed';
+  if (status === 'skipped') return 'skipped';
+  if (status === 'running') return 'running';
+  return 'pending';
+}
+
+function printQueueManifestDetail(queue: QueueManifestRef, projectDir?: string): void {
+  const root = projectDir ?? process.cwd();
+  const manifest = queue.manifest;
+  const manifestPath = path.relative(root, path.join(queue.dir, 'queue.json'));
+
+  console.log(`Queue:       ${manifest.queueId}`);
+  console.log(`Status:      ${manifest.status}`);
+  console.log(`Branch mode: ${manifest.branchAncestryMode}`);
+  console.log(`Started:     ${manifest.startedAt}`);
+  if (manifest.endedAt) console.log(`Ended:       ${manifest.endedAt}`);
+  if (manifest.stopReason) console.log(`Stop reason: ${manifest.stopReason}`);
+  console.log(`Manifest:    ${manifestPath}`);
   console.log('');
 
-  for (const entry of entries) {
-    const issueCount = entry.results.length;
-    const successCount = entry.results.filter((r) => r.status === 'success').length;
-    const failedCount = issueCount - successCount;
-    const totalDuration = entry.results.reduce((sum, r) => sum + r.duration, 0);
-    const durStr = formatDuration(totalDuration);
-
-    // Parse date from timestamp (YYYYMMDD-HHMMSS)
-    const ts = entry.timestamp;
-    const date = ts.length >= 8
-      ? `${ts.slice(0, 4)}-${ts.slice(4, 6)}-${ts.slice(6, 8)}`
-      : ts;
-
-    const issueWord = issueCount === 1 ? 'issue' : 'issues';
-    let statusParts = '';
-    if (successCount > 0) statusParts += `${successCount} \u2713`;
-    if (failedCount > 0) statusParts += ` ${failedCount} \u2717`;
-    if (issueCount === 0) statusParts = '(empty)';
+  console.log('Epics:');
+  for (const entry of manifest.epics) {
+    console.log(`  ${entry.queueIndex}/${entry.queueTotal} #${entry.epicNumber} ${entry.title} — ${formatQueueEpicStatus(entry.status)}`);
+    if (entry.sessionName) console.log(`           Session: ${entry.sessionName}`);
+    if (entry.sessionBranch) console.log(`           Branch:  ${entry.sessionBranch}`);
+    if (entry.sessionPrUrl) console.log(`           PR:      ${entry.sessionPrUrl}`);
+    if (entry.branchedFromBranch) console.log(`           From:    ${entry.branchedFromBranch}`);
+    if (entry.dependsOnSessionBranch) {
+      const pr = entry.dependsOnSessionPrUrl ? ` (${entry.dependsOnSessionPrUrl})` : '';
+      console.log(`           Depends: ${entry.dependsOnSessionBranch}${pr}`);
+    }
+    if (entry.rebaseOntoBranch) console.log(`           Rebase:  ${entry.sessionBranch ?? 'this branch'} onto ${entry.rebaseOntoBranch} after the dependency PR lands`);
+    for (const warning of entry.dependencyWarnings ?? []) console.log(`           Dependency: ${warning}`);
+    for (const warning of entry.overlapWarnings ?? []) console.log(`           File overlap: ${warning}`);
+    for (const failure of entry.failures ?? []) console.log(`           Failure: ${failure.code} — ${failure.message}`);
+  }
+}
 
-    console.log(
-      `  ${entry.name.padEnd(30)} ${date}  ${String(issueCount).padStart(2)} ${issueWord.padEnd(7)} ${statusParts.padEnd(10)} ${durStr}`,
-    );
+function printSessionQueueSummary(queue: QueueSessionContext): void {
+  console.log('');
+  console.log('Queue:');
+  console.log(`  ID:        ${queue.queueId}`);
+  console.log(`  Position:  ${queue.queueIndex} of ${queue.queueTotal}`);
+  console.log(`  Epic:      #${queue.currentEpic.number} ${queue.currentEpic.title}`);
+  console.log(`  Mode:      ${queue.branchAncestryMode}`);
+  console.log(`  From:      ${queue.branchedFromBranch}`);
+  if (queue.dependsOnSessionBranch) {
+    const pr = queue.dependsOnSessionPrUrl ? ` (${queue.dependsOnSessionPrUrl})` : '';
+    console.log(`  Depends:   ${queue.dependsOnSessionBranch}${pr}`);
+  }
+  if (queue.rebaseOntoBranch) {
+    console.log(`  Rebase:    onto ${queue.rebaseOntoBranch} after the dependency PR lands`);
   }
 }
 
-export function historyDetail(sessionsDir: string, sessionName: string): void {
+export function historyDetail(sessionsDir: string, sessionName: string, projectDir?: string): void {
+  const queue = findQueueManifest(sessionsDir, sessionName);
+  if (queue) {
+    printQueueManifestDetail(queue, projectDir);
+    return;
+  }
+
   let results: PipelineResult[] = [];
   let sessionDir: string | undefined;
+  let manifest: SessionManifest | undefined;
+  const root = projectDir ?? process.cwd();
+  const manifests = loadManifests(root);
 
   // Try local session directories first
   const localDir = path.join(sessionsDir, sessionName);
@@ -182,8 +329,7 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
 
   // Fall back to manifest from learnings (checked-in data from teammates)
   if (results.length === 0) {
-    const manifests = loadManifests();
-    const manifest = manifests.get(sessionName)
+    manifest = manifests.get(sessionName)
       ?? [...manifests.values()].find((m) => m.name.endsWith(sessionName));
     if (manifest) {
       results = manifest.results;
@@ -191,6 +337,9 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
     }
   }
 
+  manifest ??= manifests.get(sessionName)
+    ?? [...manifests.values()].find((m) => m.name === sessionName || m.name.endsWith(sessionName));
+
   if (results.length === 0) {
     log.error(`Session not found: ${sessionName}`);
     process.exitCode = 1;
@@ -205,6 +354,11 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
   console.log(`Duration: ${formatDuration(totalDuration)}`);
   console.log('');
 
+  if (manifest?.queue) {
+    printSessionQueueSummary(manifest.queue);
+    console.log('');
+  }
+
   // Stage-revert banner: if any issue in this session has an active revert event, flag it.
   const activeReverts = new Set<string>();
   for (const r of results) {
@@ -284,7 +438,7 @@ export function historyDetail(sessionsDir: string, sessionName: string): void {
   }
 
   // Check for session summary in learnings
-  const learningsDir = path.join(process.cwd(), '.alpha-loop', 'learnings');
+  const learningsDir = path.join(root, '.alpha-loop', 'learnings');
   const summaryName = `session-summary-${sessionName.replace(/\//g, '-')}.md`;
   const summaryPath = path.join(learningsDir, summaryName);
   if (fs.existsSync(summaryPath)) {
diff --git a/src/commands/roadmap.ts b/src/commands/roadmap.ts
index 0ec4ca2..f6759f2 100644
--- a/src/commands/roadmap.ts
+++ b/src/commands/roadmap.ts
@@ -14,8 +14,10 @@ import { exec } from '../lib/shell.js';
 import { log } from '../lib/logger.js';
 import {
   extractJsonFromResponse,
+  formatEpicQueuePlan,
   formatRoadmapTable,
   normalizeRoadmapPlan,
+  planEpicQueue,
   buildPlanningContext,
   type RoadmapPlan,
 } from '../lib/planning.js';
@@ -31,19 +33,28 @@ import {
 export type RoadmapOptions = {
   dryRun?: boolean;
   yes?: boolean;
+  queue?: boolean;
+  milestone?: string;
 };
 
 /** Truncate issue bodies to stay within agent context limits. */
 const MAX_BODY_CHARS = 500;
 
 export async function roadmapCommand(options: RoadmapOptions): Promise<void> {
-  const config = loadConfig({ dryRun: options.dryRun });
+  const configOverrides: NonNullable<Parameters<typeof loadConfig>[0]> = {};
+  if (options.queue) {
+    configOverrides.dryRun = true;
+    if (options.milestone) configOverrides.milestone = options.milestone;
+  } else if (options.dryRun !== undefined) {
+    configOverrides.dryRun = options.dryRun;
+  }
+  const config = loadConfig(configOverrides);
 
   // ── Fetch open issues ──────────────────────────────────────────────────────
   log.step('Fetching open issues...');
-  const issues = listOpenIssues(config.repo);
+  const issues = options.queue ? listOpenIssues(config.repo, 1000) : listOpenIssues(config.repo);
 
-  if (issues.length === 0) {
+  if (issues.length === 0 && !options.queue) {
     log.info('No open issues found. Nothing to organize.');
     return;
   }
@@ -59,6 +70,20 @@ export async function roadmapCommand(options: RoadmapOptions): Promise<void> {
   const existingMilestones = listMilestones(config.repo);
   log.info(`Found ${existingMilestones.length} existing milestone(s)`);
 
+  if (options.queue) {
+    const plan = planEpicQueue(epics, {
+      labelReady: config.labelReady,
+      milestone: options.milestone ?? null,
+      openIssues: issues,
+      milestones: existingMilestones,
+    });
+    console.log('');
+    console.log(formatEpicQueuePlan(plan));
+    console.log('');
+    log.dry('Queue planning only — no changes will be made.');
+    return;
+  }
+
   const epicIssueNums = new Set(epics.map((epic) => epic.issueNum));
   const epicChildIssueNums = new Set(epics.flatMap((epic) => epic.children.map((child) => child.issueNum)));
   const standaloneIssues = issues.filter((issue) => (
diff --git a/src/commands/run.ts b/src/commands/run.ts
index e75e4c5..3de32fb 100644
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -31,7 +31,21 @@ import { spawnAgent } from '../lib/agent.js';
 import { buildSessionReviewPrompt, type EpicPromptContext } from '../lib/prompts.js';
 import { writeTraceToSubdir } from '../lib/traces.js';
 import { readFileSync, existsSync, renameSync, unlinkSync } from 'node:fs';
-import { validateIssueQueue, printValidationReport, commentOnIncompleteIssues, type ValidationReport } from '../lib/validation.js';
+import { validateIssueQueue, printValidationReport, commentOnIncompleteIssues, parseDependencies, type ValidationReport } from '../lib/validation.js';
+import {
+  createEpicQueueManifest,
+  createEpicQueueValidationFailureManifest,
+  parseEpicQueue,
+  validateEpicQueue,
+  writeQueueManifest,
+  type BranchAncestryMode,
+  type EpicQueueManifest,
+  type EpicQueueManifestEntry,
+  type EpicQueueManifestFailure,
+  type QueueEpicLink,
+  type QueueSessionContext,
+  type ValidatedEpicQueueEntry,
+} from '../lib/epic-queue.js';
 
 export type RunOptions = {
   dryRun?: boolean;
@@ -49,10 +63,66 @@ export type RunOptions = {
   fix?: boolean;
   /** Force a specific epic by number, skip picker. */
   epic?: number;
+  /** Process multiple epics in the provided comma-separated order. */
+  epics?: string;
+  /** Branch ancestry mode for multi-epic queues. */
+  queueBranchMode?: BranchAncestryMode;
   /** Skip the epic picker entirely, use flat/milestone flow. */
   skipEpic?: boolean;
   /** Run only the verification pass on an existing epic. */
   verifyOnly?: number;
+  /** Internal queue mode: treat an unfinished epic as a queue-stopping failure. */
+  stopOnPartialEpic?: boolean;
+};
+
+export type EpicExecutionFailureCode =
+  | 'invalid-epic-number'
+  | 'epic-not-found'
+  | 'missing-epic-label'
+  | 'no-eligible-child-issues'
+  | 'checklist-update-failed'
+  | 'issue-processing-error'
+  | 'batch-processing-error'
+  | 'pipeline-failure'
+  | 'transient-stop'
+  | 'epic-verification-failed'
+  | 'epic-incomplete'
+  | 'epic-run-error';
+
+export type EpicExecutionFailure = {
+  code: EpicExecutionFailureCode;
+  message: string;
+  issueNum?: number;
+  exitCode?: number;
+};
+
+export type EpicExecutionResult = {
+  epicNumber: number;
+  sessionName: string | null;
+  sessionBranch: string | null;
+  sessionPrUrl: string | null;
+  status: 'success' | 'failure';
+  failures: EpicExecutionFailure[];
+  verificationClosedEpic: boolean;
+};
+
+type EpicVerificationFlowResult = {
+  epicNumber: number;
+  status: 'pass' | 'needs-human-input' | 'skipped' | 'failure';
+  closedEpic: boolean;
+  verdict?: string;
+  failure?: EpicExecutionFailure;
+};
+
+type SessionExecutionTarget =
+  | { type: 'epic'; epicNum: number; epicTitle?: string; epicIssue: Issue; queue?: QueueSessionContext }
+  | { type: 'flat'; activeMilestone: string };
+
+type SessionExecutionResult = {
+  session: SessionContext;
+  sessionPrUrl: string | null;
+  failures: EpicExecutionFailure[];
+  verificationClosedEpic: boolean;
 };
 
 /**
@@ -276,32 +346,6 @@ async function pickTarget(
 async function resolveRunTarget(config: Config, options: RunOptions): Promise<ResolvedRunTarget | null> {
   let activeMilestone = config.milestone;
 
-  // --epic <N> overrides everything except --verify-only
-  if (options.epic !== undefined) {
-    if (typeof options.epic !== 'number' || !Number.isFinite(options.epic) || options.epic <= 0) {
-      log.error('--epic requires a positive integer issue number (e.g. --epic 165)');
-      process.exit(1);
-      return null;
-    }
-    const epic = getIssueWithComments(config.repo, options.epic);
-    if (!epic) {
-      log.error(`Could not fetch epic #${options.epic}`);
-      process.exit(1);
-      return null;
-    }
-    if (!hasEpicLabel(epic)) {
-      log.error(`Issue #${options.epic} is not labeled 'epic'. Add the epic label before running --epic.`);
-      process.exit(1);
-      return null;
-    }
-    return {
-      activeEpic: epic.number,
-      activeEpicTitle: epic.title,
-      activeEpicIssue: epic,
-      activeMilestone: '',
-    };
-  }
-
   if (activeMilestone && options.skipEpic !== true) {
     const scheduledEpics = listEpics(config.repo, { milestone: activeMilestone });
 
@@ -362,21 +406,32 @@ async function runEpicVerificationFlow(
   epicNum: number,
   config: Config,
   session: SessionContext | null,
-): Promise<void> {
+): Promise<EpicVerificationFlowResult> {
   const epic = getIssueWithComments(config.repo, epicNum);
   if (!epic) {
-    log.error(`Could not fetch epic #${epicNum}`);
-    return;
+    const message = `Could not fetch epic #${epicNum}`;
+    log.error(message);
+    return {
+      epicNumber: epicNum,
+      status: 'failure',
+      closedEpic: false,
+      failure: { code: 'epic-not-found', message },
+    };
   }
   if (!hasEpicLabel(epic)) {
-    log.error(`Issue #${epicNum} is not labeled 'epic'. Add the epic label before running epic verification.`);
-    process.exit(1);
-    return;
+    const message = `Issue #${epicNum} is not labeled 'epic'. Add the epic label before running epic verification.`;
+    log.error(message);
+    return {
+      epicNumber: epicNum,
+      status: 'failure',
+      closedEpic: false,
+      failure: { code: 'missing-epic-label', message, issueNum: epicNum, exitCode: 1 },
+    };
   }
   const refs = getEpicSubIssues(config.repo, epicNum);
   if (refs.length === 0) {
     log.warn(`Epic #${epicNum} has no sub-issues in its checklist — nothing to verify`);
-    return;
+    return { epicNumber: epicNum, status: 'skipped', closedEpic: false };
   }
 
   const subIssues: Issue[] = [];
@@ -401,16 +456,33 @@ async function runEpicVerificationFlow(
   if (config.dryRun) {
     log.dry(`[verify-only] Would post comment on #${epicNum} (verdict=${result.verdict})`);
     console.error(result.comment);
-    return;
+    return {
+      epicNumber: epicNum,
+      status: result.verdict === 'pass' ? 'pass' : 'needs-human-input',
+      closedEpic: false,
+      verdict: result.verdict,
+    };
   }
 
   commentIssue(config.repo, epicNum, result.comment);
   if (result.verdict === 'pass') {
     closeIssue(config.repo, epicNum, 'completed');
     log.success(`Epic #${epicNum} verified and closed`);
+    return {
+      epicNumber: epicNum,
+      status: 'pass',
+      closedEpic: true,
+      verdict: result.verdict,
+    };
   } else {
     labelIssue(config.repo, epicNum, 'needs-human-input');
     log.warn(`Epic #${epicNum} needs human review: verdict=${result.verdict}`);
+    return {
+      epicNumber: epicNum,
+      status: 'needs-human-input',
+      closedEpic: false,
+      verdict: result.verdict,
+    };
   }
 }
 
@@ -538,49 +610,18 @@ function markEpicChecklistItem(
   if (contextItem) contextItem.checked = checked;
 }
 
-/**
- * Run the main loop: poll for issues, process them, finalize session.
- */
-export async function runCommand(options: RunOptions): Promise<void> {
-  // Build config from YAML + env + CLI flags
-  const overrides: Partial<Config> = {};
-  if (options.dryRun) overrides.dryRun = true;
-  if (options.model) overrides.model = options.model;
-  if (options.skipTests) overrides.skipTests = true;
-  if (options.skipReview) overrides.skipReview = true;
-  if (options.skipLearn) overrides.skipLearn = true;
-  if (options.milestone) overrides.milestone = options.milestone;
-  if (options.autoMerge) overrides.autoMerge = true;
-  if (options.mergeTo) overrides.mergeTo = options.mergeTo;
-  if (options.batch) overrides.batch = true;
-  if (options.batchSize) overrides.batchSize = options.batchSize;
-  if (options.verbose) overrides.verbose = true;
-
-  const config = loadConfig(overrides);
-
-  if (!config.repo) {
-    log.error('No repository configured. Run "alpha-loop init" or set repo in .alpha-loop.yaml');
-    process.exit(1);
-  }
-
-  // --- Verify-only path: bypass the normal loop entirely ---
-  if (options.verifyOnly !== undefined) {
-    if (!Number.isFinite(options.verifyOnly) || options.verifyOnly <= 0) {
-      log.error('--verify-only requires a positive integer issue number (e.g. --verify-only 165)');
-      process.exit(1);
-    }
-    log.step(`Running verify-only pass for epic #${options.verifyOnly}`);
-    await runEpicVerificationFlow(options.verifyOnly, config, null);
-    return;
-  }
-
-  // --- Target selection (epic or milestone) — must happen before session creation ---
-  const target = await resolveRunTarget(config, options);
-  if (!target) return;
-  let activeEpic = target.activeEpic;
-  let activeEpicTitle = target.activeEpicTitle;
-  let activeEpicIssue = target.activeEpicIssue;
-  const activeMilestone = target.activeMilestone;
+async function runIssueSession(
+  config: Config,
+  options: RunOptions,
+  target: SessionExecutionTarget,
+): Promise<SessionExecutionResult> {
+  const activeEpic = target.type === 'epic' ? target.epicNum : undefined;
+  const activeEpicTitle = target.type === 'epic' ? target.epicTitle : undefined;
+  const activeEpicIssue = target.type === 'epic' ? target.epicIssue : undefined;
+  const queueContext = target.type === 'epic' ? target.queue : undefined;
+  const activeMilestone = target.type === 'flat' ? target.activeMilestone : '';
+  const failures: EpicExecutionFailure[] = [];
+  let verificationClosedEpic = false;
 
   if (activeEpic !== undefined) {
     log.info(`Processing epic #${activeEpic}${activeEpicTitle ? ': ' + activeEpicTitle : ''}`);
@@ -593,6 +634,7 @@ export async function runCommand(options: RunOptions): Promise<void> {
     milestone: activeMilestone || undefined,
     epicNum: activeEpic,
     epicTitle: activeEpicTitle,
+    queue: queueContext,
   });
 
   // Print startup banner
@@ -637,8 +679,10 @@ export async function runCommand(options: RunOptions): Promise<void> {
     process.exit(0);
   };
 
-  process.on('SIGINT', () => { void cleanup(); });
-  process.on('SIGTERM', () => { void cleanup(); });
+  const handleSigint = () => { void cleanup(); };
+  const handleSigterm = () => { void cleanup(); };
+  process.on('SIGINT', handleSigint);
+  process.on('SIGTERM', handleSigterm);
 
   // Sync agent assets to all configured harnesses before starting the loop
   const syncResult = syncAgentAssets(resolveHarnesses(config.harnesses, config.agent));
@@ -708,37 +752,34 @@ export async function runCommand(options: RunOptions): Promise<void> {
   let epicPromptContext: EpicPromptContext | undefined;
   if (activeEpic !== undefined) {
     log.info(`Fetching sub-issues of epic #${activeEpic} in checklist order...`);
-    if (!activeEpicIssue) {
-      const epic = getIssueWithComments(config.repo, activeEpic);
-      if (!epic) {
-        log.error(`Could not fetch epic #${activeEpic}`);
-        process.exit(1);
-      }
-      activeEpicIssue = epic;
-      activeEpicTitle = epic.title;
-    }
-
-    epicChecklist = parseEpicChecklistForPrompt(activeEpicIssue.body);
-    issues = [];
-    for (const ref of epicChecklist) {
-      if (ref.checked) continue; // already done
-      const sub = getIssueWithComments(config.repo, ref.issueNum);
-      if (!sub) {
-        log.warn(`Sub-issue #${ref.issueNum} skipped: could not fetch`);
-        continue;
-      }
-      ref.title = ref.title ?? sub.title;
-      if (hasEpicLabel(sub)) {
-        log.warn(`Sub-issue #${sub.number} skipped: is itself an epic (nested epics unsupported in v1)`);
-        continue;
-      }
-      if (!sub.labels.includes(config.labelReady)) {
-        log.warn(`Sub-issue #${sub.number} skipped: not labeled '${config.labelReady}'`);
-        continue;
+    const epicIssue = activeEpicIssue;
+    if (!epicIssue) {
+      const message = `Could not fetch epic #${activeEpic}`;
+      failures.push({ code: 'epic-not-found', message, issueNum: activeEpic, exitCode: 1 });
+      issues = [];
+    } else {
+      epicChecklist = parseEpicChecklistForPrompt(epicIssue.body);
+      issues = [];
+      for (const ref of epicChecklist) {
+        if (ref.checked) continue; // already done
+        const sub = getIssueWithComments(config.repo, ref.issueNum);
+        if (!sub) {
+          log.warn(`Sub-issue #${ref.issueNum} skipped: could not fetch`);
+          continue;
+        }
+        ref.title = ref.title ?? sub.title;
+        if (hasEpicLabel(sub)) {
+          log.warn(`Sub-issue #${sub.number} skipped: is itself an epic (nested epics unsupported in v1)`);
+          continue;
+        }
+        if (!sub.labels.includes(config.labelReady)) {
+          log.warn(`Sub-issue #${sub.number} skipped: not labeled '${config.labelReady}'`);
+          continue;
+        }
+        issues.push(sub);
       }
-      issues.push(sub);
+      epicPromptContext = buildEpicPromptContextFromIssue(epicIssue, epicChecklist);
     }
-    epicPromptContext = buildEpicPromptContextFromIssue(activeEpicIssue, epicChecklist);
   } else {
     const milestoneMsg = activeMilestone ? ` in milestone '${activeMilestone}'` : '';
     log.info(`Fetching issues${milestoneMsg}...`);
@@ -754,6 +795,14 @@ export async function runCommand(options: RunOptions): Promise<void> {
 
   if (issues.length === 0) {
     log.info('No issues found. Nothing to do.');
+    const uncheckedEpicItems = epicChecklist.filter((item) => !item.checked).length;
+    if (activeEpic !== undefined && (epicChecklist.length === 0 || uncheckedEpicItems > 0)) {
+      failures.push({
+        code: 'no-eligible-child-issues',
+        message: `Epic #${activeEpic} has no eligible child issues to process`,
+        issueNum: activeEpic,
+      });
+    }
   } else {
     const issueLimit = config.maxIssues > 0 ? Math.min(issues.length, config.maxIssues) : issues.length;
     let issuesToProcess = issues.slice(0, issueLimit);
@@ -845,7 +894,9 @@ export async function runCommand(options: RunOptions): Promise<void> {
                 updateEpicChecklist(config.repo, activeEpic, r.issueNum, true);
                 markEpicChecklistItem(epicChecklist, epicPromptContext, r.issueNum, true);
               } catch (err) {
-                log.error(`Epic #${activeEpic} checklist update failed for sub-issue #${r.issueNum}: ${err instanceof Error ? err.message : err}`);
+                const message = `Epic #${activeEpic} checklist update failed for sub-issue #${r.issueNum}: ${err instanceof Error ? err.message : err}`;
+                log.error(message);
+                failures.push({ code: 'checklist-update-failed', message, issueNum: r.issueNum });
                 // One-agent-per-epic contract — halt further processing on body inconsistency
                 epicAbort = true;
                 checklistError = true;
@@ -870,7 +921,9 @@ export async function runCommand(options: RunOptions): Promise<void> {
             break;
           }
         } catch (err) {
-          log.error(`Failed to process batch ${batchIdx + 1}: ${err}`);
+          const message = `Failed to process batch ${batchIdx + 1}: ${err}`;
+          log.error(message);
+          failures.push({ code: 'batch-processing-error', message });
         }
 
         activeIssueNum = null;
@@ -920,7 +973,9 @@ export async function runCommand(options: RunOptions): Promise<void> {
               updateEpicChecklist(config.repo, activeEpic, issue.number, true);
               markEpicChecklistItem(epicChecklist, epicPromptContext, issue.number, true);
             } catch (err) {
-              log.error(`Epic #${activeEpic} checklist update failed for sub-issue #${issue.number}: ${err instanceof Error ? err.message : err}`);
+              const message = `Epic #${activeEpic} checklist update failed for sub-issue #${issue.number}: ${err instanceof Error ? err.message : err}`;
+              log.error(message);
+              failures.push({ code: 'checklist-update-failed', message, issueNum: issue.number });
               // One-agent-per-epic contract — halt further processing on body inconsistency
               epicAbort = true;
               activeIssueNum = null;
@@ -936,7 +991,9 @@ export async function runCommand(options: RunOptions): Promise<void> {
             break;
           }
         } catch (err) {
-          log.error(`Failed to process issue #${issue.number}: ${err}`);
+          const message = `Failed to process issue #${issue.number}: ${err}`;
+          log.error(message);
+          failures.push({ code: 'issue-processing-error', message, issueNum: issue.number });
         }
 
         activeIssueNum = null;
@@ -950,12 +1007,46 @@ export async function runCommand(options: RunOptions): Promise<void> {
       const remaining = epicChecklist.filter((r) => !r.checked);
       if (remaining.length === 0) {
         log.step(`All sub-issues of epic #${activeEpic} are complete — running verification pass`);
-        await runEpicVerificationFlow(activeEpic, config, session);
+        const verification = await runEpicVerificationFlow(activeEpic, config, session);
+        verificationClosedEpic = verification.closedEpic;
+        if (verification.failure) {
+          failures.push(verification.failure);
+        } else if (verification.status === 'needs-human-input') {
+          failures.push({
+            code: 'epic-verification-failed',
+            message: `Epic #${activeEpic} verification needs human review: verdict=${verification.verdict ?? 'unknown'}`,
+            issueNum: activeEpic,
+          });
+        }
       } else {
-        log.info(`Epic #${activeEpic}: ${remaining.length} sub-issue(s) still open — verification deferred`);
+        const message = `Epic #${activeEpic}: ${remaining.length} sub-issue(s) still open — verification deferred`;
+        log.info(message);
+        const hasFailedIssueResult = session.results.some((result) => result.status === 'failure');
+        if (options.stopOnPartialEpic && !hasFailedIssueResult) {
+          failures.push({
+            code: 'epic-incomplete',
+            message,
+            issueNum: activeEpic,
+          });
+        }
       }
     } catch (err) {
-      log.warn(`Epic completion check failed: ${err instanceof Error ? err.message : err}`);
+      const message = `Epic completion check failed: ${err instanceof Error ? err.message : err}`;
+      log.warn(message);
+      failures.push({ code: 'epic-verification-failed', message, issueNum: activeEpic });
+    }
+  }
+
+  for (const result of session.results) {
+    if (result.status === 'failure') {
+      const transient = result.failureReason === 'transient';
+      failures.push({
+        code: transient ? 'transient-stop' : 'pipeline-failure',
+        message: transient
+          ? `Issue #${result.issueNum} stopped due to a transient agent or rate-limit failure`
+          : `Issue #${result.issueNum} failed during processing`,
+        issueNum: result.issueNum,
+      });
     }
   }
 
@@ -1132,8 +1223,495 @@ export async function runCommand(options: RunOptions): Promise<void> {
   }
 
   // Finalize session
-  await finalizeSession(session, config);
+  const finalizedPrUrl = await finalizeSession(session, config);
+  const sessionPrUrl = finalizedPrUrl ?? session.sessionPrUrl ?? null;
 
   const successCount = session.results.filter((r) => r.status === 'success').length;
   log.info(`Session complete: ${successCount}/${session.results.length} issues succeeded`);
+  process.off('SIGINT', handleSigint);
+  process.off('SIGTERM', handleSigterm);
+
+  return {
+    session,
+    sessionPrUrl,
+    failures,
+    verificationClosedEpic,
+  };
+}
+
+function buildEpicFailureResult(epicNumber: number, failure: EpicExecutionFailure): EpicExecutionResult {
+  return {
+    epicNumber,
+    sessionName: null,
+    sessionBranch: null,
+    sessionPrUrl: null,
+    status: 'failure',
+    failures: [failure],
+    verificationClosedEpic: false,
+  };
+}
+
+export async function runSingleEpicExecution(args: {
+  config:
... (diff truncated)
```

## Review Checklist

### 1. Functional Completeness (MOST IMPORTANT)
- Does the implementation FULLY address the issue requirements?
- Are there any acceptance criteria that were NOT implemented?
- If backend API endpoints were created, are they called from the frontend?
- If frontend components were created, do they have working backend endpoints?
- Are there any dead code paths (created but never wired in)?
- Does the feature work end-to-end (data flows from UI → API → database → back to UI)?

### 2. Dependency Wiring (CRITICAL — most common source of silent failures)
- For every service, repo, or dependency the new code USES:
  1. Is it instantiated somewhere? (e.g., in a bootstrap function, DI container, or factory)
  2. Is it actually PASSED to the consumer? Check function call sites — not just that the parameter exists.
  3. RED FLAG: If a parameter defaults to None and code guards with "if x is not None" — this may silently hide missing injection. The guard makes tests pass but the feature is dead.
- For new routes: Are static routes (e.g., /evals/compare) registered BEFORE parameterized routes (e.g., /evals/{id})? Parameterized routes shadow static ones in most frameworks.
- For new data consumers (scripts, eval engines, dashboards): Trace the data back to its source. If a script queries a table, verify that something actually WRITES to that table in the production pipeline.
- For metrics and cost tracking: Are values computed from real data or estimated/hardcoded? Hardcoded "0" or len()//4 estimates violate data accuracy if displayed as real metrics.

### 3. Code Quality
- Security issues (injection, XSS, auth bypass)
- Missing error handling for user-facing operations
- Missing tests for new functionality
- Code follows project conventions

### 4. Documentation Sync
- If CLI commands were added/changed: is README.md updated? CLAUDE.md? --help text in cli.ts?
- If config options were added/changed: is README.md Configuration Reference updated?
- If directory structure changed: is CLAUDE.md Directory Structure updated?
- Never leave docs referencing commands, options, or paths that no longer exist.

### 5. UX Review
- Do UI changes match the target user profile?
- Are error states handled (loading, empty, error)?
- Is the feature discoverable (can users find it)?

## Actions

For any issues you find:
- CRITICAL (gaps, missing wiring, broken features): FIX THEM directly, run tests, commit with "fix: address review findings for #216"
- WARNING (quality, security): FIX THEM directly if possible
- INFO (suggestions, minor improvements): Note them in your report but don't block

## Gate Result (REQUIRED)

After your review, write a JSON file to: review-issue-216.json

The file must contain ONLY valid JSON with this exact schema:

{
  "passed": true,
  "summary": "One-line summary of review outcome",
  "findings": [
    {
      "severity": "critical",
      "description": "What the issue is",
      "fixed": true,
      "file": "path/to/affected/file.ts"
    }
  ]
}

Rules:
- passed: true if all critical/warning issues were fixed. false if any remain unfixed.
- findings: list ALL issues found, with fixed=true for ones you fixed, fixed=false for ones you could not fix.
- severity: "critical" for blockers, "warning" for should-fix, "info" for notes.
- If you fixed everything and the code is clean, set passed=true with an empty findings array.
- If there are unfixed critical/warning issues, set passed=false — the implementer will be sent back to fix them.
2026-05-21T23:12:06.949195Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: prompt must be at most 128 characters path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/build-ios-apps/.codex-plugin/plugin.json
2026-05-21T23:12:06.949572Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/plugin-eval/.codex-plugin/plugin.json
2026-05-21T23:12:06.951980Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/twilio-developer-kit/.codex-plugin/plugin.json
2026-05-21T23:12:06.952054Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/openai-developers/.codex-plugin/plugin.json
2026-05-21T23:12:07.775783Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: prompt must be at most 128 characters path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/build-ios-apps/.codex-plugin/plugin.json
2026-05-21T23:12:07.775982Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/plugin-eval/.codex-plugin/plugin.json
2026-05-21T23:12:07.777374Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/twilio-developer-kit/.codex-plugin/plugin.json
2026-05-21T23:12:07.777398Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/openai-developers/.codex-plugin/plugin.json
2026-05-21T23:12:07.786377Z  WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'
2026-05-21T23:12:07.786384Z  WARN codex_core_skills::loader: ignoring interface.icon_large: icon path must not contain '..'
2026-05-21T23:12:07.786725Z  WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'
2026-05-21T23:12:07.786730Z  WARN codex_core_skills::loader: ignoring interface.icon_large: icon path must not contain '..'
2026-05-21T23:12:07.787116Z  WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'
2026-05-21T23:12:07.787120Z  WARN codex_core_skills::loader: ignoring interface.icon_large: icon path must not contain '..'
2026-05-21T23:12:07.787465Z  WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'
2026-05-21T23:12:07.787470Z  WARN codex_core_skills::loader: ignoring interface.icon_large: icon path must not contain '..'
2026-05-21T23:12:07.787795Z  WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'
2026-05-21T23:12:07.787799Z  WARN codex_core_skills::loader: ignoring interface.icon_large: icon path must not contain '..'
2026-05-21T23:12:07.788431Z  WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'
2026-05-21T23:12:07.788439Z  WARN codex_core_skills::loader: ignoring interface.icon_large: icon path must not contain '..'
2026-05-21T23:12:07.808935Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/openai-developers/.codex-plugin/plugin.json
2026-05-21T23:12:07.811686Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/openai-developers/.codex-plugin/plugin.json
2026-05-21T23:12:07.811727Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/openai-developers/.codex-plugin/plugin.json
2026-05-21T23:12:08.650945Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: prompt must be at most 128 characters path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/build-ios-apps/.codex-plugin/plugin.json
2026-05-21T23:12:08.651162Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/plugin-eval/.codex-plugin/plugin.json
2026-05-21T23:12:08.652733Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/twilio-developer-kit/.codex-plugin/plugin.json
2026-05-21T23:12:08.652759Z  WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt: maximum of 3 prompts is supported path=/Users/bradtaylor/.codex/.tmp/plugins/plugins/openai-developers/.codex-plugin/plugin.json
2026-05-21T23:12:08.663529Z  WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'
2026-05-21T23:12:08.663536Z  WARN codex_core_skills::loader: ignoring interface.icon_large: icon path must not contain '..'
2026-05-21T23:12:08.663933Z  WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'
2026-05-21T23:12:08.663936Z  WARN codex_core_skills::loader: ignoring interface.icon_large: icon path must not contain '..'
2026-05-21T23:12:08.664352Z  WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'
2026-05-21T23:12:08.664355Z  WARN codex_core_skil

... (body truncated, see full log)