### PR TITLE
feat: Test config: exclude .worktrees/ in templates/jest.config.cjs (closes #231)

### DIFF
--- a/docs/epics.md
+++ b/docs/epics.md
@@ -160,6 +160,10 @@ Queue execution is fail-stop by default. Alpha Loop stops at the first epic that
 
 If the process crashes inside a child issue before its branch has a PR, run `alpha-loop resume` to recover stranded `agent/issue-*` branches as WIP PRs. Recovered PRs are not marked complete; run the project tests and final verification before merging, then inspect the queue manifest and continue with the remaining epic IDs.
 
+### Test Discovery
+
+Alpha Loop creates full project copies under `.worktrees/` while processing issues. If you maintain a custom Jest, Vitest, Mocha, or other test-runner config, exclude `.worktrees/` from test discovery before running epic queues or parallel issue work. Otherwise a parent-repo test run can discover stale or duplicate tests from sibling worktrees. The bundled Jest template ignores `.worktrees/` with `testPathIgnorePatterns`.
+
 ### Branch Ancestry Modes
 
 Queued epics always create separate session PRs that target the configured base branch. The branch ancestry controls where later session branches start.

--- a/templates/jest.config.cjs
+++ b/templates/jest.config.cjs
@@ -1,0 +1,20 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>'],
+  testMatch: ['**/*.test.ts', '**/*.test.tsx'],
+  testPathIgnorePatterns: ['/node_modules/', '/.worktrees/'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      useESM: false,
+    }],
+  },
+  silent: true,
+  testTimeout: 30000,
+  forceExit: true,
+};

--- a/tests/docs/epic-first-workflow.test.ts
+++ b/tests/docs/epic-first-workflow.test.ts
@@ -50,6 +50,14 @@ describe('epic-first workflow docs and help text', () => {
     expect(epicsDoc).toContain('alpha-loop history queue-<timestamp>');
   });
 
+  it('documents excluding alpha-loop worktrees from custom test configs', () => {
+    const epicsDoc = read('docs/epics.md');
+
+    expect(epicsDoc).toContain('### Test Discovery');
+    expect(epicsDoc).toContain('custom Jest, Vitest, Mocha, or other test-runner config');
+    expect(epicsDoc).toContain('exclude `.worktrees/` from test discovery');
+  });
+
   it('CLI descriptions mention epic grouping and epic-aware roadmap scheduling', () => {
     const cli = read('src/cli.ts');
 

--- a/tests/lib/templates.test.ts
+++ b/tests/lib/templates.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { diffSkills, diffAgents } from '../../src/lib/templates';
@@ -165,5 +165,34 @@ describe('diffAgents', () => {
     expect(result).toHaveLength(0);
 
     rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('distribution test config templates', () => {
+  const repoRoot = process.cwd();
+
+  function findTestConfigTemplates(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) return findTestConfigTemplates(path);
+      if (!entry.isFile()) return [];
+      return /(?:(?:jest|vitest|mocha)\.config\.|\.mocharc\.)(?:[cm]?[jt]s|json|ya?ml)$/.test(entry.name) ? [path] : [];
+    });
+  }
+
+  it('ships a Jest config template that ignores alpha-loop worktrees', () => {
+    const content = readFileSync(join(repoRoot, 'templates', 'jest.config.cjs'), 'utf-8');
+
+    expect(content).toContain('testPathIgnorePatterns');
+    expect(content).toContain("'/.worktrees/'");
+  });
+
+  it('keeps every shipped JS test-runner config template from discovering worktree tests', () => {
+    const configs = findTestConfigTemplates(join(repoRoot, 'templates'));
+
+    expect(configs).toContain(join(repoRoot, 'templates', 'jest.config.cjs'));
+    for (const config of configs) {
+      expect(readFileSync(config, 'utf-8')).toContain('.worktrees');
+    }
   });
 });


### PR DESCRIPTION
Closes #231
Part of #245

## Summary

Automated implementation of **Test config: exclude .worktrees/ in templates/jest.config.cjs**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Issue #231 satisfies the template test-config and documentation requirements.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*