### PR TITLE
feat: Repo hygiene: gitignore codex plugins/ directory (closes #233)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .worktrees/
+plugins/
 sessions/
 .alpha-loop/sessions/
 .alpha-loop/traces/

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -525,6 +525,7 @@ const GITIGNORE_ENTRIES = [
   '.alpha-loop/auth/',
   '.alpha-loop/templates/*.bak',
   '.worktrees/',
+  'plugins/',
 ];
 
 function ensureGitignore(): void {

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -225,6 +225,7 @@ describe('init command', () => {
     expect(gitignore).toContain('.alpha-loop/sessions/');
     expect(gitignore).toContain('.alpha-loop/auth/');
     expect(gitignore).toContain('.worktrees/');
+    expect(gitignore).toContain('plugins/');
     expect(gitignore).toContain('.alpha-loop/templates/*.bak');
   });
 


### PR DESCRIPTION
Closes #233
Part of #245

## Summary

Automated implementation of **Repo hygiene: gitignore codex plugins/ directory**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Issue #233 passes review: plugins/ is ignored in the repo and init-generated gitignore, with no tracked plugins files.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*