### PR TITLE
chore(release): sync package.json to v2.0.1 [post-release sync]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradtaylorsf/alpha-loop",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Agent-agnostic automated development loop: Plan → Build → Test → Review → Ship",
   "type": "module",
   "packageManager": "pnpm@9.0.0",


### PR DESCRIPTION
Closes the mismatch left over from the v2.0.1 release where the commit-back step failed before #272 enabled the necessary repo-level permission. Merging this fires a release that will produce v2.0.2 and validate the now-fixed commit-back end-to-end.