### PR TITLE
feat: bug: syncDir's 'delete files in target not in source' semantics silently destroys harness-only skills/files (root-caused via alpha-research PR #196) (closes #185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,9 @@ During live verification, the agent takes screenshots at key states and saves th
 | `alpha-loop history <name> --telemetry` | Show per-stage telemetry table (see [docs/telemetry.md](docs/telemetry.md)) |
 | `alpha-loop history --clean` | Remove old session data |
 | `alpha-loop report routing` | Aggregate per-stage telemetry + cost-per-issue across sessions |
-| `alpha-loop sync` | Sync templates to configured harnesses (Claude, Codex, Cursor, etc.) |
+| `alpha-loop sync` | Add/update templated assets in configured harnesses without deleting harness-only files |
+| `alpha-loop sync --check` | Check for drift, including target-only harness files, without writing changes |
+| `alpha-loop sync --prune` | Sync templates and remove target-only harness files after logging each pruned path |
 | `alpha-loop resume` | Resume stranded work — push branches, review, open WIP PRs |
 | `alpha-loop resume --issue <N>` | Resume a specific issue |
 | `alpha-loop review` | Analyze learnings and propose self-improvements |
@@ -498,6 +500,8 @@ harnesses:
   - codex
   - claude  # also sync to Claude for teammates using it
 ```
+
+Sync is additive by default: `alpha-loop sync` copies new or changed files from `.alpha-loop/templates/` into each harness path, but it leaves harness-only skills and support files in place. Use `alpha-loop sync --check` to detect strict drift, including target-only files, and `alpha-loop sync --prune` only when you explicitly want to remove files from harness paths that are not present in templates.
 
 ### Per-Step Pipeline Config
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,7 @@ program
   .command('sync')
   .description('Sync .alpha-loop/templates/ to all configured harnesses')
   .option('--check', 'Check for drift without syncing (exits non-zero if drift found)')
+  .option('--prune', 'Remove target-only harness files that are not present in templates')
   .action(syncCommand);
 
 program

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -409,7 +409,7 @@ async function applyChanges(
   }
 
   // Sync skills to all configured harnesses so editor copies stay current
-  const syncResult = syncAgentAssets(config.harnesses, { projectDir });
+  const syncResult = syncAgentAssets(config.harnesses, { projectDir, prune: false });
   if (syncResult.synced) {
     log.success('Synced agent assets after applying changes');
   }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -23,7 +23,7 @@ import {
   rmSync,
   renameSync,
 } from 'node:fs';
-import { join, relative } from 'node:path';
+import { join } from 'node:path';
 import { log } from '../lib/logger.js';
 import { loadConfig } from '../lib/config.js';
 
@@ -103,39 +103,71 @@ const LEGACY_SKILLS_DIR = 'skills';
 const LEGACY_CLAUDE_AGENTS_DIR = '.claude/agents';
 
 // ---------------------------------------------------------------------------
-// Helper functions (kept exactly as before)
+// Helper functions
 // ---------------------------------------------------------------------------
 
+type SyncDirOptions = {
+  prune?: boolean;
+};
+
 /**
- * Recursively copy a directory, deleting files in target that don't exist in source.
+ * Return every file that will be removed when pruning a target-only path.
+ * Empty directories are included so every rmSync has a visible WARN line.
  */
-function syncDir(src: string, dest: string): void {
+function collectPrunedPaths(targetPath: string): string[] {
+  const stat = statSync(targetPath);
+  if (!stat.isDirectory()) return [targetPath];
+
+  const entries = readdirSync(targetPath);
+  if (entries.length === 0) return [targetPath];
+
+  return entries.flatMap((entry) => collectPrunedPaths(join(targetPath, entry)));
+}
+
+/**
+ * Recursively copy a directory from source to target.
+ *
+ * Default sync is additive: target-only files are preserved. Pass
+ * { prune: true } to remove target entries that do not exist in source.
+ */
+function syncDir(src: string, dest: string, options: SyncDirOptions = {}): boolean {
+  const destExists = existsSync(dest);
   mkdirSync(dest, { recursive: true });
+  let changed = !destExists;
 
   const srcEntries = new Set(readdirSync(src));
 
-  // Delete files in dest that don't exist in src
-  if (existsSync(dest)) {
+  // Delete files in dest that don't exist in src only when explicitly requested.
+  if (options.prune && existsSync(dest)) {
     for (const entry of readdirSync(dest)) {
       if (!srcEntries.has(entry)) {
         const destPath = join(dest, entry);
+        for (const prunedPath of collectPrunedPaths(destPath)) {
+          log.warn(`Pruning untemplated file: ${prunedPath}`);
+        }
         rmSync(destPath, { recursive: true, force: true });
+        changed = true;
       }
     }
   }
 
-  // Copy from src to dest
+  // Copy from src to dest when content is missing or out of date.
   for (const entry of srcEntries) {
     const srcPath = join(src, entry);
     const destPath = join(dest, entry);
     const stat = statSync(srcPath);
 
     if (stat.isDirectory()) {
-      syncDir(srcPath, destPath);
+      changed = syncDir(srcPath, destPath, options) || changed;
     } else {
-      copyFileSync(srcPath, destPath);
+      if (!filesMatch(srcPath, destPath)) {
+        copyFileSync(srcPath, destPath);
+        changed = true;
+      }
     }
   }
+
+  return changed;
 }
 
 /**
@@ -256,9 +288,9 @@ export type SyncResult = {
  */
 export function syncAgentAssets(
   harnesses: string[],
-  options: { check?: boolean; projectDir?: string } = {}
+  options: { check?: boolean; projectDir?: string; prune?: boolean } = {}
 ): SyncResult {
-  const { check = false, projectDir = process.cwd() } = options;
+  const { check = false, projectDir = process.cwd(), prune = false } = options;
   const result: SyncResult = { synced: false, docSynced: false, skillsDirs: [] };
 
   const sources = resolveTemplateSources(projectDir);
@@ -281,13 +313,16 @@ export function syncAgentAssets(
         if (check) {
           log.warn(`Drift [${harness}]: ${config.skillsDir} differs from template skills/`);
         } else {
-          syncDir(sources.skillsDir, targetSkills);
-          log.info(`Synced [${harness}] skills/ → ${config.skillsDir}`);
+          const changed = syncDir(sources.skillsDir, targetSkills, { prune });
+          if (changed) {
+            log.info(`Synced [${harness}] skills/ → ${config.skillsDir}`);
+            if (!result.skillsDirs.includes(config.skillsDir)) {
+              result.skillsDirs.push(config.skillsDir);
+            }
+            result.synced = true;
+          }
         }
-        if (!result.skillsDirs.includes(config.skillsDir)) {
-          result.skillsDirs.push(config.skillsDir);
-        }
-        result.synced = true;
+        if (check) result.synced = true;
       }
     }
 
@@ -298,10 +333,13 @@ export function syncAgentAssets(
         if (check) {
           log.warn(`Drift [${harness}]: ${config.agentsDir} differs from template agents/`);
         } else {
-          syncDir(sources.agentsDir, targetAgents);
-          log.info(`Synced [${harness}] agents/ → ${config.agentsDir}`);
+          const changed = syncDir(sources.agentsDir, targetAgents, { prune });
+          if (changed) {
+            log.info(`Synced [${harness}] agents/ → ${config.agentsDir}`);
+            result.synced = true;
+          }
         }
-        result.synced = true;
+        if (check) result.synced = true;
       }
     }
 
@@ -393,7 +431,7 @@ export function migrateToTemplates(projectDir: string = process.cwd()): void {
  * Reads harness list from the caller-supplied options (populated from
  * .alpha-loop.yaml) and delegates to syncAgentAssets.
  */
-export function syncCommand(options: { check?: boolean; harnesses?: string[] } = {}): void {
+export function syncCommand(options: { check?: boolean; prune?: boolean; harnesses?: string[] } = {}): void {
   const projectDir = process.cwd();
 
   // Load harnesses from options or fall back to config file, auto-deriving from agent if needed
@@ -418,12 +456,12 @@ export function syncCommand(options: { check?: boolean; harnesses?: string[] } =
     return;
   }
 
-  const result = syncAgentAssets(harnesses, { check: options.check, projectDir });
+  const result = syncAgentAssets(harnesses, { check: options.check, prune: options.prune, projectDir });
 
   if (!result.synced) {
     log.success('Agent assets are in sync.');
   } else if (options.check) {
-    log.error('Drift detected. Run "alpha-loop sync" to resolve.');
+    log.error('Drift detected. Run "alpha-loop sync" to update templated files or "alpha-loop sync --prune" to remove target-only files.');
     process.exit(1);
   } else {
     log.success('Agent assets synced.');

--- a/tests/commands/review.test.ts
+++ b/tests/commands/review.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { reviewCommand } from '../../src/commands/review';
+import { loadConfig } from '../../src/lib/config';
+import { spawnAgent } from '../../src/lib/agent';
+import { exec } from '../../src/lib/shell';
+import { createPR } from '../../src/lib/github';
+
+jest.mock('../../src/lib/config', () => ({
+  loadConfig: jest.fn(),
+}));
+
+jest.mock('../../src/lib/agent', () => ({
+  spawnAgent: jest.fn(),
+}));
+
+jest.mock('../../src/lib/shell', () => ({
+  exec: jest.fn(),
+  formatTimestamp: jest.fn(() => '2026-05-26-120000'),
+}));
+
+jest.mock('../../src/lib/github', () => ({
+  createPR: jest.fn(),
+}));
+
+jest.mock('../../src/lib/templates', () => ({
+  findDistributionTemplatesDir: jest.fn(() => null),
+  diffSkills: jest.fn(() => []),
+  diffAgents: jest.fn(() => []),
+}));
+
+jest.mock('../../src/lib/logger', () => ({
+  log: {
+    info: jest.fn(),
+    success: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    step: jest.fn(),
+    dry: jest.fn(),
+    debug: jest.fn(),
+    rate: jest.fn(),
+  },
+}));
+
+const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
+const mockSpawnAgent = spawnAgent as jest.MockedFunction<typeof spawnAgent>;
+const mockExec = exec as jest.MockedFunction<typeof exec>;
+const mockCreatePR = createPR as jest.MockedFunction<typeof createPR>;
+
+function makeTempProject(): string {
+  return mkdtempSync(join(tmpdir(), 'alpha-loop-review-sync-'));
+}
+
+describe('reviewCommand', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = makeTempProject();
+    jest.spyOn(process, 'cwd').mockReturnValue(projectDir);
+    jest.clearAllMocks();
+
+    mockLoadConfig.mockReturnValue({
+      repo: 'owner/repo',
+      baseBranch: 'master',
+      model: 'gpt-test',
+      reviewModel: 'gpt-review',
+      harnesses: ['claude-code'],
+    } as ReturnType<typeof loadConfig>);
+    mockExec.mockReturnValue({ stdout: '', stderr: '', exitCode: 0 });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/1');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test('keeps harness-only files when review apply syncs templates', async () => {
+    const learningsDir = join(projectDir, '.alpha-loop', 'learnings');
+    mkdirSync(learningsDir, { recursive: true });
+    writeFileSync(
+      join(learningsDir, 'session-test.md'),
+      [
+        '---',
+        'status: success',
+        'retries: 0',
+        'duration: 5',
+        '---',
+        '## What Worked',
+        'Sync should be additive.',
+      ].join('\n'),
+    );
+
+    const templateSkillDir = join(projectDir, '.alpha-loop', 'templates', 'skills', 'safe-sync');
+    mkdirSync(templateSkillDir, { recursive: true });
+    writeFileSync(join(templateSkillDir, 'SKILL.md'), '# Safe Sync v1');
+
+    const harnessOnlySkillDir = join(projectDir, '.claude', 'skills', 'harness-only');
+    mkdirSync(harnessOnlySkillDir, { recursive: true });
+    writeFileSync(join(harnessOnlySkillDir, 'SKILL.md'), '# Harness Only');
+
+    mockSpawnAgent.mockResolvedValue({
+      exitCode: 0,
+      output: JSON.stringify([
+        {
+          path: '.alpha-loop/templates/skills/safe-sync/SKILL.md',
+          content: '# Safe Sync v2',
+          reason: 'Keep sync additive by default.',
+          category: 'skill',
+        },
+      ]),
+      duration: 1,
+    });
+
+    await reviewCommand({ apply: true });
+
+    expect(readFileSync(join(harnessOnlySkillDir, 'SKILL.md'), 'utf-8')).toBe('# Harness Only');
+    expect(readFileSync(join(projectDir, '.claude', 'skills', 'safe-sync', 'SKILL.md'), 'utf-8')).toBe('# Safe Sync v2');
+  });
+});

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { syncAgentAssets } from '../../src/commands/sync';
+import { log } from '../../src/lib/logger';
 
 jest.mock('../../src/lib/logger', () => ({
   log: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), success: jest.fn() },
@@ -14,6 +15,10 @@ function makeTmpDir(): string {
 }
 
 describe('syncAgentAssets', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('syncs skills from .alpha-loop/templates/ to harness paths', () => {
     const dir = makeTmpDir();
     const templatesBase = join(dir, '.alpha-loop', 'templates');
@@ -227,6 +232,63 @@ describe('syncAgentAssets', () => {
     const result = syncAgentAssets(['claude-code'], { projectDir: dir });
 
     expect(result.synced).toBe(false);
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('preserves target-only harness files by default', () => {
+    const dir = makeTmpDir();
+    const templatesBase = join(dir, '.alpha-loop', 'templates');
+    mkdirSync(join(templatesBase, 'skills', 'a'), { recursive: true });
+    writeFileSync(join(templatesBase, 'skills', 'a', 'SKILL.md'), '# Same');
+    mkdirSync(join(dir, '.claude', 'skills', 'a'), { recursive: true });
+    writeFileSync(join(dir, '.claude', 'skills', 'a', 'SKILL.md'), '# Same');
+    mkdirSync(join(dir, '.claude', 'skills', 'harness-only'), { recursive: true });
+    writeFileSync(join(dir, '.claude', 'skills', 'harness-only', 'SKILL.md'), '# Harness Only');
+
+    const result = syncAgentAssets(['claude-code'], { projectDir: dir });
+
+    expect(result.synced).toBe(false);
+    expect(readFileSync(join(dir, '.claude', 'skills', 'harness-only', 'SKILL.md'), 'utf-8')).toBe('# Harness Only');
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('check mode reports target-only harness files as drift without deleting them', () => {
+    const dir = makeTmpDir();
+    const templatesBase = join(dir, '.alpha-loop', 'templates');
+    mkdirSync(join(templatesBase, 'skills', 'a'), { recursive: true });
+    writeFileSync(join(templatesBase, 'skills', 'a', 'SKILL.md'), '# Same');
+    mkdirSync(join(dir, '.claude', 'skills', 'a'), { recursive: true });
+    writeFileSync(join(dir, '.claude', 'skills', 'a', 'SKILL.md'), '# Same');
+    mkdirSync(join(dir, '.claude', 'skills', 'harness-only'), { recursive: true });
+    writeFileSync(join(dir, '.claude', 'skills', 'harness-only', 'SKILL.md'), '# Harness Only');
+
+    const result = syncAgentAssets(['claude-code'], { check: true, projectDir: dir });
+
+    expect(result.synced).toBe(true);
+    expect(readFileSync(join(dir, '.claude', 'skills', 'harness-only', 'SKILL.md'), 'utf-8')).toBe('# Harness Only');
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('removes target-only harness files only when prune is enabled', () => {
+    const dir = makeTmpDir();
+    const templatesBase = join(dir, '.alpha-loop', 'templates');
+    mkdirSync(join(templatesBase, 'skills', 'a'), { recursive: true });
+    writeFileSync(join(templatesBase, 'skills', 'a', 'SKILL.md'), '# Same');
+    mkdirSync(join(dir, '.claude', 'skills', 'a'), { recursive: true });
+    writeFileSync(join(dir, '.claude', 'skills', 'a', 'SKILL.md'), '# Same');
+    mkdirSync(join(dir, '.claude', 'skills', 'harness-only', 'references'), { recursive: true });
+    writeFileSync(join(dir, '.claude', 'skills', 'harness-only', 'SKILL.md'), '# Harness Only');
+    writeFileSync(join(dir, '.claude', 'skills', 'harness-only', 'references', 'guide.md'), '# Guide');
+
+    const result = syncAgentAssets(['claude-code'], { projectDir: dir, prune: true });
+
+    expect(result.synced).toBe(true);
+    expect(existsSync(join(dir, '.claude', 'skills', 'harness-only'))).toBe(false);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(join('.claude', 'skills', 'harness-only', 'SKILL.md')));
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(join('.claude', 'skills', 'harness-only', 'references', 'guide.md')));
 
     rmSync(dir, { recursive: true, force: true });
   });


### PR DESCRIPTION
Closes #185
Part of #244

## Summary

Automated implementation of **bug: syncDir's 'delete files in target not in source' semantics silently destroys harness-only skills/files (root-caused via alpha-research PR #196)**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Passed after fixing review-apply staging to avoid unrelated harness-only files.

- **WARNING** [FIXED] `src/commands/review.ts`: review --apply staged whole harness directories after additive sync, which could include preserved harness-only untracked files in generated PRs.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*