### PR TITLE
feat: Pipeline: surface auto-commit fallback in the per-issue result (closes #229)

### DIFF
--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -19,7 +19,7 @@ import {
   repairSessionLearningArtifacts,
   repairSessionSummaryArtifact,
 } from '../lib/learning.js';
-import { clearCrashMarker, findCrashMarkers, type CrashMarkerRef } from '../lib/session.js';
+import { clearCrashMarker, findCrashMarkers, formatAutoCommittedResultsSection, type CrashMarkerRef } from '../lib/session.js';
 import {
   labelIssue,
   commentIssue,
@@ -587,6 +587,7 @@ ${recovered.length} recovered PR(s) were not counted as succeeded or failed beca
     ? `${successes.length}/${naturalResults.length} succeeded`
     : `${successes.length} succeeded`;
   const titleRecovery = recovered.length > 0 ? `, ${recovered.length} recovered` : '';
+  const autoCommittedSection = formatAutoCommittedResultsSection(results).join('\n');
 
   const title = `Session: ${sessionName} — ${titleStatus}${titleRecovery}`;
   const body = `## Session Summary
@@ -605,6 +606,7 @@ ${recovered.length > 0 ? `
 ### Recovered Issues
 ${recovered.map((r) => `- #${r.issueNum}: ${r.title} — ${formatSessionIssueStatus(r)}${r.prUrl ? ` ([PR](${r.prUrl}))` : ''}`).join('\n')}
 ` : ''}
+${autoCommittedSection ? `\n${autoCommittedSection}` : ''}
 
 ---
 This PR collects all changes from this session for final review before merging to ${baseBranch}.

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -330,6 +330,10 @@ export type PipelineResult = {
   status: 'success' | 'failure';
   /** Set when the result was synthesized after out-of-band recovery instead of produced by the normal pipeline. */
   recoveryMode?: PipelineRecoveryMode;
+  /** Set when the pipeline committed dirty work left behind by a successful implementation agent. */
+  autoCommittedByPipeline?: boolean;
+  /** Paths included in the pipeline-authored fallback commit. */
+  autoCommittedPaths?: string[];
   /** Why the issue failed — 'transient' means re-queue (e.g. usage limit), 'permanent' means label failed. */
   failureReason?: 'transient' | 'permanent';
   prUrl?: string;
@@ -376,6 +380,30 @@ function learningPathForCommit(worktreePath: string, learningFile: string): stri
   if (!relPath || relPath.startsWith('..') || relPath.startsWith('/')) return null;
   if (!relPath.startsWith('.alpha-loop/learnings/')) return null;
   return relPath;
+}
+
+function parseGitStatusPaths(stdout: string): string[] {
+  return stdout
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const path = line.length > 3 ? line.slice(3) : line.trim();
+      const renameTarget = path.includes(' -> ') ? path.split(' -> ').at(-1) : path;
+      return renameTarget?.trim() ?? '';
+    })
+    .filter(Boolean);
+}
+
+function autoCommitDirtyWorktree(worktreePath: string, commitMessage: string): string[] {
+  const statusResult = exec('git status --porcelain', { cwd: worktreePath });
+  const paths = parseGitStatusPaths(statusResult.stdout);
+  if (paths.length === 0) return [];
+
+  log.warn(`Agent did not commit; auto-committing ${paths.length} files: ${paths.join(', ')}`);
+  exec('git add -A', { cwd: worktreePath });
+  exec(commitMessage, { cwd: worktreePath });
+  return paths;
 }
 
 function commitLearningFiles(worktreePath: string, learningFiles: Array<string | null>, message: string): void {
@@ -645,6 +673,7 @@ export async function processIssue(
     tracker,
     events: escalationEvents,
   });
+  let autoCommittedPaths: string[] = [];
 
   // Setup logging
   mkdirSync(session.logsDir, { recursive: true });
@@ -858,11 +887,10 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     }
 
     // Auto-commit if agent didn't
-    const statusResult = exec('git status --porcelain', { cwd: worktreePath });
-    if (statusResult.stdout.trim()) {
-      exec('git add -A', { cwd: worktreePath });
-      exec(`git commit -m "feat: implement issue #${issueNum} - ${title}"`, { cwd: worktreePath });
-    }
+    autoCommittedPaths = autoCommitDirtyWorktree(
+      worktreePath,
+      `git commit -m "feat: implement issue #${issueNum} - ${title}"`,
+    );
 
     stepsCompleted.push('implement');
 
@@ -1435,6 +1463,8 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     verifySkipped,
     duration,
     filesChanged,
+    autoCommittedByPipeline: autoCommittedPaths.length > 0 ? true : undefined,
+    autoCommittedPaths: autoCommittedPaths.length > 0 ? autoCommittedPaths : undefined,
     escalationEvents: escalationEvents.length > 0 ? escalationEvents : undefined,
   };
 
@@ -1470,6 +1500,7 @@ export async function processBatch(
   const stepsCompleted: string[] = [];
   const issueNums = issues.map((i) => i.number);
   const epicOption = epicPromptOption(options);
+  let autoCommittedPaths: string[] = [];
 
   mkdirSync(session.logsDir, { recursive: true });
   const logFile = join(session.logsDir, `batch-${issueNums.join('-')}.log`);
@@ -1657,12 +1688,11 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     }
 
     // Auto-commit if agent didn't
-    const statusResult = exec('git status --porcelain', { cwd: worktreePath });
-    if (statusResult.stdout.trim()) {
-      exec('git add -A', { cwd: worktreePath });
-      const issueRefs = issues.map((i) => `#${i.number}`).join(', ');
-      exec(`git commit -m "feat: batch implement issues ${issueRefs}"`, { cwd: worktreePath });
-    }
+    const issueRefs = issues.map((i) => `#${i.number}`).join(', ');
+    autoCommittedPaths = autoCommitDirtyWorktree(
+      worktreePath,
+      `git commit -m "feat: batch implement issues ${issueRefs}"`,
+    );
 
     stepsCompleted.push('implement');
 
@@ -1944,6 +1974,8 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
       verifySkipped: true,
       duration: perIssueDuration,
       filesChanged,
+      autoCommittedByPipeline: autoCommittedPaths.length > 0 ? true : undefined,
+      autoCommittedPaths: autoCommittedPaths.length > 0 ? autoCommittedPaths : undefined,
     };
 
     results.push(result);

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -96,6 +96,24 @@ function previousPrLabel(queue: QueueSessionContext): string {
   return 'the previous session PR';
 }
 
+function formatPathList(paths: string[] | undefined): string {
+  if (!paths || paths.length === 0) return '(paths unavailable)';
+  return paths.map((path) => `\`${path.replace(/`/g, '\\`')}\``).join(', ');
+}
+
+export function formatAutoCommittedResultsSection(results: PipelineResult[]): string[] {
+  const autoCommitted = results.filter((result) => result.autoCommittedByPipeline);
+  if (autoCommitted.length === 0) return [];
+
+  const lines = ['### Auto-Committed By Pipeline', ''];
+  for (const result of autoCommitted) {
+    const pr = result.prUrl ? ` ([PR](${result.prUrl}))` : '';
+    lines.push(`- #${result.issueNum}: ${result.title}${pr} — ${formatPathList(result.autoCommittedPaths)}`);
+  }
+  lines.push('');
+  return lines;
+}
+
 function crashMarkerPath(sessionDir: string, issueNum: number): string {
   return join(sessionDir, `crash-${issueNum}.json`);
 }
@@ -540,6 +558,8 @@ export async function finalizeSession(
       testsPassing: r.testsPassing,
       verifyPassing: r.verifyPassing,
       recoveryMode: r.recoveryMode,
+      autoCommittedByPipeline: r.autoCommittedByPipeline,
+      autoCommittedPaths: r.autoCommittedPaths,
       duration: r.duration,
       filesChanged: r.filesChanged,
     })),
@@ -619,6 +639,8 @@ export async function finalizeSession(
     prLines.push('*Recovered issues were not counted as succeeded or failed because recovery did not run the full pipeline verification path.*');
     prLines.push('');
   }
+
+  prLines.push(...formatAutoCommittedResultsSection(session.results));
 
   // Permanent failures — collapsed
   if (permanentFailures.length > 0) {

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -110,6 +110,7 @@ jest.mock('node:fs', () => ({
 }));
 
 import { exec } from '../../src/lib/shell';
+import { log } from '../../src/lib/logger';
 import { spawnAgent } from '../../src/lib/agent';
 import { setupWorktree, cleanupWorktree, worktreeHasCommits } from '../../src/lib/worktree';
 import { labelIssue, commentIssue, createPR, mergePR, updateProjectStatus } from '../../src/lib/github';
@@ -122,6 +123,7 @@ import { writeTraceToSubdir } from '../../src/lib/traces';
 import type { Config } from '../../src/lib/config';
 
 const mockExec = exec as jest.MockedFunction<typeof exec>;
+const mockLog = log as jest.Mocked<typeof log>;
 const mockSpawnAgent = spawnAgent as jest.MockedFunction<typeof spawnAgent>;
 const mockSetupWorktree = setupWorktree as jest.MockedFunction<typeof setupWorktree>;
 const mockCleanupWorktree = cleanupWorktree as jest.MockedFunction<typeof cleanupWorktree>;
@@ -263,6 +265,32 @@ describe('processIssue', () => {
     expect(mockExtractLearnings).toHaveBeenCalled();
     expect(mockSaveResult).toHaveBeenCalled();
     expect(mockCleanupWorktree).toHaveBeenCalled();
+  });
+
+  test('sets auto-commit metadata when the agent leaves uncommitted work', async () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd === 'git status --porcelain') {
+        return { stdout: ' M src/lib/pipeline.ts\n?? tests/lib/pipeline.test.ts\n', stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    const result = await processIssue(42, 'Test issue', 'Issue body', makeConfig(), makeSession());
+
+    expect(result.autoCommittedByPipeline).toBe(true);
+    expect(result.autoCommittedPaths).toEqual(['src/lib/pipeline.ts', 'tests/lib/pipeline.test.ts']);
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      'Agent did not commit; auto-committing 2 files: src/lib/pipeline.ts, tests/lib/pipeline.test.ts',
+    );
+    expect(mockExec).toHaveBeenCalledWith('git add -A', { cwd: '/tmp/worktree' });
+    expect(mockExec).toHaveBeenCalledWith(
+      'git commit -m "feat: implement issue #42 - Test issue"',
+      { cwd: '/tmp/worktree' },
+    );
+    expect(mockSaveResult).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
+      autoCommittedByPipeline: true,
+      autoCommittedPaths: ['src/lib/pipeline.ts', 'tests/lib/pipeline.test.ts'],
+    }));
   });
 
   test('extracts and commits the learning artifact in the worktree before creating the PR', async () => {

--- a/tests/lib/session.test.ts
+++ b/tests/lib/session.test.ts
@@ -489,6 +489,49 @@ describe('finalizeSession', () => {
     }));
   });
 
+  test('lists auto-committed issues in final session PR body and manifest', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('diff --cached --quiet')) {
+        return { stdout: '', stderr: '', exitCode: 1 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+    mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/99');
+
+    const config = makeConfig({ autoMerge: true });
+    const session = createSession(config);
+    session.results.push({
+      issueNum: 229,
+      title: 'Surface auto commit fallback',
+      status: 'success',
+      prUrl: 'https://github.com/owner/repo/pull/229',
+      testsPassing: true,
+      verifyPassing: true,
+      verifySkipped: false,
+      duration: 60,
+      filesChanged: 2,
+      autoCommittedByPipeline: true,
+      autoCommittedPaths: ['src/lib/pipeline.ts', 'tests/lib/pipeline.test.ts'],
+    });
+
+    await finalizeSession(session, config);
+
+    const body = mockCreatePR.mock.calls.at(-1)![0].body;
+    expect(body).toContain('### Auto-Committed By Pipeline');
+    expect(body).toContain('#229: Surface auto commit fallback ([PR](https://github.com/owner/repo/pull/229))');
+    expect(body).toContain('`src/lib/pipeline.ts`, `tests/lib/pipeline.test.ts`');
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('session-session-20260101-000000.json'),
+      expect.stringContaining('"autoCommittedByPipeline": true'),
+    );
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('session-session-20260101-000000.json'),
+      expect.stringContaining('"autoCommittedPaths"'),
+    );
+  });
+
   test('adds merge order and queue risk notes to final stacked queue session PR body', async () => {
     mockExistsSync.mockReturnValue(true);
     mockExec.mockImplementation((cmd: string) => {


### PR DESCRIPTION
Closes #229
Part of #245

## Summary

Automated implementation of **Pipeline: surface auto-commit fallback in the per-issue result**

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |
| Verification | PASS |

## Code Review

Issue #229 requirements are implemented and verified.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Full logs in `.alpha-loop/sessions/`*