### PR TITLE
chore: post-session reviewer refinements from epic 243-245 run

### DIFF
--- a/.alpha-loop/templates/skills/alpha-loop-issue-author/SKILL.md
+++ b/.alpha-loop/templates/skills/alpha-loop-issue-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-issue-author
-description: Capture new features, changes, or bugs as well-formed GitHub issues optimized for alpha-loop. Use whenever the user describes something they want built or fixed, or says "add an issue", "file a feature", "let's build X". Searches existing issues/epics for duplicates, decides standalone vs epic-child vs new epic, drafts in the canonical alpha-loop body format, applies correct labels, sets dependencies, and links to parent epics.
+description: Capture new features, changes, or bugs as well-formed GitHub issues optimized for alpha-loop. Use whenever the user describes something they want built or fixed, or says "add a feature", "add an issue", "file a feature", "let's build X". Searches existing issues/epics for duplicates, decides standalone vs epic-child vs new epic, drafts in the canonical alpha-loop body format, applies correct labels, sets dependencies, and links to parent epics.
 auto_load: true
 priority: high
 ---

--- a/.alpha-loop/templates/skills/alpha-loop-runner/SKILL.md
+++ b/.alpha-loop/templates/skills/alpha-loop-runner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-runner
-description: Run and monitor alpha-loop sessions or epics safely. Use whenever the user asks to run alpha-loop, start the loop on an epic, prepare an epic run, monitor loop progress, verify an alpha-loop session, or validate completed epic issues. Performs dry-run validation, checks ready labels, syncs skills/agents, chooses batch/test/verify settings, and stops on skipped checklist items or missing pre-conditions.
+description: Run and monitor alpha-loop sessions or epics safely. Use whenever the user asks to run the loop, run alpha-loop, start the loop on an epic, prepare an epic run, monitor loop progress, verify an alpha-loop session, or validate completed epic issues. Performs dry-run validation, checks ready labels, syncs skills/agents, chooses batch/test/verify settings, and stops on skipped checklist items or missing pre-conditions.
 auto_load: true
 priority: high
 ---

--- a/.alpha-loop/templates/skills/alpha-loop-setup/SKILL.md
+++ b/.alpha-loop/templates/skills/alpha-loop-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-setup
-description: Guide a user through setting up alpha-loop in a repo, or audit an existing setup. Use when the user asks to install alpha-loop, set up the loop, configure alpha-loop, audit alpha-loop config, or add new harnesses/skills. Detects installed CLI harnesses, inspects the codebase to suggest `.alpha-loop.yaml` settings, recommends matching seed skills, and verifies the setup with a dry-run.
+description: Guide a user through setting up alpha-loop in a repo, or audit an existing setup. Use when the user asks to install alpha-loop, set up alpha-loop, set up the loop, configure alpha-loop, audit alpha-loop config, or add new harnesses/skills. Detects installed CLI harnesses, inspects the codebase to suggest `.alpha-loop.yaml` settings, recommends matching seed skills, and verifies the setup with a dry-run.
 auto_load: false
 priority: medium
 ---

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -19,6 +19,7 @@ import {
   mkdirSync,
   readdirSync,
   statSync,
+  lstatSync,
   readFileSync,
   rmSync,
   renameSync,
@@ -115,7 +116,7 @@ type SyncDirOptions = {
  * Empty directories are included so every rmSync has a visible WARN line.
  */
 function collectPrunedPaths(targetPath: string): string[] {
-  const stat = statSync(targetPath);
+  const stat = lstatSync(targetPath);
   if (!stat.isDirectory()) return [targetPath];
 
   const entries = readdirSync(targetPath);

--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -179,7 +179,8 @@ export function buildAgentArgs(options: AgentOptions): { command: string; args: 
 export type OneShotCommandOptions = {
   /**
    * Request a stdout-only response for prompts that must not create or edit
-   * files. Currently only Claude-family CLIs expose a tool allowlist flag.
+   * files. Claude-family CLIs use an empty tool allowlist; Codex-family CLIs
+   * use a read-only sandbox.
    */
   textOnly?: boolean;
 };
@@ -202,7 +203,11 @@ export function buildOneShotCommand(agent: AgentType, model: string, options: On
     case 'ollama': {
       const parts = ['codex', 'exec'];
       if (model) parts.push('--model', model);
-      parts.push('--full-auto');
+      if (options.textOnly) {
+        parts.push('--sandbox', 'read-only');
+      } else {
+        parts.push('--full-auto');
+      }
       return parts.join(' ');
     }
     case 'opencode': {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -4,7 +4,7 @@
 import { writeFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { exec } from './shell.js';
+import { exec, shellQuote } from './shell.js';
 import { ghExec, getProjectCache, setProjectCache } from './rate-limit.js';
 import { log } from './logger.js';
 import {
@@ -278,11 +278,12 @@ export function createPR(options: CreatePROptions): string {
   const { repo, base, head, title, body, cwd } = options;
 
   // Push the branch first
-  const pushResult = exec(`git push -u origin "${head}"`, { cwd });
+  const quotedHead = shellQuote(head);
+  const pushResult = exec(`git push -u origin ${quotedHead}`, { cwd });
   if (pushResult.exitCode !== 0) {
     // Try force push if branch exists from previous attempt
     log.warn('Push failed, trying force push...');
-    const forceResult = exec(`git push -u origin "${head}" --force`, { cwd });
+    const forceResult = exec(`git push -u origin ${quotedHead} --force`, { cwd });
     if (forceResult.exitCode !== 0) {
       throw new Error(`Failed to push branch ${head}: ${forceResult.stderr}`);
     }
@@ -296,7 +297,7 @@ export function createPR(options: CreatePROptions): string {
   try {
     // Check if PR already exists for this branch
     const existingResult = ghExec(
-      `gh pr list --repo "${repo}" --head "${head}" --json number,url --limit 1`,
+      `gh pr list --repo ${shellQuote(repo)} --head ${quotedHead} --json number,url --limit 1`,
     );
     if (existingResult.exitCode === 0 && existingResult.stdout) {
       try {
@@ -304,7 +305,7 @@ export function createPR(options: CreatePROptions): string {
         if (existing.length > 0) {
           const prUrl = existing[0].url;
           log.info(`PR already exists: ${prUrl}, updating...`);
-          ghExec(`gh pr edit ${existing[0].number} --repo "${repo}" --base "${base}" --title ${JSON.stringify(title)} --body-file "${bodyFile}"`, undefined, true);
+          ghExec(`gh pr edit ${existing[0].number} --repo ${shellQuote(repo)} --base ${shellQuote(base)} --title ${shellQuote(title)} --body-file ${shellQuote(bodyFile)}`, undefined, true);
           return prUrl;
         }
       } catch {
@@ -314,7 +315,7 @@ export function createPR(options: CreatePROptions): string {
 
     // Create new PR using --body-file to avoid shell escaping issues
     const createResult = ghExec(
-      `gh pr create --repo "${repo}" --base "${base}" --head "${head}" --title ${JSON.stringify(title)} --body-file "${bodyFile}"`,
+      `gh pr create --repo ${shellQuote(repo)} --base ${shellQuote(base)} --head ${quotedHead} --title ${shellQuote(title)} --body-file ${shellQuote(bodyFile)}`,
       undefined, true,
     );
     if (createResult.exitCode !== 0) {

--- a/src/lib/learning.ts
+++ b/src/lib/learning.ts
@@ -676,8 +676,7 @@ export async function generateSessionSummary(options: {
   const learningContents: string[] = [];
   if (!existsSync(learningsDir)) return null;
   for (const result of results) {
-    const files = readdirSync(learningsDir)
-      .filter((f) => f.startsWith(`issue-${result.issueNum}-`) && f.endsWith('.md'));
+    const files = learningFilesForSession(learningsDir, result.issueNum, sessionName);
     for (const file of files) {
       learningContents.push(readFileSync(join(learningsDir, file), 'utf-8'));
     }

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -4,7 +4,7 @@
 import { mkdirSync, readFileSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { log } from './logger.js';
-import { exec } from './shell.js';
+import { exec, shellQuote } from './shell.js';
 import { spawnAgent, buildEndpointEnv } from './agent.js';
 import type { AgentOptions } from './agent.js';
 import {
@@ -401,8 +401,16 @@ function autoCommitDirtyWorktree(worktreePath: string, commitMessage: string): s
   if (paths.length === 0) return [];
 
   log.warn(`Agent did not commit; auto-committing ${paths.length} files: ${paths.join(', ')}`);
-  exec('git add -A', { cwd: worktreePath });
-  exec(commitMessage, { cwd: worktreePath });
+  const addResult = exec('git add -A', { cwd: worktreePath });
+  if (addResult.exitCode !== 0) {
+    log.warn(`Could not stage fallback auto-commit paths: ${addResult.stderr || addResult.stdout}`);
+    return [];
+  }
+  const commitResult = exec(`git commit -m ${shellQuote(commitMessage)}`, { cwd: worktreePath });
+  if (commitResult.exitCode !== 0) {
+    log.warn(`Could not create fallback auto-commit: ${commitResult.stderr || commitResult.stdout}`);
+    return [];
+  }
   return paths;
 }
 
@@ -416,7 +424,7 @@ function commitLearningFiles(worktreePath: string, learningFiles: Array<string |
 
   if (paths.length === 0) return;
 
-  const pathspecs = paths.map((path) => JSON.stringify(path)).join(' ');
+  const pathspecs = paths.map((path) => shellQuote(path)).join(' ');
   const addResult = exec(`git add -- ${pathspecs}`, { cwd: worktreePath });
   if (addResult.exitCode !== 0) {
     log.warn(`Could not stage learning artifact(s): ${addResult.stderr || addResult.stdout}`);
@@ -436,7 +444,7 @@ function commitLearningFiles(worktreePath: string, learningFiles: Array<string |
   if (stagedPaths.length === 0) return;
 
   const commitResult = exec(
-    `git commit -m ${JSON.stringify(message)} -- ${stagedPaths.map((path) => JSON.stringify(path)).join(' ')}`,
+    `git commit -m ${shellQuote(message)} -- ${stagedPaths.map((path) => shellQuote(path)).join(' ')}`,
     { cwd: worktreePath },
   );
   if (commitResult.exitCode !== 0) {
@@ -889,7 +897,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     // Auto-commit if agent didn't
     autoCommittedPaths = autoCommitDirtyWorktree(
       worktreePath,
-      `git commit -m "feat: implement issue #${issueNum} - ${title}"`,
+      `feat: implement issue #${issueNum} - ${title}`,
     );
 
     stepsCompleted.push('implement');
@@ -1691,7 +1699,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     const issueRefs = issues.map((i) => `#${i.number}`).join(', ');
     autoCommittedPaths = autoCommitDirtyWorktree(
       worktreePath,
-      `git commit -m "feat: batch implement issues ${issueRefs}"`,
+      `feat: batch implement issues ${issueRefs}`,
     );
 
     stepsCompleted.push('implement');

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -14,6 +14,13 @@ export type ExecResult = {
 };
 
 /**
+ * Quote a value as a single POSIX shell argument.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
  * Execute a shell command synchronously and return structured result.
  * Does not throw on non-zero exit — returns exitCode instead.
  */

--- a/templates/skills/alpha-loop-issue-author/SKILL.md
+++ b/templates/skills/alpha-loop-issue-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-issue-author
-description: Capture new features, changes, or bugs as well-formed GitHub issues optimized for alpha-loop. Use whenever the user describes something they want built or fixed, or says "add an issue", "file a feature", "let's build X". Searches existing issues/epics for duplicates, decides standalone vs epic-child vs new epic, drafts in the canonical alpha-loop body format, applies correct labels, sets dependencies, and links to parent epics.
+description: Capture new features, changes, or bugs as well-formed GitHub issues optimized for alpha-loop. Use whenever the user describes something they want built or fixed, or says "add a feature", "add an issue", "file a feature", "let's build X". Searches existing issues/epics for duplicates, decides standalone vs epic-child vs new epic, drafts in the canonical alpha-loop body format, applies correct labels, sets dependencies, and links to parent epics.
 auto_load: true
 priority: high
 ---

--- a/templates/skills/alpha-loop-runner/SKILL.md
+++ b/templates/skills/alpha-loop-runner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-runner
-description: Run and monitor alpha-loop sessions or epics safely. Use whenever the user asks to run alpha-loop, start the loop on an epic, prepare an epic run, monitor loop progress, verify an alpha-loop session, or validate completed epic issues. Performs dry-run validation, checks ready labels, syncs skills/agents, chooses batch/test/verify settings, and stops on skipped checklist items or missing pre-conditions.
+description: Run and monitor alpha-loop sessions or epics safely. Use whenever the user asks to run the loop, run alpha-loop, start the loop on an epic, prepare an epic run, monitor loop progress, verify an alpha-loop session, or validate completed epic issues. Performs dry-run validation, checks ready labels, syncs skills/agents, chooses batch/test/verify settings, and stops on skipped checklist items or missing pre-conditions.
 auto_load: true
 priority: high
 ---

--- a/templates/skills/alpha-loop-setup/SKILL.md
+++ b/templates/skills/alpha-loop-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-setup
-description: Guide a user through setting up alpha-loop in a repo, or audit an existing setup. Use when the user asks to install alpha-loop, set up the loop, configure alpha-loop, audit alpha-loop config, or add new harnesses/skills. Detects installed CLI harnesses, inspects the codebase to suggest `.alpha-loop.yaml` settings, recommends matching seed skills, and verifies the setup with a dry-run.
+description: Guide a user through setting up alpha-loop in a repo, or audit an existing setup. Use when the user asks to install alpha-loop, set up alpha-loop, set up the loop, configure alpha-loop, audit alpha-loop config, or add new harnesses/skills. Detects installed CLI harnesses, inspects the codebase to suggest `.alpha-loop.yaml` settings, recommends matching seed skills, and verifies the setup with a dry-run.
 auto_load: false
 priority: medium
 ---

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { syncAgentAssets } from '../../src/commands/sync';
@@ -289,6 +289,29 @@ describe('syncAgentAssets', () => {
     expect(existsSync(join(dir, '.claude', 'skills', 'harness-only'))).toBe(false);
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(join('.claude', 'skills', 'harness-only', 'SKILL.md')));
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(join('.claude', 'skills', 'harness-only', 'references', 'guide.md')));
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('prune removes target-only symlinks without traversing their targets', () => {
+    const dir = makeTmpDir();
+    const templatesBase = join(dir, '.alpha-loop', 'templates');
+    const outsideDir = join(dir, 'outside-target');
+    mkdirSync(join(templatesBase, 'skills', 'a'), { recursive: true });
+    writeFileSync(join(templatesBase, 'skills', 'a', 'SKILL.md'), '# Same');
+    mkdirSync(join(dir, '.claude', 'skills', 'a'), { recursive: true });
+    writeFileSync(join(dir, '.claude', 'skills', 'a', 'SKILL.md'), '# Same');
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(outsideDir, 'keep.md'), '# Keep');
+    symlinkSync(outsideDir, join(dir, '.claude', 'skills', 'external-link'), 'dir');
+
+    const result = syncAgentAssets(['claude-code'], { projectDir: dir, prune: true });
+
+    expect(result.synced).toBe(true);
+    expect(existsSync(join(dir, '.claude', 'skills', 'external-link'))).toBe(false);
+    expect(readFileSync(join(outsideDir, 'keep.md'), 'utf-8')).toBe('# Keep');
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(join('.claude', 'skills', 'external-link')));
+    expect(log.warn).not.toHaveBeenCalledWith(expect.stringContaining(join(outsideDir, 'keep.md')));
 
     rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -199,9 +199,19 @@ describe('buildOneShotCommand', () => {
     expect(cmd).toBe('codex exec --model gpt-5.4 --full-auto');
   });
 
+  test('builds codex text-only command with read-only sandbox', () => {
+    const cmd = buildOneShotCommand('codex', 'gpt-5.4', { textOnly: true });
+    expect(cmd).toBe('codex exec --model gpt-5.4 --sandbox read-only');
+  });
+
   test('builds codex command without model', () => {
     const cmd = buildOneShotCommand('codex', '');
     expect(cmd).toBe('codex exec --full-auto');
+  });
+
+  test('builds ollama text-only command with read-only sandbox', () => {
+    const cmd = buildOneShotCommand('ollama', 'llama3.1:70b', { textOnly: true });
+    expect(cmd).toBe('codex exec --model llama3.1:70b --sandbox read-only');
   });
 
   test('builds opencode command', () => {

--- a/tests/lib/github.test.ts
+++ b/tests/lib/github.test.ts
@@ -8,6 +8,7 @@ import {
 
 jest.mock('../../src/lib/shell', () => ({
   exec: jest.fn(),
+  shellQuote: (value: string) => `'${String(value).replace(/'/g, `'\\''`)}'`,
 }));
 
 jest.mock('../../src/lib/logger', () => ({
@@ -248,6 +249,33 @@ describe('createPR', () => {
     );
     expect(createCall).toBeDefined();
     expect(createCall?.[0]).toContain('--body-file');
+  });
+
+  test('shell-quotes PR title and branch values', () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('git push')) {
+        return { stdout: '', stderr: '', exitCode: 0 };
+      }
+      if (cmd.includes('gh pr list')) {
+        return { stdout: '[]', stderr: '', exitCode: 0 };
+      }
+      if (cmd.includes('gh pr create')) {
+        return { stdout: 'https://github.com/owner/repo/pull/1', stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    createPR({
+      ...baseOptions,
+      head: "agent/issue-42-$(touch /tmp/pwned)'branch",
+      title: "feat: Add $(touch /tmp/pwned) 'quoted'",
+    });
+
+    const createCall = mockExec.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('gh pr create'),
+    );
+    expect(createCall?.[0]).toContain("--head 'agent/issue-42-$(touch /tmp/pwned)'\\''branch'");
+    expect(createCall?.[0]).toContain("--title 'feat: Add $(touch /tmp/pwned) '\\''quoted'\\'''");
   });
 
   test('tries force push on initial push failure', () => {

--- a/tests/lib/learning.test.ts
+++ b/tests/lib/learning.test.ts
@@ -245,6 +245,8 @@ function learningFileContent(): string {
   return `---
 issue: 42
 status: success
+traces:
+  plan: .alpha-loop/sessions/session/test/traces/prompts/plan-issue-42.md
 ---
 ## What Worked
 - Good tests
@@ -639,6 +641,49 @@ describe('generateSessionSummary', () => {
     expect(prompt).toContain('Recovered issues are excluded from failure counts and success-rate calculations');
     expect(prompt).toContain('| Recovered issues | #216 (resume) |');
     expect(prompt).toContain('| Success rate | 100% |');
+  });
+
+  test('uses only learning artifacts from the requested session', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue([
+      'issue-42-20260101-000000.md' as any,
+      'issue-42-20260102-000000.md' as any,
+    ]);
+    mockReadFileSync.mockImplementation((path) => {
+      const filePath = String(path);
+      if (filePath.endsWith('issue-42-20260101-000000.md')) {
+        return `---
+issue: 42
+traces:
+  plan: .alpha-loop/sessions/session/old/traces/prompts/plan-issue-42.md
+---
+## What Worked
+- Stale learning`;
+      }
+      return `---
+issue: 42
+traces:
+  plan: .alpha-loop/sessions/session/test/traces/prompts/plan-issue-42.md
+---
+## What Worked
+- Current session learning`;
+    });
+    mockSpawnAgent.mockResolvedValue({
+      exitCode: 0,
+      output: codexSummaryTranscript(),
+      duration: 5000,
+    });
+
+    await generateSessionSummary({
+      sessionName: 'session/test',
+      results: [{ issueNum: 42, title: 'Test issue', status: 'success', duration: 120 }],
+      learningsDir: '/fake/learnings',
+      config: makeConfig({ agent: 'codex' }),
+    });
+
+    const prompt = mockSpawnAgent.mock.calls[0][0].prompt;
+    expect(prompt).toContain('Current session learning');
+    expect(prompt).not.toContain('Stale learning');
   });
 
   test('skips writing session summary when output is placeholder-only', async () => {

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -4,6 +4,7 @@ import type { SessionContext } from '../../src/lib/session';
 // Mock all dependencies
 jest.mock('../../src/lib/shell', () => ({
   exec: jest.fn(),
+  shellQuote: (value: string) => `'${String(value).replace(/'/g, `'\\''`)}'`,
 }));
 
 jest.mock('../../src/lib/logger', () => ({
@@ -284,13 +285,29 @@ describe('processIssue', () => {
     );
     expect(mockExec).toHaveBeenCalledWith('git add -A', { cwd: '/tmp/worktree' });
     expect(mockExec).toHaveBeenCalledWith(
-      'git commit -m "feat: implement issue #42 - Test issue"',
+      "git commit -m 'feat: implement issue #42 - Test issue'",
       { cwd: '/tmp/worktree' },
     );
     expect(mockSaveResult).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       autoCommittedByPipeline: true,
       autoCommittedPaths: ['src/lib/pipeline.ts', 'tests/lib/pipeline.test.ts'],
     }));
+  });
+
+  test('shell-quotes issue titles in fallback auto-commit messages', async () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd === 'git status --porcelain') {
+        return { stdout: ' M src/lib/pipeline.ts\n', stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    await processIssue(42, "Danger $(touch /tmp/pwned) 'quote'", 'Issue body', makeConfig(), makeSession());
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "git commit -m 'feat: implement issue #42 - Danger $(touch /tmp/pwned) '\\''quote'\\'''",
+      { cwd: '/tmp/worktree' },
+    );
   });
 
   test('extracts and commits the learning artifact in the worktree before creating the PR', async () => {
@@ -316,7 +333,7 @@ describe('processIssue', () => {
     }));
 
     const commitCallIndex = mockExec.mock.calls.findIndex(([cmd]) =>
-      String(cmd).startsWith('git commit -m "chore: add learning artifact for issue #42"'),
+      String(cmd).startsWith("git commit -m 'chore: add learning artifact for issue #42'"),
     );
     expect(commitCallIndex).toBeGreaterThanOrEqual(0);
     expect(mockExec.mock.calls[commitCallIndex][0]).toContain('.alpha-loop/learnings/issue-42-20260101-000000.md');
@@ -1032,7 +1049,7 @@ describe('processBatch', () => {
     }));
 
     const commitCallIndex = mockExec.mock.calls.findIndex(([cmd]) =>
-      String(cmd).startsWith('git commit -m "chore: add learning artifacts for issues #10, #11"'),
+      String(cmd).startsWith("git commit -m 'chore: add learning artifacts for issues #10, #11'"),
     );
     expect(commitCallIndex).toBeGreaterThanOrEqual(0);
     expect(mockExec.mock.calls[commitCallIndex][0]).toContain('issue-10-20260101-000000.md');

--- a/tests/lib/seeded-skills.test.ts
+++ b/tests/lib/seeded-skills.test.ts
@@ -16,6 +16,7 @@ describe('seeded alpha-loop skills', () => {
 
     expect(projectSkill).toBe(distSkill);
     expect(distSkill).toMatch(/^name: alpha-loop-runner$/m);
+    expect(distSkill).toMatch(/^description: .*run the loop.*run alpha-loop/m);
     expect(distSkill).toMatch(/^auto_load: true$/m);
     expect(distSkill).toMatch(/^priority: high$/m);
     expect(distSkill).toContain('## Trigger');
@@ -41,6 +42,7 @@ describe('seeded alpha-loop skills', () => {
 
     expect(projectSkill).toBe(distSkill);
     expect(distSkill).toMatch(/^name: alpha-loop-setup$/m);
+    expect(distSkill).toMatch(/^description: .*set up alpha-loop.*set up the loop/m);
     expect(distSkill).toMatch(/^auto_load: false$/m);
     expect(distSkill).toMatch(/^priority: medium$/m);
     expect(distSkill).toContain('## Trigger');
@@ -79,6 +81,7 @@ describe('seeded alpha-loop skills', () => {
 
     expect(projectSkill).toBe(distSkill);
     expect(distSkill).toMatch(/^name: alpha-loop-issue-author$/m);
+    expect(distSkill).toMatch(/^description: .*add a feature.*add an issue/m);
     expect(distSkill).toMatch(/^auto_load: true$/m);
     expect(distSkill).toMatch(/^priority: high$/m);
     expect(distSkill).toContain('## Trigger');


### PR DESCRIPTION
## Summary

Captures the holistic post-session reviewer's improvements that were produced during the 243/244/245 epic queue but did not get committed back into any of the session PRs (an instance of the parent-orphan artifact pattern that #224 fixed for learning files — same issue, applied to reviewer output instead).

## Changes

- **Shell-injection hardening** — `shellQuote()` interpolation in `createPR` (`src/lib/github.ts`) and the auto-commit / learning-file commit paths (`src/lib/pipeline.ts`) so branch names and pathspecs can't break shell context.
- **Auto-commit fallback robustness** — Proper error handling so a failed `git add` or `git commit` returns no paths rather than silently succeeding.
- **Symlink-safe prune** — `lstatSync` (not `statSync`) when collecting prune candidates in `src/commands/sync.ts`, matching the additive-sync work from #185.
- **Codex `textOnly` mode** — `buildOneShotCommand` (`src/lib/agent.ts`) respects textOnly for Codex via read-only sandbox, matching Claude's `--allowed-tools=\"\"`. Part of the scan-validation surface from #235.
- **Seeded skill trigger tightening** — \"run the loop\" added to `alpha-loop-runner`'s description; matching adjustments to `alpha-loop-issue-author` and `alpha-loop-setup` so harnesses route to them more reliably (the new skills from #243).
- **+175 / -28 lines of test coverage** for all of the above. Local: **1283 → 1289 passing tests**.

## Why this is a follow-up PR

These edits are independent of any single epic's acceptance criteria, which is why per-issue reviewers didn't catch them — they only emerged in the post-session holistic pass that ran *after* all 10 children of #245 had already merged into their session branch. The reviewer modified files in the parent worktree but couldn't write back into already-merged PRs.

This is itself good evidence for filing a future enhancement: \"post-session reviewer should commit refinements into a dedicated PR rather than leaving them as parent-worktree orphans.\"

## Verification

- ✅ `pnpm build` clean
- ✅ `pnpm test` — 73 suites / 1289 tests / 0 failures
- ✅ Applied as a clean `git stash apply` on master, no conflict markers
- ✅ Branched from master post-#256 merge so it sits on top of all of epics 243/244/245

🤖 Generated with [Claude Code](https://claude.com/claude-code)