### PR TITLE
feat: Pipeline: commit learning files inside the worktree so they ship with the implementation PR (closes #224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ Alpha Loop implements a 12-step pipeline for each issue:
 5. **Test + Retry** — Runs your test command; if tests fail, agent fixes and retries (up to `max_test_retries`)
 6. **Verify + Retry** — Starts your dev server, uses playwright-cli to test the feature like a real user, takes screenshots
 7. **Review** — A review agent reads the diff, checks for gaps, security issues, and missing wiring — fixes what it can
-8. **Create PR** — Opens a PR with test results, review summary, and verification status
-8b. **Assumptions** — Agent summarizes assumptions and decisions made, posts as a comment on the issue for user validation
-9. **Learn** — Extracts learnings (patterns, anti-patterns, what worked/failed) for future sessions
+8. **Learn** — Extracts learnings (patterns, anti-patterns, what worked/failed) and commits them in the issue worktree
+9. **Create PR** — Opens a PR with the implementation, learning artifact, test results, review summary, and verification status
+9b. **Assumptions** — Agent summarizes assumptions and decisions made, posts as a comment on the issue for user validation
 10. **Update Issue** — Posts results as a comment, updates labels
 11. **Auto-Merge** — Merges the PR to the session branch (if enabled)
 12. **Cleanup** — Removes the worktree
 
 After all issues are processed, Alpha Loop:
 1. **Auto-captures failures** as eval cases for regression testing
-2. Generates a **session summary** aggregating learnings across issues
+2. Generates a **session summary** aggregating learnings across issues when a session branch is being finalized
 3. Runs a **post-session code review** on the full session diff to catch cross-issue integration problems
 4. Creates the **session PR** with all findings included
 
@@ -106,7 +106,7 @@ When `auto_merge` is enabled (default), Alpha Loop creates a session branch (e.g
 
 ### Learnings
 
-Each completed issue produces a learning file in `.alpha-loop/learnings/` with:
+Each completed issue produces a learning file in `.alpha-loop/learnings/` that is committed with that issue's implementation PR. It includes:
 - What worked and what failed
 - Reusable patterns discovered
 - Anti-patterns to avoid

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -14,6 +14,7 @@ import { exec } from '../lib/shell.js';
 import { ghExec } from '../lib/rate-limit.js';
 import { spawnAgent } from '../lib/agent.js';
 import { buildReviewPrompt } from '../lib/prompts.js';
+import { repairSessionLearningArtifacts } from '../lib/learning.js';
 import {
   labelIssue,
   commentIssue,
@@ -60,6 +61,87 @@ function listAgentIssueBranches(): string[] {
   }
 
   return Array.from(branches).sort();
+}
+
+function worktreePathForBranch(branch: string): string | null {
+  const worktreeResult = exec('git worktree list --porcelain');
+  if (worktreeResult.exitCode !== 0) return null;
+
+  let currentWorktree: string | null = null;
+  for (const line of worktreeResult.stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('worktree ')) {
+      currentWorktree = trimmed.slice('worktree '.length);
+      continue;
+    }
+    if (trimmed === `branch refs/heads/${branch}`) {
+      return currentWorktree;
+    }
+  }
+
+  return null;
+}
+
+function checkoutBranchForResume(branch: string): string | null {
+  const existingWorktree = worktreePathForBranch(branch);
+  if (existingWorktree) return existingWorktree;
+
+  const toplevelResult = exec('git rev-parse --show-toplevel');
+  const cwd = toplevelResult.exitCode === 0 && toplevelResult.stdout
+    ? toplevelResult.stdout
+    : process.cwd();
+  const checkoutResult = exec(`git checkout ${JSON.stringify(branch)}`, { cwd });
+  if (checkoutResult.exitCode !== 0) {
+    log.error(`Could not check out ${branch}: ${checkoutResult.stderr || checkoutResult.stdout}`);
+    return null;
+  }
+  return cwd;
+}
+
+function changedLearningPaths(cwd: string, issueNum: number): string[] {
+  const statusResult = exec('git status --porcelain -- ".alpha-loop/learnings"', { cwd });
+  if (statusResult.exitCode !== 0 || !statusResult.stdout.trim()) return [];
+
+  return statusResult.stdout
+    .split('\n')
+    .map((line) => {
+      const path = line.slice(3).trim();
+      return path.includes(' -> ') ? path.split(' -> ').pop()!.trim() : path;
+    })
+    .filter((path) => path.startsWith(`.alpha-loop/learnings/issue-${issueNum}-`) && path.endsWith('.md'));
+}
+
+function commitChangedLearningArtifacts(cwd: string, issueNum: number): boolean {
+  const paths = changedLearningPaths(cwd, issueNum);
+  if (paths.length === 0) return false;
+
+  const pathspecs = paths.map((path) => JSON.stringify(path)).join(' ');
+  const addResult = exec(`git add -- ${pathspecs}`, { cwd });
+  if (addResult.exitCode !== 0) {
+    log.warn(`Could not stage learning artifact for #${issueNum}: ${addResult.stderr || addResult.stdout}`);
+    return false;
+  }
+
+  const stagedResult = exec(`git diff --cached --name-only -- ${pathspecs}`, { cwd });
+  if (stagedResult.exitCode !== 0 || !stagedResult.stdout.trim()) return false;
+
+  const stagedPaths = stagedResult.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => paths.includes(line));
+  if (stagedPaths.length === 0) return false;
+
+  const commitResult = exec(
+    `git commit -m ${JSON.stringify(`chore: add learning artifact for issue #${issueNum}`)} -- ${stagedPaths.map((path) => JSON.stringify(path)).join(' ')}`,
+    { cwd },
+  );
+  if (commitResult.exitCode !== 0) {
+    log.warn(`Could not commit learning artifact for #${issueNum}: ${commitResult.stderr || commitResult.stdout}`);
+    return false;
+  }
+
+  log.success(`Learning artifact committed for #${issueNum}`);
+  return true;
 }
 
 /**
@@ -187,14 +269,30 @@ async function resumeBranch(
   const title = getIssueTitle(repo, issueNum);
   log.step(`Resuming issue #${issueNum}: ${title}`);
 
+  const branchWorktree = checkoutBranchForResume(branch);
+  if (!branchWorktree) return null;
+
+  const session = findSessionForIssue(issueNum);
+  if (session && !config.skipLearn) {
+    repairSessionLearningArtifacts({
+      sessionName: session.sessionName,
+      issues: [{ issueNum, title, status: 'failure', duration: 0, retries: 0 }],
+      learningsDir: join(branchWorktree, '.alpha-loop', 'learnings'),
+      sessionLogsDir: join(session.sessionDir, 'logs'),
+    });
+    commitChangedLearningArtifacts(branchWorktree, issueNum);
+  } else if (config.skipLearn) {
+    log.info('Skipping learning artifact repair (skipLearn=true)');
+  }
+
   // Push the branch so createPR can work with it.
   // createPR also pushes internally, but we do it first here for explicit
   // feedback and to fail fast if the push is going to be a problem.
   log.info(`Pushing ${branch} to origin...`);
-  const pushResult = exec(`git push -u origin "${branch}"`);
+  const pushResult = exec(`git push -u origin "${branch}"`, { cwd: branchWorktree });
   if (pushResult.exitCode !== 0) {
     log.warn(`Push failed: ${pushResult.stderr}. Attempting force push...`);
-    const forceResult = exec(`git push -u origin "${branch}" --force`);
+    const forceResult = exec(`git push -u origin "${branch}" --force`, { cwd: branchWorktree });
     if (forceResult.exitCode !== 0) {
       log.error(`Could not push ${branch}: ${forceResult.stderr}`);
       return null;
@@ -217,19 +315,12 @@ async function resumeBranch(
       baseBranch,
     });
 
-    // Determine the cwd for the review — use the repo root (git toplevel).
-    const toplevelResult = exec('git rev-parse --show-toplevel');
-    const cwd = toplevelResult.exitCode === 0 ? toplevelResult.stdout : process.cwd();
-
-    // Switch to the branch so the agent can run git commands against it.
-    exec(`git checkout "${branch}"`);
-
     const reviewStep = resolveStepConfig(config, 'review');
     const reviewResult = await spawnAgent({
       agent: reviewStep.agent as typeof config.agent,
       model: reviewStep.model,
       prompt: reviewPrompt,
-      cwd,
+      cwd: branchWorktree,
       verbose: config.verbose,
       timeout: 10 * 60 * 1000, // 10 minutes for a review
       maxTurns: 20,
@@ -264,6 +355,7 @@ This PR was recovered by \`alpha-loop resume\`. Resume creates the PR and runs b
       head: branch,
       title: `feat: ${title} (closes #${issueNum})`,
       body: prBody,
+      cwd: branchWorktree,
     });
   } catch (err) {
     log.error(`Failed to create PR for #${issueNum}: ${String(err)}`);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1084,27 +1084,31 @@ async function runIssueSession(
   // Generate session summary (aggregates learnings across all issues)
   if (session.results.length > 0) {
     const learningsDir = join(process.cwd(), '.alpha-loop', 'learnings');
-    repairSessionLearningArtifacts({
-      sessionName: session.name,
-      issues: session.results.map((r) => ({
-        issueNum: r.issueNum,
-        title: r.title,
-        status: r.status,
-        duration: r.duration,
-      })),
-      learningsDir,
-      sessionLogsDir: session.logsDir,
-    });
-    await generateSessionSummary({
-      sessionName: session.name,
-      results: session.results,
-      learningsDir,
-      config,
-    });
-    repairSessionSummaryArtifact({
-      sessionName: session.name,
-      learningsDir,
-    });
+    if (config.autoMerge) {
+      repairSessionLearningArtifacts({
+        sessionName: session.name,
+        issues: session.results.map((r) => ({
+          issueNum: r.issueNum,
+          title: r.title,
+          status: r.status,
+          duration: r.duration,
+        })),
+        learningsDir,
+        sessionLogsDir: session.logsDir,
+      });
+      await generateSessionSummary({
+        sessionName: session.name,
+        results: session.results,
+        learningsDir,
+        config,
+      });
+      repairSessionSummaryArtifact({
+        sessionName: session.name,
+        learningsDir,
+      });
+    } else {
+      log.info('Skipping parent learning artifact repair; issue learnings are committed in child PRs');
+    }
   }
 
   // Post-session holistic code review

--- a/src/lib/learning.ts
+++ b/src/lib/learning.ts
@@ -22,6 +22,8 @@ export type ExtractLearningsOptions = {
   verifyOutput: string;
   body: string;
   config: Config;
+  outputRoot?: string;
+  agentCwd?: string;
   sessionLogsDir?: string;
   sessionName?: string;
 };
@@ -469,17 +471,19 @@ export function repairSessionSummaryArtifact(options: {
  * only expected sections, and saves a concise learning file with trace pointers.
  * Raw agent output is saved separately to the traces directory.
  */
-export async function extractLearnings(options: ExtractLearningsOptions): Promise<void> {
+export async function extractLearnings(options: ExtractLearningsOptions): Promise<string | null> {
   const { config } = options;
 
   if (config.skipLearn) {
     log.info('Skipping learning extraction (skipLearn=true)');
-    return;
+    return null;
   }
 
   log.step('Extracting learnings from run...');
 
-  const learningsDir = join(process.cwd(), '.alpha-loop', 'learnings');
+  const outputRoot = options.outputRoot ?? process.cwd();
+  const agentCwd = options.agentCwd ?? outputRoot;
+  const learningsDir = join(outputRoot, '.alpha-loop', 'learnings');
   mkdirSync(learningsDir, { recursive: true });
 
   const timestamp = formatTimestamp(new Date());
@@ -500,7 +504,7 @@ export async function extractLearnings(options: ExtractLearningsOptions): Promis
 
   if (config.dryRun) {
     log.dry(`Would extract learnings to ${learningFile}`);
-    return;
+    return null;
   }
 
   const learnStep = resolveStepConfig(config, 'learn');
@@ -508,13 +512,13 @@ export async function extractLearnings(options: ExtractLearningsOptions): Promis
     agent: learnStep.agent as typeof config.agent,
     model: learnStep.model,
     prompt,
-    cwd: process.cwd(),
+    cwd: agentCwd,
     logFile: undefined,
   });
 
   if (result.exitCode !== 0 || !result.output.trim()) {
     log.warn(`Learning extraction failed (exit ${result.exitCode}, output ${result.output.length} chars), skipping`);
-    return;
+    return null;
   }
 
   const rawOutput = result.output.trim();
@@ -531,7 +535,7 @@ export async function extractLearnings(options: ExtractLearningsOptions): Promis
   const { frontmatter: parsedFm, sections, hasMeaningfulSections } = parseLearningOutput(rawOutput);
   if (!hasMeaningfulSections || !sections.trim()) {
     log.warn(`Learning extraction output for issue #${options.issueNum} did not contain meaningful learning sections, skipping`);
-    return;
+    return null;
   }
 
   const today = new Date().toISOString().split('T')[0];
@@ -570,6 +574,7 @@ export async function extractLearnings(options: ExtractLearningsOptions): Promis
 
   writeFileSync(learningFile, finalOutput + '\n');
   log.success(`Learning saved to ${learningFile}`);
+  return learningFile;
 }
 
 /**

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -2,7 +2,7 @@
  * Process Issue Pipeline — the 12-step orchestration for a single issue.
  */
 import { mkdirSync, readFileSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { log } from './logger.js';
 import { exec } from './shell.js';
 import { spawnAgent, buildEndpointEnv } from './agent.js';
@@ -359,6 +359,54 @@ function epicPromptOption(options: PipelineOptions): { epicContext?: EpicPromptC
 function formatEpicFixContext(options: PipelineOptions, issueNum: number): string {
   if (!options.epicContext) return '';
   return `\n\n${formatEpicPromptContext(options.epicContext)}\n\nUse the parent epic context to keep fixes scoped to issue #${issueNum} while preserving integration with sibling work.`;
+}
+
+function learningPathForCommit(worktreePath: string, learningFile: string): string | null {
+  const relPath = relative(worktreePath, learningFile);
+  if (!relPath || relPath.startsWith('..') || relPath.startsWith('/')) return null;
+  if (!relPath.startsWith('.alpha-loop/learnings/')) return null;
+  return relPath;
+}
+
+function commitLearningFiles(worktreePath: string, learningFiles: Array<string | null>, message: string): void {
+  const paths = Array.from(new Set(
+    learningFiles
+      .filter((file): file is string => Boolean(file))
+      .map((file) => learningPathForCommit(worktreePath, file))
+      .filter((file): file is string => Boolean(file)),
+  ));
+
+  if (paths.length === 0) return;
+
+  const pathspecs = paths.map((path) => JSON.stringify(path)).join(' ');
+  const addResult = exec(`git add -- ${pathspecs}`, { cwd: worktreePath });
+  if (addResult.exitCode !== 0) {
+    log.warn(`Could not stage learning artifact(s): ${addResult.stderr || addResult.stdout}`);
+    return;
+  }
+
+  const stagedResult = exec(`git diff --cached --name-only -- ${pathspecs}`, { cwd: worktreePath });
+  if (stagedResult.exitCode !== 0) {
+    log.warn(`Could not inspect staged learning artifact(s): ${stagedResult.stderr || stagedResult.stdout}`);
+    return;
+  }
+
+  const stagedPaths = stagedResult.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => paths.includes(line));
+  if (stagedPaths.length === 0) return;
+
+  const commitResult = exec(
+    `git commit -m ${JSON.stringify(message)} -- ${stagedPaths.map((path) => JSON.stringify(path)).join(' ')}`,
+    { cwd: worktreePath },
+  );
+  if (commitResult.exitCode !== 0) {
+    log.warn(`Could not commit learning artifact(s): ${commitResult.stderr || commitResult.stdout}`);
+    return;
+  }
+
+  log.success(`Committed ${stagedPaths.length} learning artifact(s)`);
 }
 
 /** Per-issue context for the escalation wrapper. */
@@ -1097,8 +1145,51 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     }
   }
 
-  // --- Step 8: Create PR ---
-  log.step('Step 8: Creating PR');
+  const duration = Math.round((Date.now() - startTime) / 1000);
+
+  // Get diff before writing learnings so the learning prompt analyzes only the implementation.
+  let runDiff = '';
+  if (!config.dryRun) {
+    const diffResult = exec(`git diff "origin/${config.baseBranch}...HEAD"`, { cwd: worktreePath });
+    runDiff = diffResult.stdout.slice(0, MAX_DIFF_CHARS);
+  }
+
+  // Format review gate for learnings
+  const reviewForLearnings = reviewGate.findings.length > 0
+    ? `Review: ${reviewGate.summary}\n${reviewGate.findings.map((f) => `- [${f.severity}] ${f.description} (${f.fixed ? 'fixed' : 'unfixed'})`).join('\n')}`
+    : `Review: ${reviewGate.summary || 'passed'}`;
+
+  // --- Step 8: Extract learnings ---
+  log.step('Step 8: Extracting learnings');
+  const learningFile = await extractLearnings({
+    issueNum,
+    title,
+    status: testsPassing ? 'success' : 'failure',
+    retries: testRetries,
+    duration,
+    diff: runDiff,
+    testOutput,
+    reviewOutput: reviewForLearnings,
+    verifyOutput,
+    body,
+    config,
+    outputRoot: worktreePath,
+    agentCwd: worktreePath,
+    sessionLogsDir: session.logsDir,
+    sessionName: session.name,
+  });
+
+  if (!config.dryRun) {
+    commitLearningFiles(
+      worktreePath,
+      [learningFile],
+      `chore: add learning artifact for issue #${issueNum}`,
+    );
+  }
+  stepsCompleted.push('learn');
+
+  // --- Step 9: Create PR ---
+  log.step('Step 9: Creating PR');
   let prUrl: string | undefined;
 
   if (!config.dryRun) {
@@ -1127,16 +1218,15 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     log.dry('Would create PR');
   }
 
-  // --- Step 8b: Post assumptions/decisions comment ---
+  // --- Step 9b: Post assumptions/decisions comment ---
   if (!config.dryRun && prUrl) {
     try {
-      const assumptionsDiff = exec(`git diff "origin/${config.baseBranch}...HEAD"`, { cwd: worktreePath });
       const reviewSummary = reviewGate.summary || 'No review findings';
       const assumptionsPrompt = buildAssumptionsPrompt({
         issueNum,
         title,
         body,
-        diff: assumptionsDiff.stdout,
+        diff: runDiff,
         reviewSummary,
       });
 
@@ -1168,40 +1258,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     }
   }
 
-  // --- Step 9: Extract learnings ---
-  log.step('Step 9: Extracting learnings');
-  const duration = Math.round((Date.now() - startTime) / 1000);
-
-  // Get diff for learning analysis
-  let runDiff = '';
-  if (!config.dryRun) {
-    const diffResult = exec(`git diff "origin/${config.baseBranch}...HEAD"`, { cwd: worktreePath });
-    runDiff = diffResult.stdout.slice(0, MAX_DIFF_CHARS);
-  }
-
-  // Format review gate for learnings
-  const reviewForLearnings = reviewGate.findings.length > 0
-    ? `Review: ${reviewGate.summary}\n${reviewGate.findings.map((f) => `- [${f.severity}] ${f.description} (${f.fixed ? 'fixed' : 'unfixed'})`).join('\n')}`
-    : `Review: ${reviewGate.summary || 'passed'}`;
-
-  await extractLearnings({
-    issueNum,
-    title,
-    status: testsPassing ? 'success' : 'failure',
-    retries: testRetries,
-    duration,
-    diff: runDiff,
-    testOutput,
-    reviewOutput: reviewForLearnings,
-    verifyOutput,
-    body,
-    config,
-    sessionLogsDir: session.logsDir,
-    sessionName: session.name,
-  });
-
-  // --- Step 9b: Write full traces (Meta-Harness style) ---
-  stepsCompleted.push('learn');
+  // --- Step 9c: Write full traces (Meta-Harness style) ---
   const filesChanged = runDiff ? (runDiff.match(/^diff --git/gm) ?? []).length : 0;
 
   if (!config.dryRun) {
@@ -1719,8 +1776,58 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     }
   }
 
-  // --- Step 8: Create single PR for the batch ---
-  log.step('Batch Step 7: Creating PR');
+  const duration = Math.round((Date.now() - startTime) / 1000);
+  const perIssueDuration = Math.round(duration / issues.length);
+
+  // Get diff before writing learnings so the learning prompt analyzes only the implementation.
+  let runDiff = '';
+  if (!config.dryRun) {
+    const diffResult = exec(`git diff "origin/${config.baseBranch}...HEAD"`, { cwd: worktreePath });
+    runDiff = diffResult.stdout.slice(0, MAX_DIFF_CHARS);
+  }
+
+  // Format review gate for learnings (same format as single-issue pipeline)
+  const reviewForLearnings = reviewGate.findings.length > 0
+    ? `Review: ${reviewGate.summary}\n${reviewGate.findings.map((f) => `- [${f.severity}] ${f.description} (${f.fixed ? 'fixed' : 'unfixed'})`).join('\n')}`
+    : `Review: ${reviewGate.summary || 'passed'}`;
+
+  const filesChanged = runDiff ? (runDiff.match(/^diff --git/gm) ?? []).length : 0;
+
+  // --- Step 8: Extract learnings ---
+  log.step('Batch Step 7: Extracting learnings');
+  const learningFiles: Array<string | null> = [];
+  for (const issue of issues) {
+    const learningFile = await extractLearnings({
+      issueNum: issue.number,
+      title: issue.title,
+      status: testsPassing ? 'success' : 'failure',
+      retries: 0,
+      duration: perIssueDuration,
+      diff: runDiff,
+      testOutput,
+      reviewOutput: reviewForLearnings,
+      verifyOutput: '',
+      body: issue.body,
+      config,
+      outputRoot: worktreePath,
+      agentCwd: worktreePath,
+      sessionLogsDir: session.logsDir,
+      sessionName: session.name,
+    });
+    learningFiles.push(learningFile);
+  }
+
+  if (!config.dryRun) {
+    commitLearningFiles(
+      worktreePath,
+      learningFiles,
+      `chore: add learning artifacts for issues ${issues.map((i) => `#${i.number}`).join(', ')}`,
+    );
+  }
+  stepsCompleted.push('learn');
+
+  // --- Step 9: Create single PR for the batch ---
+  log.step('Batch Step 8: Creating PR');
   let prUrl: string | undefined;
 
   if (!config.dryRun) {
@@ -1755,24 +1862,8 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     }
   }
 
-  // --- Step 9: Update each issue individually + extract learnings ---
-  log.step('Batch Step 8: Updating individual issues');
-  const duration = Math.round((Date.now() - startTime) / 1000);
-  const perIssueDuration = Math.round(duration / issues.length);
-
-  // Get diff for traces and learning analysis
-  let runDiff = '';
-  if (!config.dryRun) {
-    const diffResult = exec(`git diff "origin/${config.baseBranch}...HEAD"`, { cwd: worktreePath });
-    runDiff = diffResult.stdout.slice(0, MAX_DIFF_CHARS);
-  }
-
-  // Format review gate for learnings (same format as single-issue pipeline)
-  const reviewForLearnings = reviewGate.findings.length > 0
-    ? `Review: ${reviewGate.summary}\n${reviewGate.findings.map((f) => `- [${f.severity}] ${f.description} (${f.fixed ? 'fixed' : 'unfixed'})`).join('\n')}`
-    : `Review: ${reviewGate.summary || 'passed'}`;
-
-  const filesChanged = runDiff ? (runDiff.match(/^diff --git/gm) ?? []).length : 0;
+  // --- Step 10: Update each issue individually ---
+  log.step('Batch Step 9: Updating individual issues');
   const results: PipelineResult[] = [];
 
   for (const issue of issues) {
@@ -1799,23 +1890,6 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
 
     results.push(result);
     saveResult(session, result);
-
-    // Extract learnings per issue
-    await extractLearnings({
-      issueNum: issue.number,
-      title: issue.title,
-      status: testsPassing ? 'success' : 'failure',
-      retries: 0,
-      duration: perIssueDuration,
-      diff: runDiff,
-      testOutput,
-      reviewOutput: reviewForLearnings,
-      verifyOutput: '',
-      body: issue.body,
-      config,
-      sessionLogsDir: session.logsDir,
-      sessionName: session.name,
-    });
 
     // Write per-issue traces
     if (!config.dryRun) {
@@ -1857,8 +1931,6 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     log.success(`Issue #${issue.number} updated`);
   }
 
-  stepsCompleted.push('learn');
-
   // Write aggregate scores and costs
   if (!config.dryRun) {
     try {
@@ -1894,7 +1966,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     if (!testsPassing) {
       log.warn('Skipping auto-merge: tests are not passing');
     } else {
-      log.step('Batch Step 9: Auto-merging PR');
+        log.step('Batch Step 10: Auto-merging PR');
       try {
         mergePR(config.repo, worktreeBranch);
         mergeSucceeded = true;
@@ -1911,7 +1983,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
   }
 
   // --- Step 11: Cleanup ---
-  log.step('Batch Step 10: Cleanup');
+  log.step('Batch Step 11: Cleanup');
   if (!mergeSucceeded && config.autoMerge && prUrl) {
     // Merge was expected but didn't happen (tests failing or merge failed) — preserve worktree for recovery
     await cleanupWorktree({

--- a/tests/commands/resume.test.ts
+++ b/tests/commands/resume.test.ts
@@ -26,6 +26,10 @@ jest.mock('../../src/lib/github', () => ({
   updateProjectStatus: jest.fn(),
 }));
 
+jest.mock('../../src/lib/learning', () => ({
+  repairSessionLearningArtifacts: jest.fn(),
+}));
+
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -35,6 +39,7 @@ import { createPR, labelIssue, commentIssue, updateProjectStatus } from '../../s
 import { ghExec } from '../../src/lib/rate-limit';
 import { spawnAgent } from '../../src/lib/agent';
 import { exec } from '../../src/lib/shell';
+import { repairSessionLearningArtifacts } from '../../src/lib/learning';
 
 const mockExec = exec as jest.MockedFunction<typeof exec>;
 const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
@@ -45,6 +50,7 @@ const mockLabelIssue = labelIssue as jest.MockedFunction<typeof labelIssue>;
 const mockCommentIssue = commentIssue as jest.MockedFunction<typeof commentIssue>;
 const mockUpdateProjectStatus = updateProjectStatus as jest.MockedFunction<typeof updateProjectStatus>;
 const mockSpawnAgent = spawnAgent as jest.MockedFunction<typeof spawnAgent>;
+const mockRepairSessionLearningArtifacts = repairSessionLearningArtifacts as jest.MockedFunction<typeof repairSessionLearningArtifacts>;
 
 const ok = (stdout = '') => ({ stdout, stderr: '', exitCode: 0 });
 const repoRoot = process.cwd();
@@ -56,6 +62,7 @@ beforeEach(() => {
   tempDir = undefined;
   mockResolveStepConfig.mockReturnValue({ agent: 'codex', model: 'gpt-5' });
   mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/269');
+  mockRepairSessionLearningArtifacts.mockReturnValue({ repaired: 0, created: 1, skipped: 0, failed: 0 });
 });
 
 afterEach(() => {
@@ -194,6 +201,18 @@ describe('resumeCommand', () => {
       if (cmd === 'git worktree list --porcelain') return ok('');
       if (cmd === 'git log "origin/master..agent/issue-269" --oneline') return ok('abc123 recover stranded work\n');
       if (cmd === 'git diff --name-only "origin/master...agent/issue-269"') return ok('reports/final.pdf\nslides/final.pptx\n');
+      if (cmd === 'git rev-parse --show-toplevel') return ok(tempDir ?? '');
+      if (cmd === 'git checkout "agent/issue-269"') return ok('');
+      if (cmd === 'git status --porcelain -- ".alpha-loop/learnings"') {
+        return ok('?? .alpha-loop/learnings/issue-269-20260101-000000.md\n');
+      }
+      if (cmd === 'git add -- ".alpha-loop/learnings/issue-269-20260101-000000.md"') return ok('');
+      if (cmd === 'git diff --cached --name-only -- ".alpha-loop/learnings/issue-269-20260101-000000.md"') {
+        return ok('.alpha-loop/learnings/issue-269-20260101-000000.md\n');
+      }
+      if (cmd === 'git commit -m "chore: add learning artifact for issue #269" -- ".alpha-loop/learnings/issue-269-20260101-000000.md"') {
+        return ok('');
+      }
       if (cmd === 'git push -u origin "agent/issue-269"') return ok('');
       return ok('');
     });
@@ -214,12 +233,23 @@ describe('resumeCommand', () => {
 
     await resumeCommand({ issue: '269' });
 
+    expect(mockRepairSessionLearningArtifacts).toHaveBeenCalledWith({
+      sessionName: 'session/epic-123',
+      issues: [{ issueNum: 269, title: 'Recover artifact exports', status: 'failure', duration: 0, retries: 0 }],
+      learningsDir: join(tempDir!, '.alpha-loop', 'learnings'),
+      sessionLogsDir: expect.stringContaining('.alpha-loop/sessions/session/epic-123/logs'),
+    });
+    expect(mockExec).toHaveBeenCalledWith(
+      'git commit -m "chore: add learning artifact for issue #269" -- ".alpha-loop/learnings/issue-269-20260101-000000.md"',
+      { cwd: tempDir! },
+    );
     expect(mockCreatePR).toHaveBeenCalledWith(expect.objectContaining({
       repo: 'owner/repo',
       base: 'master',
       head: 'agent/issue-269',
       title: 'feat: Recover artifact exports (closes #269)',
       body: expect.stringContaining('Treat this PR as WIP until those checks pass.'),
+      cwd: tempDir!,
     }));
     expect(mockLabelIssue).toHaveBeenCalledWith('owner/repo', 269, 'in-review', 'in-progress');
     expect(mockUpdateProjectStatus).toHaveBeenCalledWith('owner/repo', 2, 'owner', 269, 'In Review');

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -813,6 +813,32 @@ describe('runCommand', () => {
       expect.any(Object),
       expect.any(Object),
     );
+    expect(mockRepairSessionLearningArtifacts).not.toHaveBeenCalled();
+    expect(mockRepairSessionSummaryArtifact).not.toHaveBeenCalled();
+    expect(mockLog.info).toHaveBeenCalledWith('Skipping parent learning artifact repair; issue learnings are committed in child PRs');
+    expect(mockFinalizeSession).toHaveBeenCalled();
+  });
+
+  test('repairs session learning artifacts only when auto-merge uses a session branch', async () => {
+    mockLoadConfig.mockImplementation((overrides: any = {}) =>
+      makeConfig({ ...overrides, autoMerge: true, skipPostSessionReview: true }) as any,
+    );
+    mockPollIssues.mockReturnValue([
+      { number: 42, title: 'Test issue', body: 'Body', labels: ['ready'] },
+    ]);
+    mockProcessIssue.mockResolvedValue({
+      issueNum: 42,
+      title: 'Test issue',
+      status: 'success',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 5,
+    });
+
+    await runCommand({});
+
     expect(mockRepairSessionLearningArtifacts).toHaveBeenCalledWith(expect.objectContaining({
       sessionName: 'session/20260330-143000',
       sessionLogsDir: '/tmp/sessions/logs',

--- a/tests/lib/learning.test.ts
+++ b/tests/lib/learning.test.ts
@@ -350,15 +350,41 @@ describe('extractLearnings', () => {
       duration: 5000,
     });
 
-    await extractLearnings({ ...baseOptions, config: makeConfig() });
+    const result = await extractLearnings({ ...baseOptions, config: makeConfig() });
 
     expect(mockSpawnAgent).toHaveBeenCalledWith(expect.objectContaining({
       agent: 'claude',
       model: 'opus',
+      cwd: process.cwd(),
     }));
+    expect(result).toContain('issue-42-20260101-000000.md');
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       expect.stringContaining('issue-42-'),
       expect.stringContaining('## What Worked'),
+    );
+  });
+
+  test('writes learning artifacts under outputRoot and runs the learn agent there', async () => {
+    mockSpawnAgent.mockResolvedValue({
+      exitCode: 0,
+      output: '## What Worked\n- Output root used',
+      duration: 5000,
+    });
+
+    const result = await extractLearnings({
+      ...baseOptions,
+      config: makeConfig(),
+      outputRoot: '/tmp/worktree',
+      agentCwd: '/tmp/worktree',
+    });
+
+    expect(mockSpawnAgent).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: '/tmp/worktree',
+    }));
+    expect(result).toBe('/tmp/worktree/.alpha-loop/learnings/issue-42-20260101-000000.md');
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      '/tmp/worktree/.alpha-loop/learnings/issue-42-20260101-000000.md',
+      expect.stringContaining('Output root used'),
     );
   });
 

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -232,7 +232,7 @@ beforeEach(() => {
   mockRunTests.mockReturnValue({ passed: true, output: 'All tests passed' });
   mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/1');
   mockMergePR.mockReturnValue(undefined as any);
-  mockExtractLearnings.mockResolvedValue();
+  mockExtractLearnings.mockResolvedValue(null);
   mockGetLearningContext.mockReturnValue('');
   mockGetPreviousResult.mockReturnValue(null);
 });
@@ -258,6 +258,41 @@ describe('processIssue', () => {
     expect(mockExtractLearnings).toHaveBeenCalled();
     expect(mockSaveResult).toHaveBeenCalled();
     expect(mockCleanupWorktree).toHaveBeenCalled();
+  });
+
+  test('extracts and commits the learning artifact in the worktree before creating the PR', async () => {
+    const learningPath = '/tmp/worktree/.alpha-loop/learnings/issue-42-20260101-000000.md';
+    mockExtractLearnings.mockResolvedValueOnce(learningPath);
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd === 'git diff "origin/master...HEAD"') {
+        return { stdout: 'diff --git a/src/foo.ts b/src/foo.ts', stderr: '', exitCode: 0 };
+      }
+      if (cmd.startsWith('git diff --cached --name-only --')) {
+        return { stdout: '.alpha-loop/learnings/issue-42-20260101-000000.md', stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    await processIssue(42, 'Test issue', 'Issue body', makeConfig(), makeSession());
+
+    expect(mockExtractLearnings).toHaveBeenCalledWith(expect.objectContaining({
+      outputRoot: '/tmp/worktree',
+      agentCwd: '/tmp/worktree',
+      sessionLogsDir: '/tmp/sessions/session/20260330-143000/logs',
+      sessionName: 'session/20260330-143000',
+    }));
+
+    const commitCallIndex = mockExec.mock.calls.findIndex(([cmd]) =>
+      String(cmd).startsWith('git commit -m "chore: add learning artifact for issue #42"'),
+    );
+    expect(commitCallIndex).toBeGreaterThanOrEqual(0);
+    expect(mockExec.mock.calls[commitCallIndex][0]).toContain('.alpha-loop/learnings/issue-42-20260101-000000.md');
+    expect(mockExtractLearnings.mock.invocationCallOrder[0]).toBeLessThan(
+      mockExec.mock.invocationCallOrder[commitCallIndex],
+    );
+    expect(mockExec.mock.invocationCallOrder[commitCallIndex]).toBeLessThan(
+      mockCreatePR.mock.invocationCallOrder[0],
+    );
   });
 
   test('uses per-step pipeline agents for plan, implementation, and review', async () => {
@@ -889,6 +924,55 @@ describe('processBatch', () => {
     expect(mockBuildBatchPlanPrompt).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
     expect(mockBuildBatchImplementPrompt).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
     expect(mockBuildBatchReviewPrompt).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
+  });
+
+  test('commits all batch learning artifacts before creating the batch PR', async () => {
+    mockExtractLearnings
+      .mockResolvedValueOnce('/tmp/worktree/.alpha-loop/learnings/issue-10-20260101-000000.md')
+      .mockResolvedValueOnce('/tmp/worktree/.alpha-loop/learnings/issue-11-20260101-000000.md');
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd === 'git diff "origin/master...HEAD"') {
+        return { stdout: 'diff --git a/src/foo.ts b/src/foo.ts', stderr: '', exitCode: 0 };
+      }
+      if (cmd.startsWith('git diff --cached --name-only --')) {
+        return {
+          stdout: [
+            '.alpha-loop/learnings/issue-10-20260101-000000.md',
+            '.alpha-loop/learnings/issue-11-20260101-000000.md',
+          ].join('\n'),
+          stderr: '',
+          exitCode: 0,
+        };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    await processBatch(batchIssues, makeConfig({ batch: true }), makeSession());
+
+    expect(mockExtractLearnings).toHaveBeenCalledTimes(2);
+    expect(mockExtractLearnings).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      issueNum: 10,
+      outputRoot: '/tmp/worktree',
+      agentCwd: '/tmp/worktree',
+    }));
+    expect(mockExtractLearnings).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      issueNum: 11,
+      outputRoot: '/tmp/worktree',
+      agentCwd: '/tmp/worktree',
+    }));
+
+    const commitCallIndex = mockExec.mock.calls.findIndex(([cmd]) =>
+      String(cmd).startsWith('git commit -m "chore: add learning artifacts for issues #10, #11"'),
+    );
+    expect(commitCallIndex).toBeGreaterThanOrEqual(0);
+    expect(mockExec.mock.calls[commitCallIndex][0]).toContain('issue-10-20260101-000000.md');
+    expect(mockExec.mock.calls[commitCallIndex][0]).toContain('issue-11-20260101-000000.md');
+    expect(mockExtractLearnings.mock.invocationCallOrder[1]).toBeLessThan(
+      mockExec.mock.invocationCallOrder[commitCallIndex],
+    );
+    expect(mockExec.mock.invocationCallOrder[commitCallIndex]).toBeLessThan(
+      mockCreatePR.mock.invocationCallOrder[0],
+    );
   });
 
   test('skips auto-merge when tests are failing', async () => {


### PR DESCRIPTION
Closes #224
Part of #245

## Summary

Automated implementation of **Pipeline: commit learning files inside the worktree so they ship with the implementation PR**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Fixed resume learning artifact fallback; build and full test suite pass.

- **CRITICAL** [FIXED] `src/commands/resume.ts`: alpha-loop resume only committed repaired learning artifacts from existing raw logs, so branches recovered before learning extraction could still open PRs without a learning file.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*