### PR TITLE
fix(release-watch): fetch tags so version-sync check is reliable

### DIFF
--- a/scripts/release-watch.mjs
+++ b/scripts/release-watch.mjs
@@ -76,15 +76,18 @@ if (final.conclusion !== 'success') {
 
 console.log('\n✓ Release workflow completed successfully.\n');
 
-// Sync local state
+// Sync local state. Fetch tags explicitly — `git pull` does not pull new
+// tags by default, and the release tag is the source of truth we check
+// against below.
 if (PULL) {
-  console.log('Syncing local master...');
+  console.log('Syncing local master + tags...');
   const branch = sh('git rev-parse --abbrev-ref HEAD');
   if (branch === 'master') {
     shOk('git pull --ff-only origin master');
   } else {
-    console.log(`  (on ${branch}, not pulling — pass --no-pull to silence this)`);
+    console.log(`  (on ${branch}, not pulling branch — pass --no-pull to silence this)`);
   }
+  shOk('git fetch --tags origin');
 }
 
 // Verify versions


### PR DESCRIPTION
## Summary
- `git pull` doesn't fetch tags by default, so the first run of `pnpm release:watch` after v2.0.5 reported "tag out of sync" until tags were manually fetched.
- Adds an explicit `git fetch --tags origin` so the version-sync verification works on the first try.

No version bump — the release workflow's gate will see `package.json == latest tag` and skip publish.

## Test plan
- [x] Verified locally that `git fetch --tags origin` pulls the new tag after a release
- [x] Next `pnpm release` will exercise the full happy path