### PR TITLE
feat: Docs-sync skill: trigger when src/commands/history.ts is modified (closes #232)

### DIFF
--- a/.alpha-loop/evals/cases/step/skill/006-docs-sync-history-command/checks.yaml
+++ b/.alpha-loop/evals/cases/step/skill/006-docs-sync-history-command/checks.yaml
@@ -1,0 +1,34 @@
+type: step
+step: skill
+eval_method: llm-judge
+status: ready
+checks:
+  - type: keyword_present
+    keywords:
+      - docs-sync
+      - CLAUDE.md
+      - README.md
+      - --help
+      - alpha-loop history queue-<timestamp>
+  - type: contains_any
+    values:
+      - src/commands/history.ts
+      - src/commands/*.ts
+  - type: llm_judge
+    model: claude-haiku-4-5
+    rubric: |
+      Evaluate whether the output correctly handles a review/learn-stage regression where a
+      diff changes src/commands/history.ts but command docs are stale.
+
+      Score 1-5:
+      - Score 5: Explicitly invokes docs-sync, identifies src/commands/history.ts as a CLI
+        command-handler trigger, says to compare actual alpha-loop/help text against both
+        CLAUDE.md and README.md, and proposes documenting alpha-loop history
+        queue-<timestamp> in both docs.
+      - Score 4: Invokes docs-sync and names both docs plus the missing queue command, but is
+        less explicit about help-text comparison.
+      - Score 3: Notices documentation drift but misses either README.md or CLAUDE.md.
+      - Score 2: Mentions documentation generally without triggering docs-sync or naming the
+        missing queue command.
+      - Score 1: Treats the diff as code-only or says no skill/docs action is needed.
+    min_score: 4

--- a/.alpha-loop/evals/cases/step/skill/006-docs-sync-history-command/input.md
+++ b/.alpha-loop/evals/cases/step/skill/006-docs-sync-history-command/input.md
@@ -1,0 +1,52 @@
+# Skill trigger regression: history queue command docs drift
+
+You are in the review/learn stage for a completed Alpha Loop issue. Decide which skill should
+fire and what concrete follow-up or patch should be proposed.
+
+The implementation diff touched a CLI command handler but did not update command docs:
+
+```diff
+diff --git a/src/commands/history.ts b/src/commands/history.ts
+index 1111111..2222222 100644
+--- a/src/commands/history.ts
++++ b/src/commands/history.ts
+@@
+ export function historyCommand(session?: string, options: HistoryOptions = {}): void {
++  if (session?.startsWith('queue-')) {
++    showQueueManifest(session);
++    return;
++  }
+   if (options.clean) {
+     cleanHistory();
+     return;
+   }
+```
+
+The current CLI help now describes history as session and queue history:
+
+```text
+$ alpha-loop history --help
+Usage: alpha-loop history [options] [session]
+View session and queue history
+```
+
+But `CLAUDE.md` is stale:
+
+```text
+alpha-loop history       # View session history
+alpha-loop history <name> --qa    # Show QA checklist for session
+alpha-loop history --clean        # Remove old session data
+```
+
+And `README.md` is stale:
+
+```markdown
+| `alpha-loop history` | View session history |
+| `alpha-loop history <name>` | View a specific session |
+| `alpha-loop history <name> --qa` | Show QA checklist for session |
+| `alpha-loop history --clean` | Remove old session data |
+```
+
+Expected review/learn behavior: this should not be treated as a code-only change. The agent
+should invoke the documentation synchronization skill, compare CLI help text against both docs,
+and propose adding the missing `alpha-loop history queue-<timestamp>` documentation.

--- a/.alpha-loop/evals/cases/step/skill/006-docs-sync-history-command/metadata.yaml
+++ b/.alpha-loop/evals/cases/step/skill/006-docs-sync-history-command/metadata.yaml
@@ -1,0 +1,9 @@
+id: 006-docs-sync-history-command
+description: "Skill trigger: docs-sync catches src/commands/history.ts CLI docs drift"
+tags:
+  - skill
+  - docs-sync
+  - cli-docs
+  - regression
+  - issue-232
+source: manual

--- a/.alpha-loop/templates/skills/docs-sync/SKILL.md
+++ b/.alpha-loop/templates/skills/docs-sync/SKILL.md
@@ -1,19 +1,43 @@
 ---
 name: docs-sync
-description: Ensure documentation stays in sync with code changes. Trigger when modifying CLI commands, config options, directory structure, or public APIs.
-when-to-use: When adding, removing, or changing CLI commands, config fields, directory layout, or user-facing behavior
+description: Ensure documentation stays in sync with code changes. Trigger on src/commands/*.ts command/flag/help changes, src/cli.ts help text changes, README.md/CLAUDE.md Commands entries, config options, directory structure, or public APIs.
+when-to-use: When adding, removing, or changing CLI commands, flags, arguments, help text, config fields, directory layout, public APIs, or Commands documentation in README.md or CLAUDE.md
 ---
 
 # Documentation Sync
 
 When making changes that affect user-facing behavior, always update the corresponding documentation.
 
+## Must trigger on
+
+- Any diff under `src/commands/*.ts` that adds, removes, renames, or changes a command, flag, option, argument, help text, output mode, or user-facing behavior. This includes focused command handlers such as `src/commands/history.ts`.
+- Any `src/cli.ts` change to `.command()`, `.description()`, `.option()`, arguments, aliases, examples, or generated `--help` text.
+- Any new, removed, or changed command entry in the `## Commands` section or table of `README.md` or `CLAUDE.md`.
+- Config option, directory structure, skill/agent template, public API, or other user-facing behavior changes.
+
 ## What to check
 
 ### CLI commands changed?
-- Update `README.md` commands table
-- Update `CLAUDE.md` commands section
-- Update `--help` descriptions in `src/cli.ts`
+- Capture the actual CLI help text, including top-level help and every touched command's help.
+- Diff command names, descriptions, arguments, flags/options, and aliases against `README.md` and `CLAUDE.md`.
+- Update `README.md` Commands table for every changed command or option.
+- Update `CLAUDE.md` Commands section for every changed command or option.
+- Update `--help` descriptions in `src/cli.ts` if docs reveal unclear or stale help text.
+
+### CLI docs drift workflow
+1. Identify touched CLI surfaces from the diff:
+   - `src/cli.ts` means capture `alpha-loop --help`.
+   - `src/commands/<name>.ts` means capture `alpha-loop <name> --help` plus top-level help.
+   - If a docs-only diff changes `README.md` or `CLAUDE.md` Commands entries, still compare against actual help.
+2. Prefer built help when available:
+   - `pnpm build`
+   - `node dist/cli.js --help`
+   - `node dist/cli.js <command> --help`
+   If building is not practical during review or learn, inspect `src/cli.ts` and the touched `src/commands/*.ts` handler directly, then state that the help comparison was source-based.
+3. Compare actual CLI help and command-handler behavior against:
+   - `README.md` `## Commands`
+   - `CLAUDE.md` `## Commands`
+4. Propose patches for every mismatch. Do not just say docs may be stale; name the exact file and command entry that needs to change.
 
 ### Config options changed?
 - Update `README.md` Configuration Reference table
@@ -34,9 +58,28 @@ When making changes that affect user-facing behavior, always update the correspo
 - Update relevant README sections
 - Update CLAUDE.md if architectural
 
+## Worked example
+
+A diff changes `src/commands/history.ts` so `alpha-loop history queue-<timestamp>` inspects a multi-epic queue manifest. `CLAUDE.md` still says:
+
+```text
+alpha-loop history       # View session history
+```
+
+This must trigger `docs-sync` because `src/commands/history.ts` is a CLI command handler. Capture or inspect `alpha-loop history --help`, compare it against both docs, and propose patches like:
+
+```text
+alpha-loop history       # View session and queue history
+alpha-loop history queue-<timestamp> # Inspect a multi-epic queue manifest
+```
+
+For `README.md`, add or update the corresponding Commands table rows for `alpha-loop history` and `alpha-loop history queue-<timestamp>`.
+
 ## Rules
 
 - Documentation updates MUST be in the same commit as the code change
 - Never leave README or CLAUDE.md referencing commands, options, or paths that no longer exist
 - When removing a feature, search docs for all references before committing
+- Review and learn stages must load this skill for `src/commands/*.ts` diffs even when `src/cli.ts` did not change
+- If docs are protected in the current workflow, still propose the exact patch and mark it as a required follow-up
 - Keep README under 300 lines, CLAUDE.md under 200 lines

--- a/templates/skills/docs-sync/SKILL.md
+++ b/templates/skills/docs-sync/SKILL.md
@@ -1,19 +1,43 @@
 ---
 name: docs-sync
-description: Ensure documentation stays in sync with code changes. Trigger when modifying CLI commands, config options, directory structure, or public APIs.
-when-to-use: When adding, removing, or changing CLI commands, config fields, directory layout, or user-facing behavior
+description: Ensure documentation stays in sync with code changes. Trigger on src/commands/*.ts command/flag/help changes, src/cli.ts help text changes, README.md/CLAUDE.md Commands entries, config options, directory structure, or public APIs.
+when-to-use: When adding, removing, or changing CLI commands, flags, arguments, help text, config fields, directory layout, public APIs, or Commands documentation in README.md or CLAUDE.md
 ---
 
 # Documentation Sync
 
 When making changes that affect user-facing behavior, always update the corresponding documentation.
 
+## Must trigger on
+
+- Any diff under `src/commands/*.ts` that adds, removes, renames, or changes a command, flag, option, argument, help text, output mode, or user-facing behavior. This includes focused command handlers such as `src/commands/history.ts`.
+- Any `src/cli.ts` change to `.command()`, `.description()`, `.option()`, arguments, aliases, examples, or generated `--help` text.
+- Any new, removed, or changed command entry in the `## Commands` section or table of `README.md` or `CLAUDE.md`.
+- Config option, directory structure, skill/agent template, public API, or other user-facing behavior changes.
+
 ## What to check
 
 ### CLI commands changed?
-- Update `README.md` commands table
-- Update `CLAUDE.md` commands section
-- Update `--help` descriptions in `src/cli.ts`
+- Capture the actual CLI help text, including top-level help and every touched command's help.
+- Diff command names, descriptions, arguments, flags/options, and aliases against `README.md` and `CLAUDE.md`.
+- Update `README.md` Commands table for every changed command or option.
+- Update `CLAUDE.md` Commands section for every changed command or option.
+- Update `--help` descriptions in `src/cli.ts` if docs reveal unclear or stale help text.
+
+### CLI docs drift workflow
+1. Identify touched CLI surfaces from the diff:
+   - `src/cli.ts` means capture `alpha-loop --help`.
+   - `src/commands/<name>.ts` means capture `alpha-loop <name> --help` plus top-level help.
+   - If a docs-only diff changes `README.md` or `CLAUDE.md` Commands entries, still compare against actual help.
+2. Prefer built help when available:
+   - `pnpm build`
+   - `node dist/cli.js --help`
+   - `node dist/cli.js <command> --help`
+   If building is not practical during review or learn, inspect `src/cli.ts` and the touched `src/commands/*.ts` handler directly, then state that the help comparison was source-based.
+3. Compare actual CLI help and command-handler behavior against:
+   - `README.md` `## Commands`
+   - `CLAUDE.md` `## Commands`
+4. Propose patches for every mismatch. Do not just say docs may be stale; name the exact file and command entry that needs to change.
 
 ### Config options changed?
 - Update `README.md` Configuration Reference table
@@ -34,9 +58,28 @@ When making changes that affect user-facing behavior, always update the correspo
 - Update relevant README sections
 - Update CLAUDE.md if architectural
 
+## Worked example
+
+A diff changes `src/commands/history.ts` so `alpha-loop history queue-<timestamp>` inspects a multi-epic queue manifest. `CLAUDE.md` still says:
+
+```text
+alpha-loop history       # View session history
+```
+
+This must trigger `docs-sync` because `src/commands/history.ts` is a CLI command handler. Capture or inspect `alpha-loop history --help`, compare it against both docs, and propose patches like:
+
+```text
+alpha-loop history       # View session and queue history
+alpha-loop history queue-<timestamp> # Inspect a multi-epic queue manifest
+```
+
+For `README.md`, add or update the corresponding Commands table rows for `alpha-loop history` and `alpha-loop history queue-<timestamp>`.
+
 ## Rules
 
 - Documentation updates MUST be in the same commit as the code change
 - Never leave README or CLAUDE.md referencing commands, options, or paths that no longer exist
 - When removing a feature, search docs for all references before committing
+- Review and learn stages must load this skill for `src/commands/*.ts` diffs even when `src/cli.ts` did not change
+- If docs are protected in the current workflow, still propose the exact patch and mark it as a required follow-up
 - Keep README under 300 lines, CLAUDE.md under 200 lines


### PR DESCRIPTION
Closes #232
Part of #245

## Summary

Automated implementation of **Docs-sync skill: trigger when src/commands/history.ts is modified**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Review passed: docs-sync trigger rules and regression eval satisfy issue #232.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*