### PR TITLE
feat: Pipeline: add recoveryMode field to PipelineResult so resume-written results are distinguishable (closes #225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ alpha-loop eval run --matrix --profiles "all-frontier,hybrid-v1" --out eval/repo
 alpha-loop eval run --matrix --tags routing-regression --execute  # real runs (see CASE_FORMAT.md)
 ```
 
-Eval cases live in `.alpha-loop/evals/` and scores are appended to `scores.jsonl` (Git-friendly, append-only). The composite score formula is pass-rate primary with lightweight penalties for retries and duration. Real API costs (tokens, USD) are tracked per case from agent output and used for the Pareto frontier.
+Eval cases live in `.alpha-loop/evals/` and scores are appended to `scores.jsonl` (Git-friendly, append-only). The composite score formula is pass-rate primary with lightweight penalties for retries and duration. Recovered session results are flagged and excluded from aggregate scoring. Real API costs (tokens, USD) are tracked per case from agent output and used for the Pareto frontier.
 
 Step-level evals test individual pipeline stages (plan, implement, test, test-fix, review, learn, skill) and run in seconds using LLM-judge and keyword checks:
 
@@ -257,11 +257,11 @@ If the loop hangs or crashes mid-session, work can be stranded on local branches
 3. Runs code review
 4. Creates WIP PRs, marks issues `In Review`, and updates the session PR with a verification caveat
 
-Recovered PRs are not marked complete. `resume` does not rerun the project test suite or final smoke tests, so verify recovered work before merging.
+Recovered PRs are written with `recoveryMode: "resume"` and are not marked complete. `resume` does not rerun the project test suite or final smoke tests, so verify recovered work before merging.
 
 Use `--issue <N>` to resume a specific issue.
 
-`alpha-loop history <session>` also shows `crash-<N>.json` markers for issues that crashed after writing commits but before a result file was saved.
+`alpha-loop history <session>` shows both unrecovered `crash-<N>.json` markers and recovered result files separately from normal successes and failures.
 
 ### Screenshots
 

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -67,6 +67,8 @@ import {
 } from '../lib/eval-matrix.js';
 import { renderMatrixMarkdown, renderMatrixCsv } from '../lib/eval-report.js';
 import { scanCaseDir, formatFindings } from '../lib/eval-secret-scan.js';
+import { isRecoveredResult } from '../lib/pipeline.js';
+import type { PipelineResult } from '../lib/pipeline.js';
 
 /** Canonical profiles the matrix run uses when --profiles isn't supplied. */
 const DEFAULT_MATRIX_PROFILES = ['all-frontier', 'hybrid-v1', 'all-local'];
@@ -477,7 +479,7 @@ type SessionFailure = {
   issueNum: number;
   title: string;
   file: string;
-  result: Record<string, unknown>;
+  result: PipelineResult & { issueBody?: unknown };
 };
 
 /** Collect failures from recent sessions. */
@@ -500,8 +502,8 @@ function collectSessionFailures(): SessionFailure[] {
 
     for (const file of resultFiles) {
       try {
-        const result = JSON.parse(readFileSync(join(sessionPath, file), 'utf-8'));
-        if (result.status === 'failure') {
+        const result = JSON.parse(readFileSync(join(sessionPath, file), 'utf-8')) as PipelineResult & { issueBody?: unknown };
+        if (result.status === 'failure' && !isRecoveredResult(result)) {
           failures.push({
             session: sessionDir,
             issueNum: result.issueNum,
@@ -531,7 +533,14 @@ function groupBySession(failures: SessionFailure[]): Map<string, SessionFailure[
 }
 
 /** Detect failure step from a raw session result object. */
-function detectFailureStepFromResult(result: Record<string, unknown>): string {
+function detectFailureStepFromResult(result: {
+  testsPassing?: unknown;
+  filesChanged?: unknown;
+  verifyPassing?: unknown;
+  verifySkipped?: unknown;
+  recoveryMode?: unknown;
+}): string {
+  if (result.recoveryMode) return 'recovered';
   if (!result.testsPassing) {
     return (typeof result.filesChanged === 'number' && result.filesChanged > 1) ? 'test-fix' : 'implement';
   }
@@ -550,6 +559,10 @@ async function captureSpecificIssue(issueNum: number, config: Config): Promise<v
     if (issues.includes(issueNum)) {
       const metadata = readTraceMetadata(session, issueNum);
       if (metadata) {
+        if (metadata.recoveryMode) {
+          log.warn(`Issue #${issueNum} was recovered by ${metadata.recoveryMode}; recovered runs are skipped by eval capture.`);
+          return;
+        }
         found = true;
         const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
         try {
@@ -576,7 +589,11 @@ async function captureSpecificIssue(issueNum: number, config: Config): Promise<v
         const resultFile = join(sessionsDir, sessionDir, `result-${issueNum}.json`);
         if (existsSync(resultFile)) {
           found = true;
-          const result = JSON.parse(readFileSync(resultFile, 'utf-8'));
+          const result = JSON.parse(readFileSync(resultFile, 'utf-8')) as PipelineResult;
+          if (isRecoveredResult(result)) {
+            log.warn(`Issue #${issueNum} was recovered by ${result.recoveryMode}; recovered runs are skipped by eval capture.`);
+            return;
+          }
           const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
           try {
             await captureFailure(rl, {
@@ -648,7 +665,11 @@ async function captureFailure(
 ): Promise<void> {
   log.step(`\nCapturing: #${failure.issueNum} — ${failure.title}`);
 
-  const result = JSON.parse(readFileSync(failure.file, 'utf-8'));
+  const result = JSON.parse(readFileSync(failure.file, 'utf-8')) as PipelineResult;
+  if (isRecoveredResult(result)) {
+    log.warn(`Issue #${failure.issueNum} was recovered by ${result.recoveryMode}; recovered runs are skipped by eval capture.`);
+    return;
+  }
   const step = detectFailureStepFromResult(result);
 
   console.log(`  Failed at: ${step}`);
@@ -679,7 +700,7 @@ type SessionSuccess = {
   issueNum: number;
   title: string;
   file: string;
-  result: Record<string, unknown>;
+  result: PipelineResult & { issueBody?: unknown };
 };
 
 /** Collect successful results from recent sessions. */
@@ -706,8 +727,8 @@ function collectSessionSuccesses(sessionFilter?: string): SessionSuccess[] {
 
     for (const file of resultFiles) {
       try {
-        const result = JSON.parse(readFileSync(join(sessionPath, file), 'utf-8'));
-        if (result.status === 'success') {
+        const result = JSON.parse(readFileSync(join(sessionPath, file), 'utf-8')) as PipelineResult & { issueBody?: unknown };
+        if (result.status === 'success' && !isRecoveredResult(result)) {
           successes.push({
             session: sessionDir,
             issueNum: result.issueNum,

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -4,6 +4,7 @@ import { log } from '../lib/logger.js';
 import { loadCrashMarkers, type CrashMarker } from '../lib/session.js';
 import { readStageTelemetry } from '../lib/telemetry.js';
 import type { StageTelemetry } from '../lib/telemetry.js';
+import { isRecoveredResult } from '../lib/pipeline.js';
 import type { PipelineResult } from '../lib/pipeline.js';
 import type { EscalationEvent } from '../lib/escalation.js';
 import type { EpicQueueManifest, QueueSessionContext } from '../lib/epic-queue.js';
@@ -214,9 +215,12 @@ export function historyList(sessionsDir: string, projectDir?: string): void {
     for (const entry of entries) {
       const crashCount = uniqueCrashMarkers(entry.results, entry.crashes).length;
       const issueCount = entry.results.length + crashCount;
-      const successCount = entry.results.filter((r) => r.status === 'success').length;
-      const failedCount = entry.results.length - successCount;
-      const totalDuration = entry.results.reduce((sum, r) => sum + r.duration, 0);
+      const recoveredCount = entry.results.filter(isRecoveredResult).length;
+      const successCount = entry.results.filter((r) => r.status === 'success' && !isRecoveredResult(r)).length;
+      const failedCount = entry.results.filter((r) => r.status === 'failure' && !isRecoveredResult(r)).length;
+      const totalDuration = entry.results
+        .filter((r) => !isRecoveredResult(r))
+        .reduce((sum, r) => sum + r.duration, 0);
       const durStr = formatDuration(totalDuration);
 
       // Parse date from timestamp (YYYYMMDD-HHMMSS)
@@ -229,6 +233,7 @@ export function historyList(sessionsDir: string, projectDir?: string): void {
       let statusParts = '';
       if (successCount > 0) statusParts += `${successCount} \u2713`;
       if (failedCount > 0) statusParts += ` ${failedCount} \u2717`;
+      if (recoveredCount > 0) statusParts += ` ${recoveredCount} recovered`;
       if (crashCount > 0) statusParts += ` ${crashCount} crashed`;
       if (issueCount === 0) statusParts = '(empty)';
 
@@ -371,13 +376,15 @@ export function historyDetail(sessionsDir: string, sessionName: string, projectD
     return;
   }
 
-  const totalDuration = results.reduce((sum, r) => sum + r.duration, 0);
-  const successCount = results.filter((r) => r.status === 'success').length;
-  const failureCount = results.length - successCount;
+  const naturalResults = results.filter((r) => !isRecoveredResult(r));
+  const totalDuration = naturalResults.reduce((sum, r) => sum + r.duration, 0);
+  const successCount = naturalResults.filter((r) => r.status === 'success').length;
+  const failureCount = naturalResults.filter((r) => r.status === 'failure').length;
+  const recoveredCount = results.length - naturalResults.length;
   const issueCount = results.length + visibleCrashes.length;
 
   console.log(`Session:  ${sessionName}`);
-  console.log(`Issues:   ${issueCount} (${successCount} succeeded, ${failureCount} failed, ${visibleCrashes.length} crashed)`);
+  console.log(`Issues:   ${issueCount} (${successCount} succeeded, ${failureCount} failed, ${recoveredCount} recovered, ${visibleCrashes.length} crashed)`);
   console.log(`Duration: ${formatDuration(totalDuration)}`);
   console.log('');
 
@@ -403,10 +410,13 @@ export function historyDetail(sessionsDir: string, sessionName: string, projectD
 
   console.log('Issues:');
   for (const result of results) {
-    const symbol = result.status === 'success' ? '\u2713' : '\u2717';
+    const recovered = isRecoveredResult(result);
+    const symbol = recovered ? '~' : result.status === 'success' ? '\u2713' : '\u2717';
     let statusText: string;
 
-    if (result.status === 'success' && result.prUrl) {
+    if (recovered) {
+      statusText = `RECOVERED:${result.recoveryMode.toUpperCase()}`;
+    } else if (result.status === 'success' && result.prUrl) {
       const prNum = result.prUrl.match(/(\d+)$/)?.[1] ?? '';
       statusText = `PR #${prNum}`;
     } else if (result.status === 'success') {

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -22,6 +22,7 @@ import {
   createPR,
   updateProjectStatus,
 } from '../lib/github.js';
+import { isRecoveredResult } from '../lib/pipeline.js';
 import type { PipelineResult } from '../lib/pipeline.js';
 
 export type ResumeOptions = {
@@ -485,12 +486,8 @@ function saveResumedResult(
   clearCrashMarker(sessionDir, result.issueNum);
 }
 
-function isRecoveredUnverified(result: PipelineResult): boolean {
-  return Boolean(result.prUrl) && result.verifySkipped && !result.verifyPassing;
-}
-
 function formatSessionIssueStatus(result: PipelineResult): string {
-  if (isRecoveredUnverified(result)) return 'RECOVERED - VERIFY SKIPPED';
+  if (isRecoveredResult(result)) return `RECOVERED BY ${result.recoveryMode?.toUpperCase()}`;
   return result.status === 'success' ? 'SUCCESS' : 'FAILURE';
 }
 
@@ -541,28 +538,40 @@ function updateSessionPR(
 
   if (results.length === 0) return;
 
-  const successCount = results.filter((r) => r.status === 'success').length;
-  const totalDuration = results.reduce((sum, r) => sum + r.duration, 0);
-  const recoveredUnverifiedCount = results.filter(isRecoveredUnverified).length;
-  const resumeCaveat = recoveredUnverifiedCount > 0
+  const recovered = results.filter(isRecoveredResult);
+  const naturalResults = results.filter((r) => !isRecoveredResult(r));
+  const successes = naturalResults.filter((r) => r.status === 'success');
+  const failures = naturalResults.filter((r) => r.status === 'failure');
+  const totalDuration = naturalResults.reduce((sum, r) => sum + r.duration, 0);
+  const resumeCaveat = recovered.length > 0
     ? `
 ### Resume Caveat
 
-${recoveredUnverifiedCount} recovered PR(s) were not counted as succeeded because \`alpha-loop resume\` does not rerun tests or final verification smoke tests.
+${recovered.length} recovered PR(s) were not counted as succeeded or failed because \`alpha-loop resume\` does not rerun tests or final verification smoke tests.
 `
     : '';
+  const titleStatus = naturalResults.length > 0
+    ? `${successes.length}/${naturalResults.length} succeeded`
+    : `${successes.length} succeeded`;
+  const titleRecovery = recovered.length > 0 ? `, ${recovered.length} recovered` : '';
 
-  const title = `Session: ${sessionName} — ${successCount}/${results.length} succeeded`;
+  const title = `Session: ${sessionName} — ${titleStatus}${titleRecovery}`;
   const body = `## Session Summary
 
 **Branch:** ${sessionBranch}
-**Issues processed:** ${results.length} (${successCount} succeeded, ${results.length - successCount} failed)
+**Issues processed:** ${results.length} (${successes.length} succeeded, ${failures.length} failed, ${recovered.length} recovered)
 **Total duration:** ${Math.round(totalDuration / 60)} minutes
 **Updated:** ${new Date().toISOString()}
 ${resumeCaveat}
 
 ### Issues
-${results.map((r) => `- #${r.issueNum}: ${r.title} — ${formatSessionIssueStatus(r)}${r.prUrl ? ` ([PR](${r.prUrl}))` : ''}`).join('\n')}
+${naturalResults.length > 0
+    ? naturalResults.map((r) => `- #${r.issueNum}: ${r.title} — ${formatSessionIssueStatus(r)}${r.prUrl ? ` ([PR](${r.prUrl}))` : ''}`).join('\n')
+    : 'No naturally completed issues yet.'}
+${recovered.length > 0 ? `
+### Recovered Issues
+${recovered.map((r) => `- #${r.issueNum}: ${r.title} — ${formatSessionIssueStatus(r)}${r.prUrl ? ` ([PR](${r.prUrl}))` : ''}`).join('\n')}
+` : ''}
 
 ---
 This PR collects all changes from this session for final review before merging to ${baseBranch}.
@@ -644,6 +653,7 @@ export async function resumeCommand(options: ResumeOptions): Promise<void> {
         issueNum: r.issueNum,
         title: r.title,
         status: 'failure',
+        recoveryMode: 'resume',
         failureReason: 'transient',
         prUrl: r.prUrl,
         testsPassing: false,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -126,6 +126,10 @@ type SessionExecutionResult = {
   verificationClosedEpic: boolean;
 };
 
+function isRecoveredRunResult(result: { recoveryMode?: unknown }): boolean {
+  return result.recoveryMode !== undefined;
+}
+
 /**
  * Check that required CLI tools are installed.
  * Also warns about optional tools (playwright-cli) that improve the pipeline.
@@ -675,7 +679,7 @@ async function runIssueSession(
     }
 
     const issueCount = session.results.length;
-    const successCount = session.results.filter((r) => r.status === 'success').length;
+    const successCount = session.results.filter((r) => r.status === 'success' && !isRecoveredRunResult(r)).length;
     log.info(`Session complete: ${successCount}/${issueCount} issues succeeded`);
     process.exit(0);
   };
@@ -898,7 +902,7 @@ async function runIssueSession(
           if (activeEpic !== undefined && !config.dryRun) {
             let checklistError = false;
             for (const r of results) {
-              if (r.status !== 'success') continue;
+              if (r.status !== 'success' || isRecoveredRunResult(r)) continue;
               try {
                 updateEpicChecklist(config.repo, activeEpic, r.issueNum, true);
                 markEpicChecklistItem(epicChecklist, epicPromptContext, r.issueNum, true);
@@ -918,14 +922,14 @@ async function runIssueSession(
             }
           } else if (activeEpic !== undefined && config.dryRun) {
             for (const r of results) {
-              if (r.status === 'success') {
+              if (r.status === 'success' && !isRecoveredRunResult(r)) {
                 log.dry(`Would flip epic #${activeEpic} checklist for sub-issue #${r.issueNum}`);
               }
             }
           }
 
           // Stop if any issue hit a transient error
-          if (results.some((r) => r.failureReason === 'transient')) {
+          if (results.some((r) => r.failureReason === 'transient' && !isRecoveredRunResult(r))) {
             log.warn('Agent hit a rate/usage limit — stopping session to avoid wasting cycles');
             break;
           }
@@ -977,7 +981,7 @@ async function runIssueSession(
           // Flip the epic checklist box when this sub-issue succeeded.
           // Skipped in dry-run: `processIssue` stubs tests in dry-run and returns success,
           // which would otherwise mutate the live epic body.
-          if (activeEpic !== undefined && result.status === 'success' && !config.dryRun) {
+          if (activeEpic !== undefined && result.status === 'success' && !isRecoveredRunResult(result) && !config.dryRun) {
             try {
               updateEpicChecklist(config.repo, activeEpic, issue.number, true);
               markEpicChecklistItem(epicChecklist, epicPromptContext, issue.number, true);
@@ -990,12 +994,12 @@ async function runIssueSession(
               activeIssueNum = null;
               break;
             }
-          } else if (activeEpic !== undefined && result.status === 'success' && config.dryRun) {
+          } else if (activeEpic !== undefined && result.status === 'success' && !isRecoveredRunResult(result) && config.dryRun) {
             log.dry(`Would flip epic #${activeEpic} checklist for sub-issue #${issue.number}`);
           }
 
           // Stop processing if agent hit a transient error (usage/rate limit)
-          if (result.failureReason === 'transient') {
+          if (result.failureReason === 'transient' && !isRecoveredRunResult(result)) {
             log.warn('Agent hit a rate/usage limit — stopping session to avoid wasting cycles');
             break;
           }
@@ -1030,7 +1034,7 @@ async function runIssueSession(
       } else {
         const message = `Epic #${activeEpic}: ${remaining.length} sub-issue(s) still open — verification deferred`;
         log.info(message);
-        const hasFailedIssueResult = session.results.some((result) => result.status === 'failure');
+        const hasFailedIssueResult = session.results.some((result) => result.status === 'failure' && !isRecoveredRunResult(result));
         if (options.stopOnPartialEpic && !hasFailedIssueResult) {
           failures.push({
             code: 'epic-incomplete',
@@ -1047,7 +1051,7 @@ async function runIssueSession(
   }
 
   for (const result of session.results) {
-    if (result.status === 'failure') {
+    if (result.status === 'failure' && !isRecoveredRunResult(result)) {
       const transient = result.failureReason === 'transient';
       failures.push({
         code: transient ? 'transient-stop' : 'pipeline-failure',
@@ -1061,7 +1065,7 @@ async function runIssueSession(
 
   // Auto-capture failures as eval case skeletons
   if (config.autoCapture && session.results.length > 0) {
-    const failures = session.results.filter((r) => r.status === 'failure');
+    const failures = session.results.filter((r) => r.status === 'failure' && !isRecoveredRunResult(r));
     if (failures.length > 0) {
       log.step(`Auto-capturing ${failures.length} failure(s) as eval cases...`);
       for (const failure of failures) {
@@ -1239,7 +1243,7 @@ async function runIssueSession(
   const finalizedPrUrl = await finalizeSession(session, config);
   const sessionPrUrl = finalizedPrUrl ?? session.sessionPrUrl ?? null;
 
-  const successCount = session.results.filter((r) => r.status === 'success').length;
+  const successCount = session.results.filter((r) => r.status === 'success' && !isRecoveredRunResult(r)).length;
   log.info(`Session complete: ${successCount}/${session.results.length} issues succeeded`);
   process.off('SIGINT', handleSigint);
   process.off('SIGTERM', handleSigterm);

--- a/src/lib/eval.ts
+++ b/src/lib/eval.ts
@@ -16,6 +16,7 @@ import { join, basename, relative } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { log } from './logger.js';
 import type { Config } from './config.js';
+import { isRecoveredResult } from './pipeline.js';
 import type { PipelineResult } from './pipeline.js';
 import { computeCompositeScore, appendScore, hashConfig } from './score.js';
 import type { CaseResult, ScoreEntry } from './score.js';
@@ -521,6 +522,7 @@ export type SaveCapturedCaseOptions = {
  * Detect which pipeline step failed from a PipelineResult.
  */
 export function detectFailureStep(result: PipelineResult): string {
+  if (isRecoveredResult(result)) return 'recovered';
   if (!result.testsPassing) {
     // If the issue's filesChanged > 0, the agent at least tried to implement;
     // multiple retries suggest a test-fix loop failure

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -322,10 +322,14 @@ export function formatGateFindings(gate: GateResult, gateType: string): string {
   return lines.join('\n');
 }
 
+export type PipelineRecoveryMode = 'resume' | 'manual';
+
 export type PipelineResult = {
   issueNum: number;
   title: string;
   status: 'success' | 'failure';
+  /** Set when the result was synthesized after out-of-band recovery instead of produced by the normal pipeline. */
+  recoveryMode?: PipelineRecoveryMode;
   /** Why the issue failed — 'transient' means re-queue (e.g. usage limit), 'permanent' means label failed. */
   failureReason?: 'transient' | 'permanent';
   prUrl?: string;
@@ -337,6 +341,12 @@ export type PipelineResult = {
   /** Structured escalation events recorded while processing this issue. */
   escalationEvents?: EscalationEvent[];
 };
+
+export function isRecoveredResult<T extends { recoveryMode?: PipelineRecoveryMode }>(
+  result: T,
+): result is T & { recoveryMode: PipelineRecoveryMode } {
+  return result.recoveryMode !== undefined;
+}
 
 export type PipelineOptions = {
   epicContext?: EpicPromptContext;
@@ -1985,6 +1995,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
       const scoreResults: PipelineResultForScores[] = results.map((r) => ({
         issueNum: r.issueNum,
         status: r.status,
+        recoveryMode: r.recoveryMode,
         testsPassing: r.testsPassing,
         verifyPassing: r.verifyPassing,
         verifySkipped: r.verifySkipped,

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -28,6 +28,12 @@ export type SessionContext = {
   queue?: QueueSessionContext;
 };
 
+function isRecoveredSessionResult(
+  result: PipelineResult,
+): result is PipelineResult & { recoveryMode: NonNullable<PipelineResult['recoveryMode']> } {
+  return result.recoveryMode !== undefined;
+}
+
 export type CrashMarker = {
   issueNum: number;
   step: string;
@@ -533,6 +539,7 @@ export async function finalizeSession(
       prUrl: r.prUrl,
       testsPassing: r.testsPassing,
       verifyPassing: r.verifyPassing,
+      recoveryMode: r.recoveryMode,
       duration: r.duration,
       filesChanged: r.filesChanged,
     })),
@@ -561,20 +568,25 @@ export async function finalizeSession(
   }
 
   // Create or update session PR
-  const successes = session.results.filter((r) => r.status === 'success');
-  const permanentFailures = session.results.filter((r) => r.status === 'failure' && r.failureReason !== 'transient');
-  const transientFailures = session.results.filter((r) => r.status === 'failure' && r.failureReason === 'transient');
-  const totalDuration = session.results.reduce((sum, r) => sum + r.duration, 0);
+  const recovered = session.results.filter(isRecoveredSessionResult);
+  const naturalResults = session.results.filter((r) => !isRecoveredSessionResult(r));
+  const successes = naturalResults.filter((r) => r.status === 'success');
+  const permanentFailures = naturalResults.filter((r) => r.status === 'failure' && r.failureReason !== 'transient');
+  const transientFailures = naturalResults.filter((r) => r.status === 'failure' && r.failureReason === 'transient');
+  const totalDuration = naturalResults.reduce((sum, r) => sum + r.duration, 0);
 
   // Only count completed issues (not transient failures that were re-queued)
   const completedCount = successes.length + permanentFailures.length;
-  const prTitle = `Session: ${session.name} — ${successes.length}/${completedCount} succeeded`;
+  const titleStatus = completedCount > 0
+    ? `${successes.length}/${completedCount} succeeded`
+    : `${successes.length} succeeded`;
+  const prTitle = `Session: ${session.name} — ${titleStatus}${recovered.length > 0 ? `, ${recovered.length} recovered` : ''}`;
 
   const prLines: string[] = [
     '## Session Summary',
     '',
     `**Branch:** ${session.branch}`,
-    `**Issues completed:** ${completedCount} (${successes.length} succeeded, ${permanentFailures.length} failed)`,
+    `**Issues processed:** ${session.results.length} (${successes.length} succeeded, ${permanentFailures.length} failed, ${recovered.length} recovered)`,
     `**Total duration:** ${Math.round(totalDuration / 60)} minutes`,
     `**Completed:** ${new Date().toISOString()}`,
     '',
@@ -593,6 +605,18 @@ export async function finalizeSession(
     }
     prLines.push('');
     prLines.push(...successes.map((r) => `Closes #${r.issueNum}`));
+    prLines.push('');
+  }
+
+  // Recovered issues — visible, but not natural successes/failures.
+  if (recovered.length > 0) {
+    prLines.push('### Recovered Issues');
+    for (const r of recovered) {
+      const mode = r.recoveryMode.toUpperCase();
+      prLines.push(`- #${r.issueNum}: ${r.title} — RECOVERED BY ${mode}${r.prUrl ? ` ([PR](${r.prUrl}))` : ''}`);
+    }
+    prLines.push('');
+    prLines.push('*Recovered issues were not counted as succeeded or failed because recovery did not run the full pipeline verification path.*');
     prLines.push('');
   }
 
@@ -656,7 +680,7 @@ export async function finalizeSession(
     // When not auto-merging, individual PRs were already created, so mark as "Done"
     const boardStatus = config.autoMerge ? 'In Review' : 'Done';
     for (const r of session.results) {
-      if (r.status === 'success' && config.project > 0) {
+      if (r.status === 'success' && !isRecoveredSessionResult(r) && config.project > 0) {
         updateProjectStatus(config.repo, config.project, config.repoOwner, r.issueNum, boardStatus);
       }
     }

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { estimateCost } from './config.js';
 import type { Config, RoutingEndpointType } from './config.js';
 import type { AgentResult } from './agent.js';
+import type { PipelineRecoveryMode } from './pipeline.js';
 
 /** One per-stage telemetry record. Written once per agent invocation. */
 export type StageTelemetry = {
@@ -52,6 +53,7 @@ export type SessionManifestLite = {
   results?: Array<{
     issueNum: number;
     status: 'success' | 'failure';
+    recoveryMode?: PipelineRecoveryMode;
     filesChanged?: number;
     prUrl?: string;
   }>;
@@ -241,7 +243,7 @@ function median(values: number[]): number {
  * - `pipeline_success_rate`: fraction of parent sessions that shipped a
  *   successful issue while this (stage, model) cell was active.
  * - `cost_per_issue_shipped`: total cost across this cell divided by the
- *   number of shipped (status=success, filesChanged>0) issues in the sessions
+ *   number of shipped (status=success, filesChanged>0, not recovered) issues in the sessions
  *   where this cell ran.
  * - `median_wall_time_s`: median wall_time_s across invocations.
  * - `tool_error_rate`: sum(tool_errors) / sum(tool_calls || runs).
@@ -282,10 +284,10 @@ export function aggregateRouting(
   for (const { session, entries } of items) {
     const sessionName = deriveSessionName(session);
     const manifest = manifestByName.get(sessionName) ?? manifestByName.get(session);
-    // Count shipped issues per session (success + filesChanged > 0).
+    // Count shipped issues per session (success + filesChanged > 0, excluding recovered synthetic results).
     if (manifest && !sessionShipped.has(session)) {
       const shipped = (manifest.results ?? []).filter(
-        (r) => r.status === 'success' && (r.filesChanged ?? 0) > 0,
+        (r) => r.status === 'success' && (r.filesChanged ?? 0) > 0 && r.recoveryMode === undefined,
       ).length;
       sessionShipped.set(session, shipped);
     }

--- a/src/lib/traces.ts
+++ b/src/lib/traces.ts
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 import { log } from './logger.js';
 import { computeCompositeScore } from './score.js';
 import type { CaseResult } from './score.js';
+import type { PipelineRecoveryMode } from './pipeline.js';
 
 /** Known trace file names within an issue trace directory (backward compat). */
 export type TraceFile =
@@ -36,6 +37,7 @@ export type TraceMetadata = {
   issueNum: number;
   title: string;
   status: 'success' | 'failure';
+  recoveryMode?: PipelineRecoveryMode;
   failureReason?: 'transient' | 'permanent';
   duration: number;
   retries: number;
@@ -82,6 +84,8 @@ export type RunManifest = {
 /** Per-issue score in scores.json. */
 export type IssueScore = {
   status: 'success' | 'failure';
+  recovery_mode?: PipelineRecoveryMode;
+  scored?: boolean;
   tests_passed: boolean;
   verify_passed: boolean;
   retries: number;
@@ -99,6 +103,8 @@ export type ScoresJson = {
     avg_retries: number;
     avg_duration: number;
     total_issues: number;
+    scored_issues?: number;
+    recovered_issues?: number;
     issues_passed: number;
   };
 };
@@ -129,6 +135,7 @@ export type CostsJson = {
 export type PipelineResultForScores = {
   issueNum: number;
   status: 'success' | 'failure';
+  recoveryMode?: PipelineRecoveryMode;
   testsPassing: boolean;
   verifyPassing: boolean;
   verifySkipped: boolean;
@@ -269,8 +276,11 @@ export function computeScores(results: PipelineResultForScores[]): ScoresJson {
   const issues: Record<string, IssueScore> = {};
 
   for (const r of results) {
+    const recovered = r.recoveryMode !== undefined;
     issues[String(r.issueNum)] = {
       status: r.status,
+      recovery_mode: r.recoveryMode,
+      scored: !recovered,
       tests_passed: r.testsPassing,
       verify_passed: r.verifyPassing,
       retries: r.retries,
@@ -280,14 +290,16 @@ export function computeScores(results: PipelineResultForScores[]): ScoresJson {
     };
   }
 
-  const total = results.length;
-  const passed = results.filter((r) => r.status === 'success').length;
+  const scoredResults = results.filter((r) => r.recoveryMode === undefined);
+  const total = scoredResults.length;
+  const recovered = results.length - total;
+  const passed = scoredResults.filter((r) => r.status === 'success').length;
   const passRate = total > 0 ? passed / total : 0;
-  const avgRetries = total > 0 ? results.reduce((sum, r) => sum + r.retries, 0) / total : 0;
-  const avgDuration = total > 0 ? results.reduce((sum, r) => sum + r.duration, 0) / total : 0;
+  const avgRetries = total > 0 ? scoredResults.reduce((sum, r) => sum + r.retries, 0) / total : 0;
+  const avgDuration = total > 0 ? scoredResults.reduce((sum, r) => sum + r.duration, 0) / total : 0;
 
   // Use the canonical composite score formula from score.ts
-  const caseResults: CaseResult[] = results.map((r) => ({
+  const caseResults: CaseResult[] = scoredResults.map((r) => ({
     caseId: String(r.issueNum),
     passed: r.status === 'success',
     partialCredit: r.status === 'success' ? 1 : 0,
@@ -303,7 +315,9 @@ export function computeScores(results: PipelineResultForScores[]): ScoresJson {
       pass_rate: Math.round(passRate * 1000) / 1000,
       avg_retries: Math.round(avgRetries * 10) / 10,
       avg_duration: Math.round(avgDuration),
-      total_issues: total,
+      total_issues: results.length,
+      scored_issues: total,
+      recovered_issues: recovered,
       issues_passed: passed,
     },
   };

--- a/tests/commands/history.test.ts
+++ b/tests/commands/history.test.ts
@@ -14,7 +14,7 @@ function createTempDir(): string {
 function createSession(
   sessionsDir: string,
   timestamp: string,
-  results: Array<{ issueNum: number; title: string; status: string; prUrl?: string; duration: number }>,
+  results: Array<{ issueNum: number; title: string; status: string; prUrl?: string; duration: number; recoveryMode?: 'resume' | 'manual' }>,
 ): void {
   const dir = path.join(sessionsDir, 'session', timestamp);
   fs.mkdirSync(dir, { recursive: true });
@@ -25,6 +25,7 @@ function createSession(
         issueNum: r.issueNum,
         title: r.title,
         status: r.status,
+        recoveryMode: r.recoveryMode,
         prUrl: r.prUrl,
         testsPassing: r.status === 'success',
         verifyPassing: r.status === 'success',
@@ -232,6 +233,22 @@ describe('history', () => {
       expect(output).toContain('1 crashed');
     });
 
+    it('shows recovered issue counts separately from success and failure counts', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      createSession(sessionsDir, '20250115-100000', [
+        { issueNum: 1, title: 'Good issue', status: 'success', duration: 180 },
+        { issueNum: 2, title: 'Recovered issue', status: 'failure', recoveryMode: 'resume', duration: 0 },
+      ]);
+
+      historyList(sessionsDir, tmpDir);
+
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('2 issues');
+      expect(output).toContain('1 recovered');
+      expect(output).toContain('1 ✓');
+      expect(output).not.toContain('1 ✗');
+    });
+
     it('lists multi-epic queue manifests with status and pending counts', () => {
       const sessionsDir = path.join(tmpDir, '.alpha-loop', 'sessions');
       createQueueManifest(sessionsDir);
@@ -281,6 +298,20 @@ describe('history', () => {
       expect(output).toContain('#216  CRASHED during review');
       expect(output).toContain('branch agent/issue-216');
       expect(output).toContain('error: review log ended unexpectedly');
+    });
+
+    it('shows recovered issues distinctly in session detail', () => {
+      const sessionsDir = path.join(tmpDir, 'sessions');
+      createSession(sessionsDir, '20250115-103000', [
+        { issueNum: 216, title: 'Recovered branch', status: 'failure', prUrl: 'https://github.com/owner/repo/pull/216', recoveryMode: 'resume', duration: 0 },
+      ]);
+
+      historyDetail(sessionsDir, 'session/20250115-103000');
+
+      const output = consoleSpy.mock.calls.map((c: unknown[]) => c[0]).join('\n');
+      expect(output).toContain('0 succeeded, 0 failed, 1 recovered');
+      expect(output).toContain('~ #216');
+      expect(output).toContain('RECOVERED:RESUME');
     });
 
     it('shows error for non-existent session', () => {

--- a/tests/commands/resume.test.ts
+++ b/tests/commands/resume.test.ts
@@ -242,7 +242,8 @@ describe('resumeCommand', () => {
     }));
     expect(existsSync(join(sessionDir, 'crash-269.json'))).toBe(false);
     expect(existsSync(join(sessionDir, 'result-269.json'))).toBe(true);
-    expect(sessionPrBody).toContain('#269: Recover artifact exports — RECOVERED - VERIFY SKIPPED');
+    expect(sessionPrBody).toContain('### Recovered Issues');
+    expect(sessionPrBody).toContain('#269: Recover artifact exports — RECOVERED BY RESUME');
   });
 
   test('records recovered PRs as unverified WIP and updates the session PR without CommonJS require', async () => {
@@ -326,6 +327,7 @@ describe('resumeCommand', () => {
       issueNum: 269,
       title: 'Recover artifact exports',
       status: 'failure',
+      recoveryMode: 'resume',
       failureReason: 'transient',
       prUrl: 'https://github.com/owner/repo/pull/269',
       testsPassing: false,
@@ -335,13 +337,14 @@ describe('resumeCommand', () => {
     }));
 
     expect(mockGhExec).toHaveBeenCalledWith(
-      expect.stringContaining('gh pr edit 999 --repo "owner/repo" --title "Session: session/epic-123'),
+      expect.stringContaining('gh pr edit 999 --repo "owner/repo" --title "Session: session/epic-123 — 0 succeeded, 1 recovered"'),
       undefined,
       true,
     );
-    expect(sessionPrBody).toContain('0 succeeded, 1 failed');
+    expect(sessionPrBody).toContain('0 succeeded, 0 failed, 1 recovered');
     expect(sessionPrBody).toContain('Resume Caveat');
-    expect(sessionPrBody).toContain('#269: Recover artifact exports — RECOVERED - VERIFY SKIPPED');
+    expect(sessionPrBody).toContain('### Recovered Issues');
+    expect(sessionPrBody).toContain('#269: Recover artifact exports — RECOVERED BY RESUME');
     expect(sessionPrBody).toContain('https://github.com/owner/repo/pull/269');
   });
 

--- a/tests/eval-capture.test.ts
+++ b/tests/eval-capture.test.ts
@@ -78,6 +78,17 @@ describe('detectFailureStep', () => {
     });
     expect(detectFailureStep(result)).toBe('review');
   });
+
+  it('flags recovered results instead of assigning them to a normal failure step', () => {
+    const result = makePipelineResult({
+      recoveryMode: 'resume',
+      testsPassing: false,
+      verifyPassing: false,
+      verifySkipped: true,
+      filesChanged: 2,
+    });
+    expect(detectFailureStep(result)).toBe('recovered');
+  });
 });
 
 describe('saveCapturedCase', () => {

--- a/tests/lib/session.test.ts
+++ b/tests/lib/session.test.ts
@@ -631,4 +631,34 @@ describe('finalizeSession', () => {
     const title = mockCreatePR.mock.calls[0][0].title;
     expect(title).toContain('1/1 succeeded');
   });
+
+  test('shows recovered issues separately from natural successes in final session PR body', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('diff --cached --quiet')) {
+        return { stdout: '', stderr: '', exitCode: 1 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/99');
+
+    const config = makeConfig({ autoMerge: true });
+    const session = createSession(config);
+    session.results.push(
+      { issueNum: 1, title: 'Success issue', status: 'success', prUrl: 'https://github.com/owner/repo/pull/1', testsPassing: true, verifyPassing: true, verifySkipped: false, duration: 60, filesChanged: 3 },
+      { issueNum: 2, title: 'Recovered issue', status: 'failure', recoveryMode: 'resume', failureReason: 'transient', prUrl: 'https://github.com/owner/repo/pull/2', testsPassing: false, verifyPassing: false, verifySkipped: true, duration: 0, filesChanged: 2 },
+    );
+
+    await finalizeSession(session, config);
+
+    const finalPrCall = mockCreatePR.mock.calls.at(-1)![0];
+    const title = finalPrCall.title;
+    const body = finalPrCall.body;
+    expect(title).toContain('1/1 succeeded, 1 recovered');
+    expect(body).toContain('1 succeeded, 0 failed, 1 recovered');
+    expect(body).toContain('### Recovered Issues');
+    expect(body).toContain('#2: Recovered issue — RECOVERED BY RESUME');
+    expect(body).toContain('Closes #1');
+    expect(body).not.toContain('Closes #2');
+  });
 });

--- a/tests/lib/telemetry.test.ts
+++ b/tests/lib/telemetry.test.ts
@@ -356,6 +356,23 @@ describe('aggregateRouting', () => {
     expect(agg.cells[0].cost_per_issue_shipped).toBeNull();
   });
 
+  it('excludes recovered session results from shipped issue counts', () => {
+    const items = [
+      { session: 'S', entries: [entry('implement', 'm', 0.5, 10, 1, 0)] },
+    ];
+    const manifests: SessionManifestLite[] = [{
+      name: 'S',
+      results: [
+        { issueNum: 1, status: 'success', filesChanged: 3 },
+        { issueNum: 2, status: 'success', recoveryMode: 'resume', filesChanged: 3 },
+      ],
+    }];
+
+    const agg = aggregateRouting(items, manifests);
+    expect(agg.total_issues_shipped).toBe(1);
+    expect(agg.cells[0].cost_per_issue_shipped).toBe(0.5);
+  });
+
   it('handles sessions without a matching manifest gracefully', () => {
     const items = [
       { session: 'S', entries: [entry('implement', 'm', 0.5, 10, 1, 0)] },

--- a/tests/lib/traces.test.ts
+++ b/tests/lib/traces.test.ts
@@ -277,6 +277,46 @@ describe('computeScores', () => {
     // score.ts formula: (1/1)*100 - 0.1*0 - 0.01*100 = 99
     expect(scores.composite_score).toBe(99);
   });
+
+  it('flags recovered results and excludes them from aggregate scoring', () => {
+    const results: PipelineResultForScores[] = [
+      {
+        issueNum: 1,
+        status: 'success',
+        testsPassing: true,
+        verifyPassing: true,
+        verifySkipped: false,
+        retries: 0,
+        duration: 100,
+        filesChanged: 1,
+        stepsCompleted: ['plan', 'implement', 'test', 'review', 'pr'],
+      },
+      {
+        issueNum: 2,
+        status: 'failure',
+        recoveryMode: 'resume',
+        testsPassing: false,
+        verifyPassing: false,
+        verifySkipped: true,
+        retries: 0,
+        duration: 0,
+        filesChanged: 2,
+        stepsCompleted: [],
+      },
+    ];
+
+    const scores = computeScores(results);
+    expect(scores.aggregate.total_issues).toBe(2);
+    expect(scores.aggregate.scored_issues).toBe(1);
+    expect(scores.aggregate.recovered_issues).toBe(1);
+    expect(scores.aggregate.issues_passed).toBe(1);
+    expect(scores.aggregate.pass_rate).toBe(1);
+    expect(scores.aggregate.avg_duration).toBe(100);
+    expect(scores.issues['2']).toEqual(expect.objectContaining({
+      recovery_mode: 'resume',
+      scored: false,
+    }));
+  });
 });
 
 describe('computeCosts', () => {


### PR DESCRIPTION
Closes #225
Part of #245

## Summary

Automated implementation of **Pipeline: add recoveryMode field to PipelineResult so resume-written results are distinguishable**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Issue #225 implementation passes review; recoveryMode is stamped and downstream consumers distinguish recovered results.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*