### PR TITLE
feat: Resume: regenerate session summary when updating the session PR (closes #228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ If the loop hangs or crashes mid-session, work can be stranded on local branches
 2. Pushes each branch to origin
 3. Runs code review
 4. Creates WIP PRs, marks issues `In Review`, and updates the session PR with a verification caveat
+5. Regenerates missing learning artifacts and the aggregate session summary from recovered session results
 
 Recovered PRs are written with `recoveryMode: "resume"` and are not marked complete. `resume` does not rerun the project test suite or final smoke tests, so verify recovered work before merging.
 

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -14,7 +14,11 @@ import { exec } from '../lib/shell.js';
 import { ghExec } from '../lib/rate-limit.js';
 import { spawnAgent } from '../lib/agent.js';
 import { buildReviewPrompt } from '../lib/prompts.js';
-import { repairSessionLearningArtifacts } from '../lib/learning.js';
+import {
+  generateSessionSummary,
+  repairSessionLearningArtifacts,
+  repairSessionSummaryArtifact,
+} from '../lib/learning.js';
 import { clearCrashMarker, findCrashMarkers, type CrashMarkerRef } from '../lib/session.js';
 import {
   labelIssue,
@@ -494,12 +498,14 @@ function formatSessionIssueStatus(result: PipelineResult): string {
 /**
  * Find and update the session PR with current results.
  */
-function updateSessionPR(
-  repo: string,
+async function updateSessionPR(
+  config: ReturnType<typeof loadConfig>,
   sessionName: string,
   sessionDir: string,
-  baseBranch: string,
-): void {
+): Promise<void> {
+  const repo = config.repo;
+  const baseBranch = config.baseBranch;
+
   // Find the session branch
   const sessionBranch = sessionName;
 
@@ -537,6 +543,33 @@ function updateSessionPR(
   }
 
   if (results.length === 0) return;
+
+  const learningsDir = join(process.cwd(), '.alpha-loop', 'learnings');
+  if (!config.skipLearn) {
+    repairSessionLearningArtifacts({
+      sessionName,
+      issues: results.map((r) => ({
+        issueNum: r.issueNum,
+        title: r.title,
+        status: r.status,
+        duration: r.duration,
+      })),
+      learningsDir,
+      sessionLogsDir: join(sessionDir, 'logs'),
+    });
+    await generateSessionSummary({
+      sessionName,
+      results,
+      learningsDir,
+      config,
+    });
+    repairSessionSummaryArtifact({
+      sessionName,
+      learningsDir,
+    });
+  } else {
+    log.info('Skipping session summary regeneration (skipLearn=true)');
+  }
 
   const recovered = results.filter(isRecoveredResult);
   const naturalResults = results.filter((r) => !isRecoveredResult(r));
@@ -645,7 +678,9 @@ export async function resumeCommand(options: ResumeOptions): Promise<void> {
     }
   }
 
-  // Save results to session and update session PR
+  // Save all recovered results before updating each touched session PR, so the
+  // regenerated summary sees the complete recovered set for that session.
+  const sessionsToUpdate = new Map<string, { sessionDir: string; sessionName: string }>();
   for (const r of results) {
     const session = findSessionForIssue(r.issueNum);
     if (session) {
@@ -663,8 +698,12 @@ export async function resumeCommand(options: ResumeOptions): Promise<void> {
         filesChanged: r.filesChanged,
       };
       saveResumedResult(session.sessionDir, pipelineResult);
-      updateSessionPR(config.repo, session.sessionName, session.sessionDir, config.baseBranch);
+      sessionsToUpdate.set(session.sessionDir, session);
     }
+  }
+
+  for (const session of sessionsToUpdate.values()) {
+    await updateSessionPR(config, session.sessionName, session.sessionDir);
   }
 
   // Print summary

--- a/src/lib/learning.ts
+++ b/src/lib/learning.ts
@@ -43,6 +43,14 @@ export type SessionLearningRepairIssue = {
   retries?: number;
 };
 
+export type SessionSummaryResult = {
+  issueNum: number;
+  title: string;
+  status: string;
+  duration: number;
+  recoveryMode?: string;
+};
+
 /** Expected sections in learning output. */
 const LEARNING_SECTIONS = [
   '## What Worked',
@@ -654,7 +662,7 @@ export function getLearningContext(learningsDir: string): string {
  */
 export async function generateSessionSummary(options: {
   sessionName: string;
-  results: Array<{ issueNum: number; title: string; status: string; duration: number }>;
+  results: SessionSummaryResult[];
   learningsDir: string;
   config: Config;
 }): Promise<string | null> {
@@ -677,14 +685,38 @@ export async function generateSessionSummary(options: {
 
   if (learningContents.length === 0) return null;
 
-  const successCount = results.filter((r) => r.status === 'success').length;
-  const totalDuration = results.reduce((sum, r) => sum + r.duration, 0);
+  const recoveredResults = results.filter((r) => r.recoveryMode !== undefined);
+  const naturalResults = results.filter((r) => r.recoveryMode === undefined);
+  const metricResults = recoveredResults.length > 0 ? naturalResults : results;
+  const successCount = metricResults.filter((r) => r.status === 'success').length;
+  const failureCount = metricResults.filter((r) => r.status !== 'success').length;
+  const totalDuration = metricResults.reduce((sum, r) => sum + r.duration, 0);
+  const processedSummary = recoveredResults.length > 0
+    ? `${results.length} (${successCount} succeeded, ${failureCount} failed, ${recoveredResults.length} recovered)`
+    : `${results.length} (${successCount} succeeded, ${results.length - successCount} failed)`;
+  const successRate = metricResults.length > 0
+    ? `${Math.round((successCount / metricResults.length) * 100)}%`
+    : 'N/A';
+  const avgDuration = metricResults.length > 0
+    ? `${Math.round(totalDuration / metricResults.length)}s`
+    : 'N/A';
+  const recoveryDetails = recoveredResults.length > 0
+    ? `\n## Recovery Details
+
+Recovered issues are excluded from failure counts and success-rate calculations because resume creates synthetic results after recovering stranded work.
+- Recovered issues: ${recoveredResults.map((r) => `#${r.issueNum} ${r.title} (${r.recoveryMode})`).join(', ')}
+`
+    : '';
+  const recoveredMetricRow = recoveredResults.length > 0
+    ? `| Recovered issues | ${recoveredResults.map((r) => `#${r.issueNum} (${r.recoveryMode})`).join(', ')} |\n`
+    : '';
 
   const prompt = `Analyze these learnings from a development session and produce a concise session summary with actionable recommendations.
 
 ## Session: ${sessionName}
-- Issues processed: ${results.length} (${successCount} succeeded, ${results.length - successCount} failed)
+- Issues processed: ${processedSummary}
 - Total duration: ${Math.round(totalDuration / 60)} minutes
+${recoveryDetails}
 
 ## Individual Learnings
 
@@ -712,8 +744,8 @@ Output ONLY this markdown structure:
 | Metric | Value |
 |--------|-------|
 | Issues processed | ${results.length} |
-| Success rate | ${Math.round((successCount / results.length) * 100)}% |
-| Avg duration | ${Math.round(totalDuration / results.length)}s |
+${recoveredMetricRow}| Success rate | ${successRate} |
+| Avg duration | ${avgDuration} |
 | Total duration | ${Math.round(totalDuration / 60)} min |`;
 
   const agentResult = await spawnAgent({

--- a/tests/commands/resume.test.ts
+++ b/tests/commands/resume.test.ts
@@ -27,7 +27,9 @@ jest.mock('../../src/lib/github', () => ({
 }));
 
 jest.mock('../../src/lib/learning', () => ({
+  generateSessionSummary: jest.fn().mockResolvedValue(null),
   repairSessionLearningArtifacts: jest.fn(),
+  repairSessionSummaryArtifact: jest.fn(),
 }));
 
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -39,7 +41,11 @@ import { createPR, labelIssue, commentIssue, updateProjectStatus } from '../../s
 import { ghExec } from '../../src/lib/rate-limit';
 import { spawnAgent } from '../../src/lib/agent';
 import { exec } from '../../src/lib/shell';
-import { repairSessionLearningArtifacts } from '../../src/lib/learning';
+import {
+  generateSessionSummary,
+  repairSessionLearningArtifacts,
+  repairSessionSummaryArtifact,
+} from '../../src/lib/learning';
 
 const mockExec = exec as jest.MockedFunction<typeof exec>;
 const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
@@ -50,7 +56,9 @@ const mockLabelIssue = labelIssue as jest.MockedFunction<typeof labelIssue>;
 const mockCommentIssue = commentIssue as jest.MockedFunction<typeof commentIssue>;
 const mockUpdateProjectStatus = updateProjectStatus as jest.MockedFunction<typeof updateProjectStatus>;
 const mockSpawnAgent = spawnAgent as jest.MockedFunction<typeof spawnAgent>;
+const mockGenerateSessionSummary = generateSessionSummary as jest.MockedFunction<typeof generateSessionSummary>;
 const mockRepairSessionLearningArtifacts = repairSessionLearningArtifacts as jest.MockedFunction<typeof repairSessionLearningArtifacts>;
+const mockRepairSessionSummaryArtifact = repairSessionSummaryArtifact as jest.MockedFunction<typeof repairSessionSummaryArtifact>;
 
 const ok = (stdout = '') => ({ stdout, stderr: '', exitCode: 0 });
 const repoRoot = process.cwd();
@@ -357,6 +365,21 @@ describe('resumeCommand', () => {
     expect(sessionPrBody).toContain('### Recovered Issues');
     expect(sessionPrBody).toContain('#269: Recover artifact exports — RECOVERED BY RESUME');
     expect(sessionPrBody).toContain('https://github.com/owner/repo/pull/269');
+    expect(mockGenerateSessionSummary).toHaveBeenCalledWith(expect.objectContaining({
+      sessionName: 'session/epic-123',
+      results: [expect.objectContaining({
+        issueNum: 269,
+        title: 'Recover artifact exports',
+        status: 'failure',
+        recoveryMode: 'resume',
+      })],
+      learningsDir: expect.stringMatching(/\.alpha-loop\/learnings$/),
+      config: expect.objectContaining({ repo: 'owner/repo', skipLearn: false }),
+    }));
+    expect(mockRepairSessionSummaryArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      sessionName: 'session/epic-123',
+      learningsDir: expect.stringMatching(/\.alpha-loop\/learnings$/),
+    }));
   });
 
   test('keeps the ESM resume command free of runtime CommonJS require calls', () => {

--- a/tests/lib/learning.test.ts
+++ b/tests/lib/learning.test.ts
@@ -610,6 +610,37 @@ describe('generateSessionSummary', () => {
     expect(writtenContent).not.toContain('(patterns that appeared');
   });
 
+  test('reports recovered issues separately from ordinary failures in the summary prompt', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue([
+      'issue-42-20260101-000000.md' as any,
+      'issue-216-20260101-000000.md' as any,
+    ]);
+    mockReadFileSync.mockReturnValue(learningFileContent());
+    mockSpawnAgent.mockResolvedValue({
+      exitCode: 0,
+      output: codexSummaryTranscript(),
+      duration: 5000,
+    });
+
+    await generateSessionSummary({
+      sessionName: 'session/test',
+      results: [
+        { issueNum: 42, title: 'Clean issue', status: 'success', duration: 120 },
+        { issueNum: 216, title: 'Recovered issue', status: 'failure', recoveryMode: 'resume', duration: 0 },
+      ],
+      learningsDir: '/fake/learnings',
+      config: makeConfig({ agent: 'codex' }),
+    });
+
+    const prompt = mockSpawnAgent.mock.calls[0][0].prompt;
+    expect(prompt).toContain('- Issues processed: 2 (1 succeeded, 0 failed, 1 recovered)');
+    expect(prompt).toContain('- Recovered issues: #216 Recovered issue (resume)');
+    expect(prompt).toContain('Recovered issues are excluded from failure counts and success-rate calculations');
+    expect(prompt).toContain('| Recovered issues | #216 (resume) |');
+    expect(prompt).toContain('| Success rate | 100% |');
+  });
+
   test('skips writing session summary when output is placeholder-only', async () => {
     mockExistsSync.mockReturnValue(true);
     mockReaddirSync.mockReturnValue(['issue-42-20260101-000000.md' as any]);


### PR DESCRIPTION
Closes #228
Part of #245

## Summary

Automated implementation of **Resume: regenerate session summary when updating the session PR**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Resume now regenerates session learning artifacts and the aggregate summary when updating touched session PRs; tests and build pass.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*