### PR TITLE
ci(release): add workflow_dispatch trigger for manual release runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ on:
       - '*.md'
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why are you manually triggering a release? (e.g. "validate post-#271 commit-back logic")'
+        required: false
+        default: 'manual release'
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds a manual run option to the release workflow so maintainers can re-trigger it without making a code commit. Useful next time we want to validate workflow changes without bumping the version artificially. Patch-level change (chore: prefix → patch bump on merge).