### PR TITLE
feat: bug: project-board warnings flood epic runs when board metadata can't resolve (closes #237)

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -364,6 +364,21 @@ export function mergePR(repo: string, head: string, method: 'squash' | 'merge' =
   log.info(`PR #${prNum} merged`);
 }
 
+function projectFailureReason(message: string, detail?: string): string {
+  const trimmed = detail?.trim();
+  return trimmed ? `${message}: ${trimmed}` : message;
+}
+
+function disableProjectStatus(owner: string, projectNum: number, reason: string): void {
+  const existing = getProjectCache(owner, projectNum);
+  if (existing?.disabled) {
+    return;
+  }
+
+  setProjectCache(owner, projectNum, { disabled: true, reason });
+  log.warn(`Project board #${projectNum} disabled for this session: ${reason}`);
+}
+
 /**
  * Update project board status for an issue.
  * This is a multi-step operation using gh project commands.
@@ -375,15 +390,27 @@ export function updateProjectStatus(
   issueNum: number,
   status: string,
 ): void {
-  // ── Resolve project metadata (cached after first call) ────────────────
+  if (!projectNum || projectNum <= 0) {
+    return;
+  }
+
+  // ── Resolve project metadata (cached on success, disabled on failure) ─
   let cache = getProjectCache(owner, projectNum);
+  if (cache?.disabled) {
+    return;
+  }
+
   if (!cache) {
     // Fetch field list (contains field IDs and option IDs)
     const fieldResult = ghExec(
       `gh project field-list ${projectNum} --owner "${owner}" --format json`,
     );
     if (fieldResult.exitCode !== 0) {
-      log.warn(`Could not list project fields: ${fieldResult.stderr}`);
+      disableProjectStatus(
+        owner,
+        projectNum,
+        projectFailureReason('Could not list project fields', fieldResult.stderr),
+      );
       return;
     }
 
@@ -405,12 +432,12 @@ export function updateProjectStatus(
         }
       }
     } catch {
-      log.warn('Failed to parse project fields');
+      disableProjectStatus(owner, projectNum, 'Failed to parse project fields');
       return;
     }
 
     if (!fieldId || optionMap.size === 0) {
-      log.warn('Could not resolve project Status field');
+      disableProjectStatus(owner, projectNum, 'Could not resolve project Status field');
       return;
     }
 
@@ -419,7 +446,11 @@ export function updateProjectStatus(
       `gh project view ${projectNum} --owner "${owner}" --format json`,
     );
     if (projectResult.exitCode !== 0) {
-      log.warn(`Could not view project: ${projectResult.stderr}`);
+      disableProjectStatus(
+        owner,
+        projectNum,
+        projectFailureReason('Could not view project', projectResult.stderr),
+      );
       return;
     }
 
@@ -428,12 +459,12 @@ export function updateProjectStatus(
       const data = JSON.parse(projectResult.stdout) as { id: string };
       projectId = data.id;
     } catch {
-      log.warn('Failed to parse project data');
+      disableProjectStatus(owner, projectNum, 'Failed to parse project data');
       return;
     }
 
     if (!projectId) {
-      log.warn('Could not get project ID');
+      disableProjectStatus(owner, projectNum, 'Could not get project ID');
       return;
     }
 
@@ -442,10 +473,14 @@ export function updateProjectStatus(
     log.debug(`Cached project metadata for ${owner}/${projectNum}`);
   }
 
+  if (cache.disabled) {
+    return;
+  }
+
   // ── Resolve option ID for the requested status ──────────────────────
   const optionId = cache.optionMap.get(status);
   if (!optionId) {
-    log.warn(`Could not resolve project option for status '${status}'`);
+    disableProjectStatus(owner, projectNum, `Could not resolve project option for status '${status}'`);
     return;
   }
 
@@ -459,7 +494,11 @@ export function updateProjectStatus(
     `gh project item-add ${projectNum} --owner "${owner}" --url "${issueUrl}" --format json`,
   );
   if (itemResult.exitCode !== 0) {
-    log.warn(`Could not resolve project item for #${issueNum}: ${itemResult.stderr}`);
+    disableProjectStatus(
+      owner,
+      projectNum,
+      projectFailureReason(`Could not resolve project item for #${issueNum}`, itemResult.stderr),
+    );
     return;
   }
 
@@ -468,12 +507,12 @@ export function updateProjectStatus(
     const data = JSON.parse(itemResult.stdout) as { id: string };
     itemId = data.id;
   } catch {
-    log.warn('Failed to parse project item response');
+    disableProjectStatus(owner, projectNum, 'Failed to parse project item response');
     return;
   }
 
   if (!itemId) {
-    log.warn(`Could not find project item for issue #${issueNum}`);
+    disableProjectStatus(owner, projectNum, `Could not find project item for issue #${issueNum}`);
     return;
   }
 
@@ -483,7 +522,11 @@ export function updateProjectStatus(
     undefined, true,
   );
   if (editResult.exitCode !== 0) {
-    log.warn(`Failed to update project status for #${issueNum}: ${editResult.stderr}`);
+    disableProjectStatus(
+      owner,
+      projectNum,
+      projectFailureReason(`Failed to update project status for #${issueNum}`, editResult.stderr),
+    );
     return;
   }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -207,11 +207,19 @@ export function ghExec(
 
 // ── Project metadata cache ──────────────────────────────────────────────────
 
-type ProjectCache = {
+type ResolvedProjectCache = {
+  disabled?: false;
   projectId: string;
   fieldId: string;
   optionMap: Map<string, string>; // status name → option ID
 };
+
+type DisabledProjectCache = {
+  disabled: true;
+  reason: string;
+};
+
+type ProjectCache = ResolvedProjectCache | DisabledProjectCache;
 
 const projectCacheMap = new Map<string, ProjectCache>();
 

--- a/tests/lib/github.test.ts
+++ b/tests/lib/github.test.ts
@@ -3,7 +3,7 @@ import {
   createIssue, updateIssue, closeIssue, createMilestone,
   setIssueMilestone, listOpenIssues, addIssueToProject,
   getIssueBody, updateEpicIssueBody, commentChildEpicBacklink,
-  listRoadmapEpics, listEpics, getEpicSubIssues,
+  listRoadmapEpics, listEpics, getEpicSubIssues, updateProjectStatus,
 } from '../../src/lib/github';
 
 jest.mock('../../src/lib/shell', () => ({
@@ -26,11 +26,20 @@ jest.mock('../../src/lib/logger', () => ({
 // Mock ghExec to delegate to the already-mocked exec from shell.ts
 jest.mock('../../src/lib/rate-limit', () => {
   const shell = require('../../src/lib/shell');
+  const projectCache = new Map<string, unknown>();
+  const projectKey = (owner: string, projectNum: number) => `${owner}/${projectNum}`;
+
   return {
     ghExec: jest.fn((cmd: string) => shell.exec(cmd)),
-    getProjectCache: jest.fn(() => null),
-    setProjectCache: jest.fn(),
-    clearProjectCache: jest.fn(),
+    getProjectCache: jest.fn(
+      (owner: string, projectNum: number) => projectCache.get(projectKey(owner, projectNum)) ?? null,
+    ),
+    setProjectCache: jest.fn((owner: string, projectNum: number, cache: unknown) => {
+      projectCache.set(projectKey(owner, projectNum), cache);
+    }),
+    clearProjectCache: jest.fn(() => {
+      projectCache.clear();
+    }),
     resetRateLimitState: jest.fn(),
     getRateLimitStatus: jest.fn(() => ({ remaining: 5000, limit: 5000, used: 0, resetAt: 0, ratio: 1 })),
     parseRateLimitHeaders: jest.fn(() => null),
@@ -44,6 +53,8 @@ const mockExec = exec as jest.MockedFunction<typeof exec>;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  const { clearProjectCache } = require('../../src/lib/rate-limit');
+  clearProjectCache();
   mockExec.mockReturnValue({ stdout: '', stderr: '', exitCode: 0 });
 });
 
@@ -308,6 +319,95 @@ describe('mergePR', () => {
     expect(mockLog.warn).toHaveBeenCalledWith(
       expect.stringContaining('No PR found'),
     );
+  });
+});
+
+describe('updateProjectStatus', () => {
+  test('returns without gh calls when project number is not configured', () => {
+    updateProjectStatus('owner/repo', 0, 'owner', 42, 'In progress');
+    updateProjectStatus('owner/repo', -1, 'owner', 42, 'In Review');
+
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  test('disables project board once when field list fails across epic transitions', () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('gh project field-list')) {
+        return { stdout: '', stderr: 'missing project scope', exitCode: 1 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    for (let issueNum = 1; issueNum <= 5; issueNum += 1) {
+      updateProjectStatus('owner/repo', 2, 'owner', issueNum, 'In progress');
+      updateProjectStatus('owner/repo', 2, 'owner', issueNum, 'In Review');
+    }
+
+    const projectCalls = mockExec.mock.calls.filter(
+      ([cmd]) => typeof cmd === 'string' && cmd.includes('gh project'),
+    );
+    const fieldListCalls = mockExec.mock.calls.filter(
+      ([cmd]) => typeof cmd === 'string' && cmd.includes('gh project field-list'),
+    );
+    const { log: mockLog } = require('../../src/lib/logger');
+
+    expect(fieldListCalls).toHaveLength(1);
+    expect(projectCalls).toHaveLength(1);
+    expect(mockLog.warn).toHaveBeenCalledTimes(1);
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      'Project board #2 disabled for this session: Could not list project fields: missing project scope',
+    );
+  });
+
+  test('updates project item status when project metadata resolves', () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('gh project field-list')) {
+        return {
+          stdout: JSON.stringify({
+            fields: [
+              {
+                id: 'field-id',
+                name: 'Status',
+                options: [
+                  { id: 'todo-id', name: 'Todo' },
+                  { id: 'progress-id', name: 'In progress' },
+                  { id: 'review-id', name: 'In Review' },
+                ],
+              },
+            ],
+          }),
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      if (cmd.includes('gh project view')) {
+        return { stdout: JSON.stringify({ id: 'project-id' }), stderr: '', exitCode: 0 };
+      }
+      if (cmd.includes('gh project item-add')) {
+        return { stdout: JSON.stringify({ id: 'item-id' }), stderr: '', exitCode: 0 };
+      }
+      if (cmd.includes('gh project item-edit')) {
+        return { stdout: '', stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 1 };
+    });
+
+    updateProjectStatus('owner/repo', 2, 'owner', 42, 'In progress');
+
+    const commands = mockExec.mock.calls.map(([cmd]) => cmd as string);
+    const { log: mockLog } = require('../../src/lib/logger');
+
+    expect(commands.some((cmd) => cmd.includes('gh project field-list 2'))).toBe(true);
+    expect(commands.some((cmd) => cmd.includes('gh project view 2'))).toBe(true);
+    expect(commands.some((cmd) => cmd.includes('gh project item-add 2'))).toBe(true);
+    expect(commands.some((cmd) => cmd.includes('gh project item-edit'))).toBe(true);
+    expect(commands.find((cmd) => cmd.includes('gh project item-edit'))).toContain('--project-id "project-id"');
+    expect(commands.find((cmd) => cmd.includes('gh project item-edit'))).toContain('--field-id "field-id"');
+    expect(commands.find((cmd) => cmd.includes('gh project item-edit'))).toContain(
+      '--single-select-option-id "progress-id"',
+    );
+    expect(mockLog.warn).not.toHaveBeenCalled();
+    expect(mockLog.info).toHaveBeenCalledWith('Project board: #42 -> In progress');
   });
 });
 

--- a/tests/lib/rate-limit.test.ts
+++ b/tests/lib/rate-limit.test.ts
@@ -178,8 +178,16 @@ describe('project metadata cache', () => {
     const cache2 = { projectId: 'p2', fieldId: 'f2', optionMap: new Map() };
     setProjectCache('owner1', 1, cache1);
     setProjectCache('owner2', 1, cache2);
-    expect(getProjectCache('owner1', 1)?.projectId).toBe('p1');
-    expect(getProjectCache('owner2', 1)?.projectId).toBe('p2');
+    expect(getProjectCache('owner1', 1)).toMatchObject({ projectId: 'p1' });
+    expect(getProjectCache('owner2', 1)).toMatchObject({ projectId: 'p2' });
+  });
+
+  it('stores and retrieves disabled project metadata', () => {
+    const cache = { disabled: true as const, reason: 'Could not resolve project Status field' };
+
+    setProjectCache('owner', 1, cache);
+
+    expect(getProjectCache('owner', 1)).toBe(cache);
   });
 
   it('clears all cached data', () => {


### PR DESCRIPTION
Closes #237
Part of #244

## Summary

Automated implementation of **bug: project-board warnings flood epic runs when board metadata can't resolve**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Project-board warning suppression meets issue #237 acceptance criteria; no blocking findings.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*