### PR TITLE
chore(release): bump version to v2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bradtaylorsf/alpha-loop",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Agent-agnostic automated development loop: Plan → Build → Test → Review → Ship",
   "type": "module",
   "packageManager": "pnpm@9.0.0",


### PR DESCRIPTION
Closes the bump-back chain. PR title matches the loop-guard regex, so the release fired by this merge will skip cleanly. After this lands, master and npm will both be at v2.0.4.