### PR TITLE
release: loop reliability cleanup — 18 issues across 3 epics + holistic-reviewer refinements

### DIFF
--- a/.alpha-loop/templates/skills/alpha-loop-issue-author/SKILL.md
+++ b/.alpha-loop/templates/skills/alpha-loop-issue-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-issue-author
-description: Capture new features, changes, or bugs as well-formed GitHub issues optimized for alpha-loop. Use whenever the user describes something they want built or fixed, or says "add an issue", "file a feature", "let's build X". Searches existing issues/epics for duplicates, decides standalone vs epic-child vs new epic, drafts in the canonical alpha-loop body format, applies correct labels, sets dependencies, and links to parent epics.
+description: Capture new features, changes, or bugs as well-formed GitHub issues optimized for alpha-loop. Use whenever the user describes something they want built or fixed, or says "add a feature", "add an issue", "file a feature", "let's build X". Searches existing issues/epics for duplicates, decides standalone vs epic-child vs new epic, drafts in the canonical alpha-loop body format, applies correct labels, sets dependencies, and links to parent epics.
 auto_load: true
 priority: high
 ---

--- a/.alpha-loop/templates/skills/alpha-loop-runner/SKILL.md
+++ b/.alpha-loop/templates/skills/alpha-loop-runner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-runner
-description: Run and monitor alpha-loop sessions or epics safely. Use whenever the user asks to run alpha-loop, start the loop on an epic, prepare an epic run, monitor loop progress, verify an alpha-loop session, or validate completed epic issues. Performs dry-run validation, checks ready labels, syncs skills/agents, chooses batch/test/verify settings, and stops on skipped checklist items or missing pre-conditions.
+description: Run and monitor alpha-loop sessions or epics safely. Use whenever the user asks to run the loop, run alpha-loop, start the loop on an epic, prepare an epic run, monitor loop progress, verify an alpha-loop session, or validate completed epic issues. Performs dry-run validation, checks ready labels, syncs skills/agents, chooses batch/test/verify settings, and stops on skipped checklist items or missing pre-conditions.
 auto_load: true
 priority: high
 ---

--- a/.alpha-loop/templates/skills/alpha-loop-runner/SKILL.md
+++ b/.alpha-loop/templates/skills/alpha-loop-runner/SKILL.md
@@ -82,7 +82,7 @@ git status --short
 
 Confirm the skill appears in every configured harness output directory from `.alpha-loop.yaml` (`.claude/skills/`, `.agents/skills/`, or another harness-specific path).
 
-Until issue #185 lands, `alpha-loop sync` can delete skills that exist only in generated harness directories. If sync removes a useful harness-only skill, recover it by restoring the file from git or shell history, copying it into `.alpha-loop/templates/skills/<name>/`, and running `<alpha-loop> sync` again. Never treat `.claude/skills/`, `.agents/skills/`, or other harness outputs as canonical.
+`alpha-loop sync` is **additive by default** (#185): it copies skills from `.alpha-loop/templates/skills/` into harness output dirs and updates files that differ, but it does NOT delete files in the harness output that aren't in the templates. Harness-only skills are left alone. Use `<alpha-loop> sync --check` to see what would change, or `<alpha-loop> sync --prune` if you explicitly want to remove anything not in the templates dir. Never treat `.claude/skills/`, `.agents/skills/`, or other harness outputs as canonical — `.alpha-loop/templates/skills/` is the source of truth.
 
 ## Repo-Specific Posture
 
@@ -160,7 +160,7 @@ Follow this ordered playbook for `alpha-loop run --epic <N>` work.
    git status --short
    ```
 
-   If sync deletes or mutates unexpected project-owned skill files, restore or report them before continuing.
+   Sync is additive by default. If you intend to remove untemplated entries from harness output dirs, run `<alpha-loop> sync --check` first to see what would be pruned, then `<alpha-loop> sync --prune` if the list looks right.
 
 6. Choose the run shape and explain it briefly before the dry run.
 
@@ -214,7 +214,7 @@ Interrupt the run, or stop before starting it, and report exact status if any of
 - Repeated verification failures indicate the issue needs new planning or human input instead of another retry.
 - A merge conflict, missing dependency, service startup failure, or auth failure prevents safe unattended progress.
 - A per-issue learning file is not written after an issue exits.
-- Sync deletes a useful harness-only skill and it has not been restored into `.alpha-loop/templates/skills/`.
+- A `<alpha-loop> sync --prune` run reports it would delete a skill the user actually wanted to keep (stop and confirm before re-running with `--prune`).
 - The user says stop, pause, wait, hold, or questions the queue order.
 
 When interrupted, pause any heartbeat automation, wait for Alpha Loop cleanup/finalization when safe, inspect `git status --short --branch`, and summarize the exact PRs, branches, issues, worktrees, and files touched.

--- a/.alpha-loop/templates/skills/alpha-loop-setup/SKILL.md
+++ b/.alpha-loop/templates/skills/alpha-loop-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-setup
-description: Guide a user through setting up alpha-loop in a repo, or audit an existing setup. Use when the user asks to install alpha-loop, set up the loop, configure alpha-loop, audit alpha-loop config, or add new harnesses/skills. Detects installed CLI harnesses, inspects the codebase to suggest `.alpha-loop.yaml` settings, recommends matching seed skills, and verifies the setup with a dry-run.
+description: Guide a user through setting up alpha-loop in a repo, or audit an existing setup. Use when the user asks to install alpha-loop, set up alpha-loop, set up the loop, configure alpha-loop, audit alpha-loop config, or add new harnesses/skills. Detects installed CLI harnesses, inspects the codebase to suggest `.alpha-loop.yaml` settings, recommends matching seed skills, and verifies the setup with a dry-run.
 auto_load: false
 priority: medium
 ---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Determine version from git tags (source of truth) + commit messages
-      # This avoids needing to commit version bumps back to master
+      # Determine version from git tags (source of truth) + commit messages.
+      # The stamped package.json is committed back to master after publish so
+      # `--version` on a fresh source clone matches what's published on npm.
       - name: Determine version
         id: version
         run: |
@@ -139,3 +140,27 @@ jobs:
             --title "v$NEW_VERSION" \
             --notes "$NOTES" \
             --latest
+
+      # Commit the stamped package.json back to master so source-of-truth
+      # tracks the published npm version. Without this, a fresh `git clone`
+      # + `node dist/cli.js --version` reports the stale value left over
+      # from before the last release.
+      #
+      # The `[skip ci]` marker prevents this commit from re-triggering the
+      # release workflow (infinite loop).
+      - name: Commit version bump back to master
+        if: steps.version.outputs.skip != 'true'
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add package.json
+          if git diff --cached --quiet; then
+            echo "package.json already at v$NEW_VERSION on master — nothing to commit."
+            exit 0
+          fi
+
+          git commit -m "chore(release): bump version to v$NEW_VERSION [skip ci]"
+          git push origin HEAD:master

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadConfig, resolveStepConfig } from '../lib/config.js';
 import { log } from '../lib/logger.js';
-import { exec } from '../lib/shell.js';
+import { exec, shellQuote } from '../lib/shell.js';
 import { ghExec } from '../lib/rate-limit.js';
 import { spawnAgent } from '../lib/agent.js';
 import { buildReviewPrompt } from '../lib/prompts.js';
@@ -97,7 +97,7 @@ function checkoutBranchForResume(branch: string): string | null {
   const cwd = toplevelResult.exitCode === 0 && toplevelResult.stdout
     ? toplevelResult.stdout
     : process.cwd();
-  const checkoutResult = exec(`git checkout ${JSON.stringify(branch)}`, { cwd });
+  const checkoutResult = exec(`git checkout ${shellQuote(branch)}`, { cwd });
   if (checkoutResult.exitCode !== 0) {
     log.error(`Could not check out ${branch}: ${checkoutResult.stderr || checkoutResult.stdout}`);
     return null;
@@ -122,7 +122,7 @@ function commitChangedLearningArtifacts(cwd: string, issueNum: number): boolean 
   const paths = changedLearningPaths(cwd, issueNum);
   if (paths.length === 0) return false;
 
-  const pathspecs = paths.map((path) => JSON.stringify(path)).join(' ');
+  const pathspecs = paths.map((path) => shellQuote(path)).join(' ');
   const addResult = exec(`git add -- ${pathspecs}`, { cwd });
   if (addResult.exitCode !== 0) {
     log.warn(`Could not stage learning artifact for #${issueNum}: ${addResult.stderr || addResult.stdout}`);
@@ -139,7 +139,7 @@ function commitChangedLearningArtifacts(cwd: string, issueNum: number): boolean 
   if (stagedPaths.length === 0) return false;
 
   const commitResult = exec(
-    `git commit -m ${JSON.stringify(`chore: add learning artifact for issue #${issueNum}`)} -- ${stagedPaths.map((path) => JSON.stringify(path)).join(' ')}`,
+    `git commit -m ${shellQuote(`chore: add learning artifact for issue #${issueNum}`)} -- ${stagedPaths.map((path) => shellQuote(path)).join(' ')}`,
     { cwd },
   );
   if (commitResult.exitCode !== 0) {
@@ -183,8 +183,9 @@ function inspectStrandedBranch(
   crashMarker?: CrashMarkerRef,
 ): StrandedBranch | null {
   // Check if there are commits ahead of the base branch
+  const range = shellQuote(`origin/${baseBranch}..${branch}`);
   const aheadResult = exec(
-    `git log "origin/${baseBranch}..${branch}" --oneline`,
+    `git log ${range} --oneline`,
   );
   if (aheadResult.exitCode !== 0 || !aheadResult.stdout.trim()) {
     // No commits ahead — not stranded
@@ -198,7 +199,7 @@ function inspectStrandedBranch(
 
   // Get files changed relative to base branch
   const filesResult = exec(
-    `git diff --name-only "origin/${baseBranch}...${branch}"`,
+    `git diff --name-only ${shellQuote(`origin/${baseBranch}...${branch}`)}`,
   );
   const filesChanged = filesResult.exitCode === 0
     ? filesResult.stdout.split('\n').map((l) => l.trim()).filter(Boolean)
@@ -244,7 +245,7 @@ function findStrandedBranchesFromCrashMarkers(
  */
 function prExists(repo: string, branch: string): boolean {
   const result = ghExec(
-    `gh pr list --repo "${repo}" --head "${branch}" --state open --json number --limit 1`,
+    `gh pr list --repo ${shellQuote(repo)} --head ${shellQuote(branch)} --state open --json number --limit 1`,
   );
   if (result.exitCode !== 0) return false;
   try {
@@ -260,7 +261,7 @@ function prExists(repo: string, branch: string): boolean {
  */
 function getIssueTitle(repo: string, issueNum: number): string {
   const result = ghExec(
-    `gh issue view ${issueNum} --repo "${repo}" --json title`,
+    `gh issue view ${issueNum} --repo ${shellQuote(repo)} --json title`,
   );
   if (result.exitCode !== 0) return `Issue #${issueNum}`;
   try {
@@ -275,7 +276,7 @@ function getIssueTitle(repo: string, issueNum: number): string {
  * Get the diff between the base branch and the given branch.
  */
 function getBranchDiff(baseBranch: string, branch: string): string {
-  const result = exec(`git diff "origin/${baseBranch}...${branch}"`);
+  const result = exec(`git diff ${shellQuote(`origin/${baseBranch}...${branch}`)}`);
   if (result.exitCode !== 0) return '';
   // Cap at 50k chars to avoid bloating the review prompt
   const MAX = 50_000;
@@ -342,10 +343,11 @@ async function resumeBranch(
   // createPR also pushes internally, but we do it first here for explicit
   // feedback and to fail fast if the push is going to be a problem.
   log.info(`Pushing ${branch} to origin...`);
-  const pushResult = exec(`git push -u origin "${branch}"`, { cwd: branchWorktree });
+  const quotedBranch = shellQuote(branch);
+  const pushResult = exec(`git push -u origin ${quotedBranch}`, { cwd: branchWorktree });
   if (pushResult.exitCode !== 0) {
     log.warn(`Push failed: ${pushResult.stderr}. Attempting force push...`);
-    const forceResult = exec(`git push -u origin "${branch}" --force`, { cwd: branchWorktree });
+    const forceResult = exec(`git push -u origin ${quotedBranch} --force`, { cwd: branchWorktree });
     if (forceResult.exitCode !== 0) {
       log.error(`Could not push ${branch}: ${forceResult.stderr}`);
       return null;
@@ -511,7 +513,7 @@ async function updateSessionPR(
 
   // Find the PR for this session branch
   const prResult = ghExec(
-    `gh pr list --repo "${repo}" --head "${sessionBranch}" --state open --json number,url --limit 1`,
+    `gh pr list --repo ${shellQuote(repo)} --head ${shellQuote(sessionBranch)} --state open --json number,url --limit 1`,
   );
   if (prResult.exitCode !== 0 || !prResult.stdout.trim()) {
     log.info('No session PR found to update');
@@ -613,12 +615,13 @@ This PR collects all changes from this session for final review before merging t
 
 *Automated by alpha-loop*`;
 
-  ghExec(`gh pr edit ${prNumber} --repo "${repo}" --title ${JSON.stringify(title)}`, undefined, true);
+  const quotedRepo = shellQuote(repo);
+  ghExec(`gh pr edit ${prNumber} --repo ${quotedRepo} --title ${shellQuote(title)}`, undefined, true);
 
   // Use --body-file to avoid escaping issues
   const bodyFile = join(tmpdir(), `alpha-loop-session-pr-${Date.now()}`);
   writeFileSync(bodyFile, body, 'utf-8');
-  ghExec(`gh pr edit ${prNumber} --repo "${repo}" --body-file "${bodyFile}"`, undefined, true);
+  ghExec(`gh pr edit ${prNumber} --repo ${quotedRepo} --body-file ${shellQuote(bodyFile)}`, undefined, true);
   try { unlinkSync(bodyFile); } catch { /* cleanup */ }
 
   log.success(`Session PR updated: ${prUrl}`);
@@ -645,10 +648,26 @@ export async function resumeCommand(options: ResumeOptions): Promise<void> {
   log.step('Scanning for stranded branches...');
 
   // Prefer explicit crash markers when present; fall back to branch walking for older sessions.
+  //
+  // IMPORTANT: when --session is provided, ONLY trust crash markers. Branch walking has no
+  // session context and would silently resume work from unrelated sessions, defeating the
+  // filter. If the requested session has no recoverable markers, surface that explicitly
+  // rather than papering over it with cross-session results.
   const markerStranded = findStrandedBranchesFromCrashMarkers(config.baseBranch, filterIssue, options.session);
-  const stranded = markerStranded.length > 0
-    ? markerStranded
-    : findStrandedBranches(config.baseBranch, filterIssue);
+  let stranded: StrandedBranch[];
+  if (options.session) {
+    stranded = markerStranded;
+    if (stranded.length === 0) {
+      log.info(
+        `No recoverable crash markers matched --session ${options.session}. ` +
+        `Branch walking is skipped when --session is set to avoid resuming unrelated work.`,
+      );
+    }
+  } else {
+    stranded = markerStranded.length > 0
+      ? markerStranded
+      : findStrandedBranches(config.baseBranch, filterIssue);
+  }
 
   // Filter out branches that already have an open PR
   const withoutPR = stranded.filter((item) => !prExists(config.repo, item.branch));

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -19,6 +19,7 @@ import {
   mkdirSync,
   readdirSync,
   statSync,
+  lstatSync,
   readFileSync,
   rmSync,
   renameSync,
@@ -115,7 +116,7 @@ type SyncDirOptions = {
  * Empty directories are included so every rmSync has a visible WARN line.
  */
 function collectPrunedPaths(targetPath: string): string[] {
-  const stat = statSync(targetPath);
+  const stat = lstatSync(targetPath);
   if (!stat.isDirectory()) return [targetPath];
 
   const entries = readdirSync(targetPath);

--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -179,7 +179,8 @@ export function buildAgentArgs(options: AgentOptions): { command: string; args: 
 export type OneShotCommandOptions = {
   /**
    * Request a stdout-only response for prompts that must not create or edit
-   * files. Currently only Claude-family CLIs expose a tool allowlist flag.
+   * files. Claude-family CLIs use an empty tool allowlist; Codex-family CLIs
+   * use a read-only sandbox.
    */
   textOnly?: boolean;
 };
@@ -202,7 +203,11 @@ export function buildOneShotCommand(agent: AgentType, model: string, options: On
     case 'ollama': {
       const parts = ['codex', 'exec'];
       if (model) parts.push('--model', model);
-      parts.push('--full-auto');
+      if (options.textOnly) {
+        parts.push('--sandbox', 'read-only');
+      } else {
+        parts.push('--full-auto');
+      }
       return parts.join(' ');
     }
     case 'opencode': {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -4,7 +4,7 @@
 import { writeFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { exec } from './shell.js';
+import { exec, shellQuote } from './shell.js';
 import { ghExec, getProjectCache, setProjectCache } from './rate-limit.js';
 import { log } from './logger.js';
 import {
@@ -278,11 +278,12 @@ export function createPR(options: CreatePROptions): string {
   const { repo, base, head, title, body, cwd } = options;
 
   // Push the branch first
-  const pushResult = exec(`git push -u origin "${head}"`, { cwd });
+  const quotedHead = shellQuote(head);
+  const pushResult = exec(`git push -u origin ${quotedHead}`, { cwd });
   if (pushResult.exitCode !== 0) {
     // Try force push if branch exists from previous attempt
     log.warn('Push failed, trying force push...');
-    const forceResult = exec(`git push -u origin "${head}" --force`, { cwd });
+    const forceResult = exec(`git push -u origin ${quotedHead} --force`, { cwd });
     if (forceResult.exitCode !== 0) {
       throw new Error(`Failed to push branch ${head}: ${forceResult.stderr}`);
     }
@@ -296,7 +297,7 @@ export function createPR(options: CreatePROptions): string {
   try {
     // Check if PR already exists for this branch
     const existingResult = ghExec(
-      `gh pr list --repo "${repo}" --head "${head}" --json number,url --limit 1`,
+      `gh pr list --repo ${shellQuote(repo)} --head ${quotedHead} --json number,url --limit 1`,
     );
     if (existingResult.exitCode === 0 && existingResult.stdout) {
       try {
@@ -304,7 +305,7 @@ export function createPR(options: CreatePROptions): string {
         if (existing.length > 0) {
           const prUrl = existing[0].url;
           log.info(`PR already exists: ${prUrl}, updating...`);
-          ghExec(`gh pr edit ${existing[0].number} --repo "${repo}" --base "${base}" --title ${JSON.stringify(title)} --body-file "${bodyFile}"`, undefined, true);
+          ghExec(`gh pr edit ${existing[0].number} --repo ${shellQuote(repo)} --base ${shellQuote(base)} --title ${shellQuote(title)} --body-file ${shellQuote(bodyFile)}`, undefined, true);
           return prUrl;
         }
       } catch {
@@ -314,7 +315,7 @@ export function createPR(options: CreatePROptions): string {
 
     // Create new PR using --body-file to avoid shell escaping issues
     const createResult = ghExec(
-      `gh pr create --repo "${repo}" --base "${base}" --head "${head}" --title ${JSON.stringify(title)} --body-file "${bodyFile}"`,
+      `gh pr create --repo ${shellQuote(repo)} --base ${shellQuote(base)} --head ${quotedHead} --title ${shellQuote(title)} --body-file ${shellQuote(bodyFile)}`,
       undefined, true,
     );
     if (createResult.exitCode !== 0) {

--- a/src/lib/learning.ts
+++ b/src/lib/learning.ts
@@ -676,8 +676,7 @@ export async function generateSessionSummary(options: {
   const learningContents: string[] = [];
   if (!existsSync(learningsDir)) return null;
   for (const result of results) {
-    const files = readdirSync(learningsDir)
-      .filter((f) => f.startsWith(`issue-${result.issueNum}-`) && f.endsWith('.md'));
+    const files = learningFilesForSession(learningsDir, result.issueNum, sessionName);
     for (const file of files) {
       learningContents.push(readFileSync(join(learningsDir, file), 'utf-8'));
     }

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -4,7 +4,7 @@
 import { mkdirSync, readFileSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { log } from './logger.js';
-import { exec } from './shell.js';
+import { exec, shellQuote } from './shell.js';
 import { spawnAgent, buildEndpointEnv } from './agent.js';
 import type { AgentOptions } from './agent.js';
 import {
@@ -401,8 +401,16 @@ function autoCommitDirtyWorktree(worktreePath: string, commitMessage: string): s
   if (paths.length === 0) return [];
 
   log.warn(`Agent did not commit; auto-committing ${paths.length} files: ${paths.join(', ')}`);
-  exec('git add -A', { cwd: worktreePath });
-  exec(commitMessage, { cwd: worktreePath });
+  const addResult = exec('git add -A', { cwd: worktreePath });
+  if (addResult.exitCode !== 0) {
+    log.warn(`Could not stage fallback auto-commit paths: ${addResult.stderr || addResult.stdout}`);
+    return [];
+  }
+  const commitResult = exec(`git commit -m ${shellQuote(commitMessage)}`, { cwd: worktreePath });
+  if (commitResult.exitCode !== 0) {
+    log.warn(`Could not create fallback auto-commit: ${commitResult.stderr || commitResult.stdout}`);
+    return [];
+  }
   return paths;
 }
 
@@ -416,7 +424,7 @@ function commitLearningFiles(worktreePath: string, learningFiles: Array<string |
 
   if (paths.length === 0) return;
 
-  const pathspecs = paths.map((path) => JSON.stringify(path)).join(' ');
+  const pathspecs = paths.map((path) => shellQuote(path)).join(' ');
   const addResult = exec(`git add -- ${pathspecs}`, { cwd: worktreePath });
   if (addResult.exitCode !== 0) {
     log.warn(`Could not stage learning artifact(s): ${addResult.stderr || addResult.stdout}`);
@@ -436,7 +444,7 @@ function commitLearningFiles(worktreePath: string, learningFiles: Array<string |
   if (stagedPaths.length === 0) return;
 
   const commitResult = exec(
-    `git commit -m ${JSON.stringify(message)} -- ${stagedPaths.map((path) => JSON.stringify(path)).join(' ')}`,
+    `git commit -m ${shellQuote(message)} -- ${stagedPaths.map((path) => shellQuote(path)).join(' ')}`,
     { cwd: worktreePath },
   );
   if (commitResult.exitCode !== 0) {
@@ -889,7 +897,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     // Auto-commit if agent didn't
     autoCommittedPaths = autoCommitDirtyWorktree(
       worktreePath,
-      `git commit -m "feat: implement issue #${issueNum} - ${title}"`,
+      `feat: implement issue #${issueNum} - ${title}`,
     );
 
     stepsCompleted.push('implement');
@@ -1691,7 +1699,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
     const issueRefs = issues.map((i) => `#${i.number}`).join(', ');
     autoCommittedPaths = autoCommitDirtyWorktree(
       worktreePath,
-      `git commit -m "feat: batch implement issues ${issueRefs}"`,
+      `feat: batch implement issues ${issueRefs}`,
     );
 
     stepsCompleted.push('implement');

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -14,6 +14,13 @@ export type ExecResult = {
 };
 
 /**
+ * Quote a value as a single POSIX shell argument.
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
  * Execute a shell command synchronously and return structured result.
  * Does not throw on non-zero exit — returns exitCode instead.
  */

--- a/templates/skills/alpha-loop-issue-author/SKILL.md
+++ b/templates/skills/alpha-loop-issue-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-issue-author
-description: Capture new features, changes, or bugs as well-formed GitHub issues optimized for alpha-loop. Use whenever the user describes something they want built or fixed, or says "add an issue", "file a feature", "let's build X". Searches existing issues/epics for duplicates, decides standalone vs epic-child vs new epic, drafts in the canonical alpha-loop body format, applies correct labels, sets dependencies, and links to parent epics.
+description: Capture new features, changes, or bugs as well-formed GitHub issues optimized for alpha-loop. Use whenever the user describes something they want built or fixed, or says "add a feature", "add an issue", "file a feature", "let's build X". Searches existing issues/epics for duplicates, decides standalone vs epic-child vs new epic, drafts in the canonical alpha-loop body format, applies correct labels, sets dependencies, and links to parent epics.
 auto_load: true
 priority: high
 ---

--- a/templates/skills/alpha-loop-runner/SKILL.md
+++ b/templates/skills/alpha-loop-runner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-runner
-description: Run and monitor alpha-loop sessions or epics safely. Use whenever the user asks to run alpha-loop, start the loop on an epic, prepare an epic run, monitor loop progress, verify an alpha-loop session, or validate completed epic issues. Performs dry-run validation, checks ready labels, syncs skills/agents, chooses batch/test/verify settings, and stops on skipped checklist items or missing pre-conditions.
+description: Run and monitor alpha-loop sessions or epics safely. Use whenever the user asks to run the loop, run alpha-loop, start the loop on an epic, prepare an epic run, monitor loop progress, verify an alpha-loop session, or validate completed epic issues. Performs dry-run validation, checks ready labels, syncs skills/agents, chooses batch/test/verify settings, and stops on skipped checklist items or missing pre-conditions.
 auto_load: true
 priority: high
 ---

--- a/templates/skills/alpha-loop-runner/SKILL.md
+++ b/templates/skills/alpha-loop-runner/SKILL.md
@@ -82,7 +82,7 @@ git status --short
 
 Confirm the skill appears in every configured harness output directory from `.alpha-loop.yaml` (`.claude/skills/`, `.agents/skills/`, or another harness-specific path).
 
-Until issue #185 lands, `alpha-loop sync` can delete skills that exist only in generated harness directories. If sync removes a useful harness-only skill, recover it by restoring the file from git or shell history, copying it into `.alpha-loop/templates/skills/<name>/`, and running `<alpha-loop> sync` again. Never treat `.claude/skills/`, `.agents/skills/`, or other harness outputs as canonical.
+`alpha-loop sync` is **additive by default** (#185): it copies skills from `.alpha-loop/templates/skills/` into harness output dirs and updates files that differ, but it does NOT delete files in the harness output that aren't in the templates. Harness-only skills are left alone. Use `<alpha-loop> sync --check` to see what would change, or `<alpha-loop> sync --prune` if you explicitly want to remove anything not in the templates dir. Never treat `.claude/skills/`, `.agents/skills/`, or other harness outputs as canonical — `.alpha-loop/templates/skills/` is the source of truth.
 
 ## Repo-Specific Posture
 
@@ -160,7 +160,7 @@ Follow this ordered playbook for `alpha-loop run --epic <N>` work.
    git status --short
    ```
 
-   If sync deletes or mutates unexpected project-owned skill files, restore or report them before continuing.
+   Sync is additive by default. If you intend to remove untemplated entries from harness output dirs, run `<alpha-loop> sync --check` first to see what would be pruned, then `<alpha-loop> sync --prune` if the list looks right.
 
 6. Choose the run shape and explain it briefly before the dry run.
 
@@ -214,7 +214,7 @@ Interrupt the run, or stop before starting it, and report exact status if any of
 - Repeated verification failures indicate the issue needs new planning or human input instead of another retry.
 - A merge conflict, missing dependency, service startup failure, or auth failure prevents safe unattended progress.
 - A per-issue learning file is not written after an issue exits.
-- Sync deletes a useful harness-only skill and it has not been restored into `.alpha-loop/templates/skills/`.
+- A `<alpha-loop> sync --prune` run reports it would delete a skill the user actually wanted to keep (stop and confirm before re-running with `--prune`).
 - The user says stop, pause, wait, hold, or questions the queue order.
 
 When interrupted, pause any heartbeat automation, wait for Alpha Loop cleanup/finalization when safe, inspect `git status --short --branch`, and summarize the exact PRs, branches, issues, worktrees, and files touched.

--- a/templates/skills/alpha-loop-setup/SKILL.md
+++ b/templates/skills/alpha-loop-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alpha-loop-setup
-description: Guide a user through setting up alpha-loop in a repo, or audit an existing setup. Use when the user asks to install alpha-loop, set up the loop, configure alpha-loop, audit alpha-loop config, or add new harnesses/skills. Detects installed CLI harnesses, inspects the codebase to suggest `.alpha-loop.yaml` settings, recommends matching seed skills, and verifies the setup with a dry-run.
+description: Guide a user through setting up alpha-loop in a repo, or audit an existing setup. Use when the user asks to install alpha-loop, set up alpha-loop, set up the loop, configure alpha-loop, audit alpha-loop config, or add new harnesses/skills. Detects installed CLI harnesses, inspects the codebase to suggest `.alpha-loop.yaml` settings, recommends matching seed skills, and verifies the setup with a dry-run.
 auto_load: false
 priority: medium
 ---

--- a/tests/commands/resume.test.ts
+++ b/tests/commands/resume.test.ts
@@ -1,5 +1,6 @@
 jest.mock('../../src/lib/shell', () => ({
   exec: jest.fn(),
+  shellQuote: (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`,
 }));
 
 jest.mock('../../src/lib/config', () => ({
@@ -138,11 +139,11 @@ describe('findStrandedBranches', () => {
         return ok('  agent/issue-462\n+ agent/issue-466\n');
       }
       if (cmd === 'git worktree list --porcelain') return ok('');
-      if (cmd === 'git log "origin/master..agent/issue-462" --oneline') return ok('');
-      if (cmd === 'git log "origin/master..agent/issue-466" --oneline') {
+      if (cmd === `git log 'origin/master..agent/issue-462' --oneline`) return ok('');
+      if (cmd === `git log 'origin/master..agent/issue-466' --oneline`) {
         return ok('a3f214b fix(#466): address verification findings\n');
       }
-      if (cmd === 'git diff --name-only "origin/master...agent/issue-466"') {
+      if (cmd === `git diff --name-only 'origin/master...agent/issue-466'`) {
         return ok('src/lib/agent.ts\n');
       }
       return ok('');
@@ -173,10 +174,10 @@ describe('findStrandedBranches', () => {
           '',
         ].join('\n'));
       }
-      if (cmd === 'git log "origin/master..agent/issue-187" --oneline') {
+      if (cmd === `git log 'origin/master..agent/issue-187' --oneline`) {
         return ok('def456 fix(#187): recover after result\n');
       }
-      if (cmd === 'git diff --name-only "origin/master...agent/issue-187"') {
+      if (cmd === `git diff --name-only 'origin/master...agent/issue-187'`) {
         return ok('src/commands/resume.ts\n');
       }
       return ok('');
@@ -216,27 +217,27 @@ describe('resumeCommand', () => {
       if (cmd === 'git branch --list "agent/issue-*"') {
         throw new Error('branch walking should not be used when a crash marker exists');
       }
-      if (cmd === 'git log "origin/master..agent/issue-269" --oneline') return ok('abc123 recover stranded work\n');
-      if (cmd === 'git diff --name-only "origin/master...agent/issue-269"') return ok('src/lib/pipeline.ts\n');
+      if (cmd === `git log 'origin/master..agent/issue-269' --oneline`) return ok('abc123 recover stranded work\n');
+      if (cmd === `git diff --name-only 'origin/master...agent/issue-269'`) return ok('src/lib/pipeline.ts\n');
       if (cmd === 'git worktree list --porcelain') return ok('');
       if (cmd === 'git rev-parse --show-toplevel') return ok(tempDir ?? '');
-      if (cmd === 'git checkout "agent/issue-269"') return ok('');
+      if (cmd === `git checkout 'agent/issue-269'`) return ok('');
       if (cmd === 'git status --porcelain -- ".alpha-loop/learnings"') return ok('');
-      if (cmd === 'git push -u origin "agent/issue-269"') return ok('');
+      if (cmd === `git push -u origin 'agent/issue-269'`) return ok('');
       return ok('');
     });
     mockGhExec.mockImplementation((cmd: string) => {
-      if (cmd === 'gh pr list --repo "owner/repo" --head "agent/issue-269" --state open --json number --limit 1') return ok('[]');
-      if (cmd === 'gh issue view 269 --repo "owner/repo" --json title') return ok('{"title":"Recover artifact exports"}');
-      if (cmd === 'gh pr list --repo "owner/repo" --head "session/epic-226" --state open --json number,url --limit 1') {
+      if (cmd === `gh pr list --repo 'owner/repo' --head 'agent/issue-269' --state open --json number --limit 1`) return ok('[]');
+      if (cmd === `gh issue view 269 --repo 'owner/repo' --json title`) return ok('{"title":"Recover artifact exports"}');
+      if (cmd === `gh pr list --repo 'owner/repo' --head 'session/epic-226' --state open --json number,url --limit 1`) {
         return ok('[{"number":999,"url":"https://github.com/owner/repo/pull/999"}]');
       }
-      if (cmd.startsWith('gh pr edit 999 --repo "owner/repo" --body-file ')) {
-        const bodyFile = cmd.match(/--body-file "([^"]+)"/)?.[1];
+      if (cmd.startsWith(`gh pr edit 999 --repo 'owner/repo' --body-file `)) {
+        const bodyFile = cmd.match(/--body-file '([^']+)'/)?.[1];
         if (bodyFile) sessionPrBody = readFileSync(bodyFile, 'utf-8');
         return ok('');
       }
-      if (cmd.startsWith('gh pr edit 999 --repo "owner/repo" --title ')) return ok('');
+      if (cmd.startsWith(`gh pr edit 999 --repo 'owner/repo' --title `)) return ok('');
       return ok('');
     });
 
@@ -268,38 +269,38 @@ describe('resumeCommand', () => {
     mockExec.mockImplementation((cmd: string) => {
       if (cmd === 'git branch --list "agent/issue-*"') return ok('  agent/issue-269\n');
       if (cmd === 'git worktree list --porcelain') return ok('');
-      if (cmd === 'git log "origin/master..agent/issue-269" --oneline') return ok('abc123 recover stranded work\n');
-      if (cmd === 'git diff --name-only "origin/master...agent/issue-269"') return ok('reports/final.pdf\nslides/final.pptx\n');
+      if (cmd === `git log 'origin/master..agent/issue-269' --oneline`) return ok('abc123 recover stranded work\n');
+      if (cmd === `git diff --name-only 'origin/master...agent/issue-269'`) return ok('reports/final.pdf\nslides/final.pptx\n');
       if (cmd === 'git rev-parse --show-toplevel') return ok(tempDir ?? '');
-      if (cmd === 'git checkout "agent/issue-269"') return ok('');
+      if (cmd === `git checkout 'agent/issue-269'`) return ok('');
       if (cmd === 'git status --porcelain -- ".alpha-loop/learnings"') {
         return ok('?? .alpha-loop/learnings/issue-269-20260101-000000.md\n');
       }
-      if (cmd === 'git add -- ".alpha-loop/learnings/issue-269-20260101-000000.md"') return ok('');
-      if (cmd === 'git diff --cached --name-only -- ".alpha-loop/learnings/issue-269-20260101-000000.md"') {
+      if (cmd === `git add -- '.alpha-loop/learnings/issue-269-20260101-000000.md'`) return ok('');
+      if (cmd === `git diff --cached --name-only -- '.alpha-loop/learnings/issue-269-20260101-000000.md'`) {
         return ok('.alpha-loop/learnings/issue-269-20260101-000000.md\n');
       }
-      if (cmd === 'git commit -m "chore: add learning artifact for issue #269" -- ".alpha-loop/learnings/issue-269-20260101-000000.md"') {
+      if (cmd === `git commit -m 'chore: add learning artifact for issue #269' -- '.alpha-loop/learnings/issue-269-20260101-000000.md'`) {
         return ok('');
       }
-      if (cmd === 'git push -u origin "agent/issue-269"') return ok('');
+      if (cmd === `git push -u origin 'agent/issue-269'`) return ok('');
       return ok('');
     });
     mockGhExec.mockImplementation((cmd: string) => {
-      if (cmd === 'gh pr list --repo "owner/repo" --head "agent/issue-269" --state open --json number --limit 1') return ok('[]');
-      if (cmd === 'gh issue view 269 --repo "owner/repo" --json title') return ok('{"title":"Recover artifact exports"}');
-      if (cmd === 'gh pr list --repo "owner/repo" --head "session/epic-123" --state open --json number,url --limit 1') {
+      if (cmd === `gh pr list --repo 'owner/repo' --head 'agent/issue-269' --state open --json number --limit 1`) return ok('[]');
+      if (cmd === `gh issue view 269 --repo 'owner/repo' --json title`) return ok('{"title":"Recover artifact exports"}');
+      if (cmd === `gh pr list --repo 'owner/repo' --head 'session/epic-123' --state open --json number,url --limit 1`) {
         return ok('[{"number":999,"url":"https://github.com/owner/repo/pull/999"}]');
       }
-      if (cmd.startsWith('gh pr edit 999 --repo "owner/repo" --body-file ')) {
-        const bodyFile = cmd.match(/--body-file "([^"]+)"/)?.[1];
+      if (cmd.startsWith(`gh pr edit 999 --repo 'owner/repo' --body-file `)) {
+        const bodyFile = cmd.match(/--body-file '([^']+)'/)?.[1];
         if (bodyFile) {
           sessionPrBodyFile = bodyFile;
           sessionPrBody = readFileSync(bodyFile, 'utf-8');
         }
         return ok('');
       }
-      if (cmd.startsWith('gh pr edit 999 --repo "owner/repo" --title ')) return ok('');
+      if (cmd.startsWith(`gh pr edit 999 --repo 'owner/repo' --title `)) return ok('');
       return ok('');
     });
 
@@ -312,7 +313,7 @@ describe('resumeCommand', () => {
       sessionLogsDir: expect.stringContaining('.alpha-loop/sessions/session/epic-123/logs'),
     });
     expect(mockExec).toHaveBeenCalledWith(
-      'git commit -m "chore: add learning artifact for issue #269" -- ".alpha-loop/learnings/issue-269-20260101-000000.md"',
+      `git commit -m 'chore: add learning artifact for issue #269' -- '.alpha-loop/learnings/issue-269-20260101-000000.md'`,
       { cwd: tempDir! },
     );
     expect(mockCreatePR).toHaveBeenCalledWith(expect.objectContaining({
@@ -349,12 +350,12 @@ describe('resumeCommand', () => {
     }));
 
     expect(mockGhExec).toHaveBeenCalledWith(
-      expect.stringContaining('gh pr edit 999 --repo "owner/repo" --title "Session: session/epic-123 — 0 succeeded, 1 recovered"'),
+      expect.stringContaining(`gh pr edit 999 --repo 'owner/repo' --title 'Session: session/epic-123 — 0 succeeded, 1 recovered'`),
       undefined,
       true,
     );
     expect(mockGhExec).toHaveBeenCalledWith(
-      expect.stringMatching(/^gh pr edit 999 --repo "owner\/repo" --body-file ".+"/),
+      expect.stringMatching(/^gh pr edit 999 --repo 'owner\/repo' --body-file '.+'/),
       undefined,
       true,
     );
@@ -386,5 +387,134 @@ describe('resumeCommand', () => {
     const source = readFileSync(join(repoRoot, 'src', 'commands', 'resume.ts'), 'utf-8');
 
     expect(source).not.toMatch(/\brequire\s*\(/);
+  });
+
+  test('shell-quotes malicious repo/branch values so shell metachars cannot escape arguments', () => {
+    // Regression for the reviewer-flagged shell-injection risk in resume.ts.
+    // If repo or branch contains shell metacharacters (backticks, $(), ;, &&),
+    // they must be encoded as single-quoted POSIX literals, not interpolated raw.
+    mockLoadConfig.mockReturnValue(baseConfig({
+      repo: 'owner/repo;rm -rf /',
+      baseBranch: 'mas`whoami`ter',
+    }));
+
+    const observed: string[] = [];
+    mockExec.mockImplementation((cmd: string) => {
+      observed.push(cmd);
+      if (cmd === 'git branch --list "agent/issue-*"') return ok('  agent/issue-1$(curl evil)\n');
+      if (cmd === 'git worktree list --porcelain') return ok('');
+      return ok('');
+    });
+    mockGhExec.mockReturnValue(ok('[]'));
+
+    return resumeCommand({}).then(() => {
+      // Every dynamic value containing shell metachars must appear inside a
+      // single-quoted POSIX literal in the emitted commands.
+      const allCommands = observed.join('\n');
+      // Repo with `;rm -rf /` must be inside '...' so the semicolon stays literal
+      expect(allCommands).not.toMatch(/owner\/repo;rm -rf \//);
+      // Base branch with backticks must be inside '...'
+      expect(allCommands).not.toMatch(/mas`whoami`ter(?!')/);
+      // Specifically: shellQuote wraps the value in single quotes
+      const containsQuotedDirty = observed.some((c) =>
+        c.includes(`'owner/repo;rm -rf /'`)
+        || c.includes(`'mas\`whoami\`ter'`)
+        || c.includes(`'agent/issue-1$(curl evil)'`),
+      );
+      // At least one of the dynamic values should have been emitted, and when
+      // it was, it must have been quoted.
+      if (allCommands.includes('owner/repo')
+        || allCommands.includes('mas')
+        || allCommands.includes('agent/issue-1')) {
+        expect(containsQuotedDirty).toBe(true);
+      }
+    });
+  });
+
+  test('--session does NOT fall back to branch walking when no crash markers match', async () => {
+    // Regression: previously, if no crash marker matched --session, the resume
+    // command would fall through to findStrandedBranches() ignoring the session
+    // filter — potentially resuming unrelated work from other sessions.
+    tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-resume-session-'));
+    process.chdir(tempDir);
+
+    // Create a crash marker for a DIFFERENT session than the one filtered for.
+    const otherSessionDir = join(tempDir, '.alpha-loop', 'sessions', 'session', 'epic-aaa');
+    mkdirSync(otherSessionDir, { recursive: true });
+    writeFileSync(join(otherSessionDir, 'crash-100.json'), JSON.stringify({
+      issueNum: 100,
+      step: 'review',
+      branch: 'agent/issue-100',
+      hasCommits: true,
+      error: 'crashed',
+      timestamp: '2026-05-25T00:00:00.000Z',
+      recoverable: true,
+    }, null, 2));
+
+    mockLoadConfig.mockReturnValue(baseConfig());
+    mockExec.mockImplementation((cmd: string) => {
+      // Branch walking would normally find this branch — assert it is NOT called.
+      if (cmd === 'git branch --list "agent/issue-*"') {
+        throw new Error('branch walking must be skipped when --session is set and no markers match');
+      }
+      if (cmd === 'git worktree list --porcelain') return ok('');
+      return ok('');
+    });
+    mockGhExec.mockReturnValue(ok('[]'));
+
+    // Filter for a session that has NO matching crash marker.
+    await resumeCommand({ session: 'session/epic-does-not-exist' });
+
+    // Should complete cleanly without invoking branch walking; nothing to resume.
+    expect(mockCreatePR).not.toHaveBeenCalled();
+    expect(mockLabelIssue).not.toHaveBeenCalled();
+  });
+
+  test('--session resumes only branches whose crash marker matches the session', async () => {
+    // Positive complement: when --session DOES match a crash marker, resume
+    // proceeds for that issue and ignores other sessions' markers.
+    tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-resume-session-match-'));
+    process.chdir(tempDir);
+
+    const targetSessionDir = join(tempDir, '.alpha-loop', 'sessions', 'session', 'epic-bbb');
+    const otherSessionDir = join(tempDir, '.alpha-loop', 'sessions', 'session', 'epic-ccc');
+    mkdirSync(targetSessionDir, { recursive: true });
+    mkdirSync(otherSessionDir, { recursive: true });
+
+    writeFileSync(join(targetSessionDir, 'crash-200.json'), JSON.stringify({
+      issueNum: 200,
+      step: 'review',
+      branch: 'agent/issue-200',
+      hasCommits: true,
+      error: 'crashed',
+      timestamp: '2026-05-25T00:00:00.000Z',
+      recoverable: true,
+    }, null, 2));
+    writeFileSync(join(otherSessionDir, 'crash-300.json'), JSON.stringify({
+      issueNum: 300,
+      step: 'review',
+      branch: 'agent/issue-300',
+      hasCommits: true,
+      error: 'crashed',
+      timestamp: '2026-05-25T00:00:00.000Z',
+      recoverable: true,
+    }, null, 2));
+
+    mockLoadConfig.mockReturnValue(baseConfig({ skipReview: true, skipLearn: true }));
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd === 'git worktree list --porcelain') return ok('');
+      if (cmd === 'git rev-parse --show-toplevel') return ok(tempDir ?? '');
+      if (cmd === `git log 'origin/master..agent/issue-200' --oneline`) return ok('aaa target session work\n');
+      if (cmd === `git log 'origin/master..agent/issue-300' --oneline`) {
+        throw new Error('issue-300 belongs to other session and must NOT be inspected');
+      }
+      return ok('');
+    });
+    mockGhExec.mockReturnValue(ok('[]'));
+
+    await resumeCommand({ session: 'session/epic-bbb' });
+
+    // Other-session marker MUST NOT be touched.
+    expect(existsSync(join(otherSessionDir, 'crash-300.json'))).toBe(true);
   });
 });

--- a/tests/commands/sync.test.ts
+++ b/tests/commands/sync.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { syncAgentAssets } from '../../src/commands/sync';
@@ -289,6 +289,29 @@ describe('syncAgentAssets', () => {
     expect(existsSync(join(dir, '.claude', 'skills', 'harness-only'))).toBe(false);
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(join('.claude', 'skills', 'harness-only', 'SKILL.md')));
     expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(join('.claude', 'skills', 'harness-only', 'references', 'guide.md')));
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('prune removes target-only symlinks without traversing their targets', () => {
+    const dir = makeTmpDir();
+    const templatesBase = join(dir, '.alpha-loop', 'templates');
+    const outsideDir = join(dir, 'outside-target');
+    mkdirSync(join(templatesBase, 'skills', 'a'), { recursive: true });
+    writeFileSync(join(templatesBase, 'skills', 'a', 'SKILL.md'), '# Same');
+    mkdirSync(join(dir, '.claude', 'skills', 'a'), { recursive: true });
+    writeFileSync(join(dir, '.claude', 'skills', 'a', 'SKILL.md'), '# Same');
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(outsideDir, 'keep.md'), '# Keep');
+    symlinkSync(outsideDir, join(dir, '.claude', 'skills', 'external-link'), 'dir');
+
+    const result = syncAgentAssets(['claude-code'], { projectDir: dir, prune: true });
+
+    expect(result.synced).toBe(true);
+    expect(existsSync(join(dir, '.claude', 'skills', 'external-link'))).toBe(false);
+    expect(readFileSync(join(outsideDir, 'keep.md'), 'utf-8')).toBe('# Keep');
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(join('.claude', 'skills', 'external-link')));
+    expect(log.warn).not.toHaveBeenCalledWith(expect.stringContaining(join(outsideDir, 'keep.md')));
 
     rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -199,9 +199,19 @@ describe('buildOneShotCommand', () => {
     expect(cmd).toBe('codex exec --model gpt-5.4 --full-auto');
   });
 
+  test('builds codex text-only command with read-only sandbox', () => {
+    const cmd = buildOneShotCommand('codex', 'gpt-5.4', { textOnly: true });
+    expect(cmd).toBe('codex exec --model gpt-5.4 --sandbox read-only');
+  });
+
   test('builds codex command without model', () => {
     const cmd = buildOneShotCommand('codex', '');
     expect(cmd).toBe('codex exec --full-auto');
+  });
+
+  test('builds ollama text-only command with read-only sandbox', () => {
+    const cmd = buildOneShotCommand('ollama', 'llama3.1:70b', { textOnly: true });
+    expect(cmd).toBe('codex exec --model llama3.1:70b --sandbox read-only');
   });
 
   test('builds opencode command', () => {

--- a/tests/lib/github.test.ts
+++ b/tests/lib/github.test.ts
@@ -8,6 +8,7 @@ import {
 
 jest.mock('../../src/lib/shell', () => ({
   exec: jest.fn(),
+  shellQuote: (value: string) => `'${String(value).replace(/'/g, `'\\''`)}'`,
 }));
 
 jest.mock('../../src/lib/logger', () => ({
@@ -248,6 +249,33 @@ describe('createPR', () => {
     );
     expect(createCall).toBeDefined();
     expect(createCall?.[0]).toContain('--body-file');
+  });
+
+  test('shell-quotes PR title and branch values', () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('git push')) {
+        return { stdout: '', stderr: '', exitCode: 0 };
+      }
+      if (cmd.includes('gh pr list')) {
+        return { stdout: '[]', stderr: '', exitCode: 0 };
+      }
+      if (cmd.includes('gh pr create')) {
+        return { stdout: 'https://github.com/owner/repo/pull/1', stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    createPR({
+      ...baseOptions,
+      head: "agent/issue-42-$(touch /tmp/pwned)'branch",
+      title: "feat: Add $(touch /tmp/pwned) 'quoted'",
+    });
+
+    const createCall = mockExec.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('gh pr create'),
+    );
+    expect(createCall?.[0]).toContain("--head 'agent/issue-42-$(touch /tmp/pwned)'\\''branch'");
+    expect(createCall?.[0]).toContain("--title 'feat: Add $(touch /tmp/pwned) '\\''quoted'\\'''");
   });
 
   test('tries force push on initial push failure', () => {

--- a/tests/lib/learning.test.ts
+++ b/tests/lib/learning.test.ts
@@ -245,6 +245,8 @@ function learningFileContent(): string {
   return `---
 issue: 42
 status: success
+traces:
+  plan: .alpha-loop/sessions/session/test/traces/prompts/plan-issue-42.md
 ---
 ## What Worked
 - Good tests
@@ -639,6 +641,49 @@ describe('generateSessionSummary', () => {
     expect(prompt).toContain('Recovered issues are excluded from failure counts and success-rate calculations');
     expect(prompt).toContain('| Recovered issues | #216 (resume) |');
     expect(prompt).toContain('| Success rate | 100% |');
+  });
+
+  test('uses only learning artifacts from the requested session', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue([
+      'issue-42-20260101-000000.md' as any,
+      'issue-42-20260102-000000.md' as any,
+    ]);
+    mockReadFileSync.mockImplementation((path) => {
+      const filePath = String(path);
+      if (filePath.endsWith('issue-42-20260101-000000.md')) {
+        return `---
+issue: 42
+traces:
+  plan: .alpha-loop/sessions/session/old/traces/prompts/plan-issue-42.md
+---
+## What Worked
+- Stale learning`;
+      }
+      return `---
+issue: 42
+traces:
+  plan: .alpha-loop/sessions/session/test/traces/prompts/plan-issue-42.md
+---
+## What Worked
+- Current session learning`;
+    });
+    mockSpawnAgent.mockResolvedValue({
+      exitCode: 0,
+      output: codexSummaryTranscript(),
+      duration: 5000,
+    });
+
+    await generateSessionSummary({
+      sessionName: 'session/test',
+      results: [{ issueNum: 42, title: 'Test issue', status: 'success', duration: 120 }],
+      learningsDir: '/fake/learnings',
+      config: makeConfig({ agent: 'codex' }),
+    });
+
+    const prompt = mockSpawnAgent.mock.calls[0][0].prompt;
+    expect(prompt).toContain('Current session learning');
+    expect(prompt).not.toContain('Stale learning');
   });
 
   test('skips writing session summary when output is placeholder-only', async () => {

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -4,6 +4,7 @@ import type { SessionContext } from '../../src/lib/session';
 // Mock all dependencies
 jest.mock('../../src/lib/shell', () => ({
   exec: jest.fn(),
+  shellQuote: (value: string) => `'${String(value).replace(/'/g, `'\\''`)}'`,
 }));
 
 jest.mock('../../src/lib/logger', () => ({
@@ -284,13 +285,29 @@ describe('processIssue', () => {
     );
     expect(mockExec).toHaveBeenCalledWith('git add -A', { cwd: '/tmp/worktree' });
     expect(mockExec).toHaveBeenCalledWith(
-      'git commit -m "feat: implement issue #42 - Test issue"',
+      "git commit -m 'feat: implement issue #42 - Test issue'",
       { cwd: '/tmp/worktree' },
     );
     expect(mockSaveResult).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       autoCommittedByPipeline: true,
       autoCommittedPaths: ['src/lib/pipeline.ts', 'tests/lib/pipeline.test.ts'],
     }));
+  });
+
+  test('shell-quotes issue titles in fallback auto-commit messages', async () => {
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd === 'git status --porcelain') {
+        return { stdout: ' M src/lib/pipeline.ts\n', stderr: '', exitCode: 0 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    await processIssue(42, "Danger $(touch /tmp/pwned) 'quote'", 'Issue body', makeConfig(), makeSession());
+
+    expect(mockExec).toHaveBeenCalledWith(
+      "git commit -m 'feat: implement issue #42 - Danger $(touch /tmp/pwned) '\\''quote'\\'''",
+      { cwd: '/tmp/worktree' },
+    );
   });
 
   test('extracts and commits the learning artifact in the worktree before creating the PR', async () => {
@@ -316,7 +333,7 @@ describe('processIssue', () => {
     }));
 
     const commitCallIndex = mockExec.mock.calls.findIndex(([cmd]) =>
-      String(cmd).startsWith('git commit -m "chore: add learning artifact for issue #42"'),
+      String(cmd).startsWith("git commit -m 'chore: add learning artifact for issue #42'"),
     );
     expect(commitCallIndex).toBeGreaterThanOrEqual(0);
     expect(mockExec.mock.calls[commitCallIndex][0]).toContain('.alpha-loop/learnings/issue-42-20260101-000000.md');
@@ -1032,7 +1049,7 @@ describe('processBatch', () => {
     }));
 
     const commitCallIndex = mockExec.mock.calls.findIndex(([cmd]) =>
-      String(cmd).startsWith('git commit -m "chore: add learning artifacts for issues #10, #11"'),
+      String(cmd).startsWith("git commit -m 'chore: add learning artifacts for issues #10, #11'"),
     );
     expect(commitCallIndex).toBeGreaterThanOrEqual(0);
     expect(mockExec.mock.calls[commitCallIndex][0]).toContain('issue-10-20260101-000000.md');

--- a/tests/lib/seeded-skills.test.ts
+++ b/tests/lib/seeded-skills.test.ts
@@ -16,6 +16,7 @@ describe('seeded alpha-loop skills', () => {
 
     expect(projectSkill).toBe(distSkill);
     expect(distSkill).toMatch(/^name: alpha-loop-runner$/m);
+    expect(distSkill).toMatch(/^description: .*run the loop.*run alpha-loop/m);
     expect(distSkill).toMatch(/^auto_load: true$/m);
     expect(distSkill).toMatch(/^priority: high$/m);
     expect(distSkill).toContain('## Trigger');
@@ -41,6 +42,7 @@ describe('seeded alpha-loop skills', () => {
 
     expect(projectSkill).toBe(distSkill);
     expect(distSkill).toMatch(/^name: alpha-loop-setup$/m);
+    expect(distSkill).toMatch(/^description: .*set up alpha-loop.*set up the loop/m);
     expect(distSkill).toMatch(/^auto_load: false$/m);
     expect(distSkill).toMatch(/^priority: medium$/m);
     expect(distSkill).toContain('## Trigger');
@@ -79,6 +81,7 @@ describe('seeded alpha-loop skills', () => {
 
     expect(projectSkill).toBe(distSkill);
     expect(distSkill).toMatch(/^name: alpha-loop-issue-author$/m);
+    expect(distSkill).toMatch(/^description: .*add a feature.*add an issue/m);
     expect(distSkill).toMatch(/^auto_load: true$/m);
     expect(distSkill).toMatch(/^priority: high$/m);
     expect(distSkill).toContain('## Trigger');


### PR DESCRIPTION
# Release: Loop Reliability & UX Cleanup (2026-05-26)

This PR consolidates **18 child issues across 3 epics + 1 follow-up of holistic-reviewer refinements + 2 reviewer-blocker fixes** into a single review surface. The cumulative diff (vs the pre-cleanup baseline `0dce68a`) is **~95 files changed, ~+8000 / -490 lines**.

> **Reviewer note**: Three of the four contributing PRs (#246, #251, #256) have already been squash-merged to `master`. This PR represents the *last remaining unmerged piece* (the holistic post-session reviewer's refinements + a round of fixes for reviewer-flagged blockers) and acts as the consolidated entry point for review of the entire release. Compare against `0dce68a` to see the full cumulative diff; compare against `master` to see only this PR's incremental changes.

> **Round 2 (post-review)**: An independent AI reviewer found 2 BLOCKER findings + 1 HIGH + 3 MED, all addressed in commit `16e55c5`. See the "Round 2 fixes" section at the bottom.

---

## Contributing PRs

| PR | Status | Epic | Children | Branch |
|---|---|---|---|---|
| [#246](https://github.com/bradtaylorsf/alpha-loop/pull/246) | ✅ Merged | #243 — Seeded harness skills | 4 | (deleted) |
| [#251](https://github.com/bradtaylorsf/alpha-loop/pull/251) | ✅ Merged | #244 — Sync/scan safety + CLI observability | 4 | (deleted) |
| [#256](https://github.com/bradtaylorsf/alpha-loop/pull/256) | ✅ Merged | #245 — Post-#217 reliability cleanup | 10 | (deleted) |
| **this PR** | ⏳ Open | (holistic reviewer follow-up + Round 2 fixes) | n/a | `release/loop-reliability-cleanup-2026-05-26` |

---

## Issues addressed (all closed)

### Epic #243 — Seeded harness skills (4 issues)
- **#239** — `alpha-loop-runner` skill: pre-flight, dry-run + validate, monitor, stop conditions, completion validation
- **#240** — `alpha-loop-setup` skill: guided init + codebase inspection + harness detection + skill suggestions
- **#241** — `alpha-loop-issue-author` skill: search-before-create, canonical issue/epic body format, dependency/batching awareness
- **#242** — `alpha-loop-learning-review` skill: two-phase review (proposals + independent research) before applying

### Epic #244 — Sync/scan safety + CLI observability (4 issues)
- **#185** — Additive `syncDir` by default with opt-in `--prune` (root-causal for the alpha-research PR #196 incident)
- **#235** — Stop `scanCommand` writing the agent's stdout-summary into `.alpha-loop/context.md` / `CLAUDE.md` when the agent uses its Write tool
- **#236** — Read CLI version from `package.json` at runtime so `--version` matches the installed package
- **#237** — Negative-cache project-board failures; emit at most one warning per session

### Epic #245 — Post-#217 reliability cleanup (10 issues)

**Hygiene & docs (4):**
- **#233** — Gitignore codex `plugins/` directory
- **#231** — Exclude `.worktrees/` in `templates/jest.config.cjs`
- **#232** — Tighten `docs-sync` skill trigger for `src/commands/*.ts` changes
- **#224** — Commit learning files inside the worktree so they ship with the implementation PR

**Session recovery & result integrity (4):**
- **#226** — Pipeline writes a crash marker when `processIssue` throws (detection primitive)
- **#225** — Add `PipelineResult.recoveryMode` field (consumes marker info)
- **#227** — Integration coverage for resume's session-PR update path
- **#228** — Resume regenerates the session summary when updating the PR

**Queue execution finalization (2):**
- **#230** — Replace `process.exit(1)` with typed errors so finalize/summary always runs
- **#229** — Surface auto-commit fallback in the per-issue result + session PR body

### Holistic reviewer refinements (PR's original incremental diff)
- **Shell-injection hardening** in `createPR` (`src/lib/github.ts`) and the auto-commit / learning-file commit paths (`src/lib/pipeline.ts`)
- **Auto-commit fallback robustness** — proper error handling on `git add` / `git commit` failures
- **Symlink-safe prune** — `lstatSync` in `src/commands/sync.ts`
- **Codex `textOnly` mode** in `buildOneShotCommand` (`src/lib/agent.ts`)
- **Seeded skill trigger tightening** — "run the loop" added to `alpha-loop-runner`
- **+175 / -28 lines of test coverage** for the above

### Round 2 — reviewer-blocker fixes (commit `16e55c5`)
- **Resume shell-injection** — `shellQuote()` applied to all dynamic interpolations in `src/commands/resume.ts` (lines 100, 126, 142, 187, 201, 247, 263, 278, 345, 348, 514, 616, 621). Reviewer-flagged as BLOCKER.
- **`--session` fallback bug** — when `--session` is set, branch walking is now skipped entirely if no crash markers match (was silently resuming unrelated work from other sessions). Reviewer-flagged as HIGH.
- **Stale `#185`-era sync warnings** in `alpha-loop-runner` skill — replaced with additive-by-default guidance pointing to `--check` and `--prune`.
- **3 new regression tests** added: malicious metachar handling, `--session` fallback skip, `--session` correct-marker-only behavior. Suite: 1289 → 1292 tests.

---

## Verification done

- ✅ `pnpm build` clean on `release/...` branch
- ✅ `pnpm test` — 73 suites / **1292 tests** passing, 0 failures
- ✅ All 18 child issues CLOSED on GitHub
- ✅ All 3 contributing session PRs (#246, #251, #256) merged
- ✅ Local `master` synced to `origin/master` at `076c822` (post-#256 merge)
- ✅ Reviewer-flagged BLOCKER + HIGH + MED items resolved in commit `16e55c5`

## How to test each piece using the CLI

Run from this repo root after checking out the release branch:

```bash
git switch release/loop-reliability-cleanup-2026-05-26
pnpm install --frozen-lockfile && pnpm build
```

### Skills (#239-#242)
The four seeded skills are installed by `alpha-loop init` and propagated to each configured harness output dir by `alpha-loop sync`. This repo configures `harnesses: codex` in `.alpha-loop.yaml`, so they appear under `.agents/skills/`:

```bash
node dist/cli.js sync
# Verify all 4 skills appear in EACH configured harness dir.
# This repo: harnesses=[codex] → .agents/skills/
for s in alpha-loop-runner alpha-loop-setup alpha-loop-issue-author alpha-loop-learning-review; do
  test -f ".agents/skills/$s/SKILL.md" && echo "OK: $s" || echo "MISSING: $s"
done
# Also verify in the canonical templates dir
for s in alpha-loop-runner alpha-loop-setup alpha-loop-issue-author alpha-loop-learning-review; do
  test -f ".alpha-loop/templates/skills/$s/SKILL.md" && echo "OK template: $s" || echo "MISSING template: $s"
done
```

### Sync safety (#185)
This repo configures `harnesses: [codex]` in `.alpha-loop.yaml`, so sync writes to `.agents/skills/`. If your repo configures `claude-code` instead, swap `.agents/skills/` for `.claude/skills/`.
```bash
# Simulate a harness-only skill the user added (not in templates dir).
mkdir -p .agents/skills/throwaway-test
echo "test" > .agents/skills/throwaway-test/SKILL.md
node dist/cli.js sync
ls .agents/skills/throwaway-test/  # PASS = SKILL.md still exists (additive default)

# Opt-in prune
node dist/cli.js sync --prune
ls .agents/skills/throwaway-test/ 2>&1  # PASS = directory removed + WARN line printed
```

### Scan corruption (#235)
The fix is harder to verify without a live agent run — code path is:
1. `scanCommand` invokes the agent with `textOnly: true` (no Write tool access)
2. Stdout is run through `scan-validation.ts` before being written
3. Invalid output (e.g., status-summary text) is rejected with a clear error

Verify via the unit tests + a grep:
```bash
pnpm exec jest tests/commands/scan.test.ts tests/lib/scan-validation.test.ts
grep -n "textOnly\|validateScanOutput\|scan-validation" src/commands/scan.ts | head -10
```

### Version reporting (#236)
```bash
pnpm build
PKG=$(node -p "require('./package.json').version")
DIST=$(node dist/cli.js --version)
TSX=$(pnpm exec tsx src/cli.ts --version)
[ "$PKG" = "$DIST" ] && [ "$PKG" = "$TSX" ] && echo PASS || echo "FAIL: pkg=$PKG dist=$DIST tsx=$TSX"
```

### Project-warning quieting (#237)
With a misconfigured project, expect at most one project-related warning per session:
```bash
# Run a fast dry-run that exercises a status transition
node dist/cli.js run --epic 243 --dry-run --validate 2>&1 | grep -c "Could not list project fields"
# Expected: 0 or 1 (was 4-8+ before fix)
```

### Gitignore hygiene (#233)
```bash
mkdir -p plugins/test-plugin && echo "x" > plugins/test-plugin/file
git status plugins/   # empty output = ignored (PASS)
rm -rf plugins/test-plugin
```

### Jest worktree exclusion (#231)
```bash
grep -F ".worktrees" jest.config.cjs templates/jest.config.cjs
# Both should show .worktrees/ in testPathIgnorePatterns
```

### Docs-sync trigger (#232)
```bash
grep -nE "src/commands|history" templates/skills/docs-sync/SKILL.md | head -5
# Should mention src/commands/*.ts triggering the skill
```

### Learning-files-in-worktree (#224)
This is tested at the unit level — there's no `--issue` flag on `run`. Run the targeted tests:
```bash
pnpm exec jest tests/lib/pipeline.test.ts --testNamePattern "learning"
pnpm exec jest tests/commands/resume.test.ts --testNamePattern "learning"
```

### Crash marker (#226) + recoveryMode (#225)
```bash
pnpm exec jest tests/lib/pipeline.test.ts --testNamePattern "crash"
pnpm exec jest tests/lib/pipeline.test.ts --testNamePattern "recoveryMode"
pnpm exec jest tests/lib/session.test.ts --testNamePattern "crash"
```

### Resume PR update + summary regen (#227, #228)
```bash
pnpm exec jest tests/commands/resume.test.ts --testNamePattern "session PR"
pnpm exec jest tests/commands/resume.test.ts --testNamePattern "summary"
pnpm exec jest tests/lib/learning.test.ts --testNamePattern "session summary"
```

### Queue typed errors (#230)
```bash
pnpm exec jest tests/commands/run.test.ts --testNamePattern "queue"
# Verify no process.exit(N) calls in queue path:
grep -nE "process\.exit\([0-9]+\)" src/commands/run.ts
# Should be empty (only the outer handler is allowed to exit)
```

### Auto-commit fallback surfacing (#229)
```bash
pnpm exec jest tests/lib/pipeline.test.ts --testNamePattern "auto-commit"
grep -n "autoCommittedByPipeline\|formatAutoCommittedResultsSection" src/lib/pipeline.ts src/lib/session.ts | head -5
```

### Round 2 fixes: resume shell-quoting + --session fallback
```bash
pnpm exec jest tests/commands/resume.test.ts --testNamePattern "shell-quotes malicious"
pnpm exec jest tests/commands/resume.test.ts --testNamePattern=--session
# (note: the `=` form is required when the test name itself starts with `--`,
#  otherwise jest treats `--session` as an unrecognized flag)
# Should show 3 passing tests across these patterns.

# Verify no raw "${var}" patterns remain in dynamic exec/ghExec calls:
grep -nE 'exec\(`[^`]*"\$\{[^}]+\}[^`]*`\)' src/commands/resume.ts
# Should be empty.
```

### Whole-suite smoke
```bash
pnpm build && pnpm test
# Expected: 73 suites / 1292 tests / 0 failures
```

---

## Risk assessment

### Low risk
- The 4 seeded skills (#239-#242): new files only, no behavioral change to existing skills.
- Hygiene: `plugins/` gitignore, `.worktrees/` jest exclusion, version-from-package.json — additive / surface-only.
- Negative-cache project warnings (#237): falls back to same behavior on success, only changes failure-loop noise.

### Medium risk
- `syncDir` additive default (#185): changes a destructive default. **Mitigation**: opt-in `--prune` preserves the old behavior; both tested. SKILL.md guidance updated in Round 2.
- `scanCommand` stdout validation (#235): new validation layer between agent and canonical files. **Mitigation**: `.bak` written before any overwrite; explicit error message points to it; `textOnly: true` prevents the agent from writing files at all.
- `process.exit(1)` → typed errors (#230): outer handler now catches and runs finalize. **Mitigation**: exit codes preserved.

### Higher risk (worth focused review)
- `src/commands/resume.ts` overhaul: the entire recovery story (now includes Round 2 shell-quoting + `--session` fallback fix). **Mitigation**: integration tests added (#227); recoveryMode field (#225) distinguishes recovered results; 3 new regression tests for the Round 2 fixes.
- `src/lib/pipeline.ts`: core orchestration. **Mitigation**: heavy test coverage; `pipeline.test.ts` exercises crash markers, recoveryMode, auto-commit fallback, learning files.

---

## Round 2 fixes (commit `16e55c5`)

| Reviewer finding | Severity | Status | Evidence |
|---|---|---|---|
| `resume.ts` raw shell interpolation (lines 247, 278, 345, 514, 616, 621) | BLOCKER | ✅ Fixed | All 13 dynamic interpolations now use `shellQuote`. Regression test: `shell-quotes malicious repo/branch values`. |
| `--session` fallback ignores filter (line 648) | HIGH | ✅ Fixed | Branch walking skipped entirely when `--session` is set. 2 new regression tests cover the fallback-skip + correct-marker-only behavior. |
| Stale `#185`-era sync warnings in runner SKILL.md (lines 85, 163, 217) | MED | ✅ Fixed | Replaced with additive-by-default guidance pointing to `--check` and `--prune`. Both `templates/` and `.alpha-loop/templates/` copies updated. |
| PR body skills check assumed `.claude/` dir; repo configures codex only | MED | ✅ Fixed | This block now iterates `.agents/skills/` (matching `.alpha-loop.yaml` config) and `.alpha-loop/templates/skills/`. |
| `run --once --issue 239` — no `--issue` flag exists | MED | ✅ Fixed | Replaced with direct `pnpm exec jest` calls against the relevant tests. |
| `node node_modules/.bin/jest ...` shell-parse failures | MED | ✅ Fixed | Switched to `pnpm exec jest ...` throughout. |

---

## Open follow-ups (not in this release)

1. **Reviewer-output PR loop** — The post-session holistic review currently can't commit back into already-merged sub-PRs. Worth filing: "post-session reviewer should open a dedicated PR for its refinements, not leave them as parent-worktree orphans."
2. **Stacked session branches in queue** — Epic #245 conflicted on merge against epics 243/244 because each session branch was independently based on master at queue start, not stacked. #214 added stacked-branch support but the queue runner didn't use it here.
3. **`.agents/skills/*` gitignore** — Codex's sync output directories were left untracked. Same family as #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

