### PR TITLE
[codex] seed context rot skill

### DIFF
--- a/templates/skills/context-rot/SKILL.md
+++ b/templates/skills/context-rot/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: context-rot
+description: Audit a codebase for "context rot" — patterns that confuse AI coding agents like inconsistent naming, dead/orphaned implementations, stale documentation, duplicate utilities, misspellings, and inconsistent patterns (error handling, async, logging). Use this skill whenever the user asks to audit, review, or assess a repo for agent-confusion risk, AI-readiness, codebase health, or cleanup; whenever they mention "context rot," "agent rot," "AI hygiene," or "cleanup for Claude/Cursor/Copilot"; or when they ask why an agent keeps editing the wrong file, hallucinating APIs, or producing inconsistent code. Works on any language — detects and adapts. Produces either an inline report with quick fixes or Alpha Loop-ready GitHub epic and child issues, based on user choice after analysis.
+auto_load: false
+priority: medium
+---
+
+# Context Rot Audit
+
+## Purpose
+
+Codebases accumulate "context rot" — artifacts that are invisible to humans (who know which file is current) but actively mislead AI coding agents. An agent doing pattern matching on a repo will faithfully copy whatever it finds, including the dead code, the typo, and the convention nobody uses anymore. This skill finds that rot and gets it fixed.
+
+The audit covers six categories:
+
+1. **Naming inconsistency** — same concept named differently across files (`userId` / `user_id` / `uid`)
+2. **Dead/orphaned code & old implementations** — `*.old.ts`, `_v2`, `legacy_*`, files nothing imports
+3. **Inconsistent patterns** — mixed error handling, async styles, logging, config access
+4. **Misspellings & typos** — especially in identifiers, where they propagate
+5. **Duplicate concepts/utilities** — two `formatDate`, three `httpClient`, parallel implementations
+6. **Stale documentation** — README/comments describing code that no longer exists or behaves differently
+
+## Mental model
+
+Frame every finding by asking: "If a fresh agent loaded this codebase tomorrow with no other context, what would it get wrong?" A typo in a comment doesn't matter much. A typo in an exported function name that's then copied into ten call sites does. A `legacy/` folder is fine if it's clearly marked; an unmarked `auth_v1.ts` next to `auth.ts` is rot. Severity always flows from "how likely is an agent to be misled."
+
+## Workflow
+
+Follow these phases in order. Don't skip ahead — the report quality depends on doing detection thoroughly before deciding output format.
+
+### Phase 1 — Orient
+
+Before running any detection, get the lay of the land. Run these in the repo root:
+
+```bash
+# Languages and rough size
+git ls-files | awk -F. '{print $NF}' | sort | uniq -c | sort -rn | head -20
+
+# Repo conventions worth knowing
+ls -la | grep -E '^\.|README|CONTRIBUTING|CLAUDE|AGENTS|\.cursorrules'
+test -f package.json && cat package.json | head -50
+test -f pyproject.toml && cat pyproject.toml | head -50
+
+# Recently active vs stale areas — older = more rot risk
+git log --pretty=format: --name-only --since='1 year ago' | sort | uniq -c | sort -rn | head -30
+```
+
+Use this to:
+- Determine primary language(s) for category-specific detection — see `references/per-language.md`
+- Spot any `CLAUDE.md` / `AGENTS.md` / `.cursorrules` that document intended conventions (these become the ground truth for inconsistency findings)
+- Identify hot vs cold zones (a typo in a file touched weekly is higher priority than one in untouched code)
+
+If the repo has more than ~50k tracked files or is clearly a monorepo with vendored deps, ask the user which subdirectory to scope the audit to. Don't try to audit `node_modules` or `vendor/`.
+
+### Phase 2 — Detect
+
+Work through each of the six categories. For each category, read the corresponding section in `references/detection-patterns.md` for the specific commands and heuristics. The reference file is organized by category and includes both language-agnostic detection (ripgrep patterns) and language-specific tools where they meaningfully help.
+
+Record findings as you go in a structured list. Use this shape for each finding:
+
+```
+- category: naming | dead-code | inconsistent-pattern | typo | duplicate | stale-doc
+  severity: high | medium | low
+  title: short imperative ("Unify userId vs user_id across auth module")
+  evidence:
+    - path:line — what's there
+    - path:line — conflicting case
+  impact: one sentence on why this misleads an agent
+  fix: concrete suggestion, ideally a command or diff sketch
+```
+
+Severity rubric (apply consistently):
+
+- **high** — actively misleading. Agent will pick the wrong file, copy the wrong pattern, or hallucinate behavior. Examples: two functions with the same name doing different things; a README describing an API that was renamed; an unmarked `_old` file that looks current.
+- **medium** — inconsistency that produces drift. Agent's output will be stylistically off, code review will catch it but it wastes cycles. Examples: mixed `async/await` vs `.then()` in one module; `userId` vs `user_id` in adjacent files.
+- **low** — cosmetic or low-blast-radius. Examples: typo in a private function name used in one place; a stale comment in a file that's otherwise self-explanatory.
+
+Aim for thoroughness over speed. False positives are fine in this phase — you'll filter in Phase 3. But don't pad: if a category genuinely has nothing, say so.
+
+### Phase 3 — Triage and summarize
+
+Look at the full finding list and compute:
+- Total findings, broken down by category and severity
+- "Quick wins" — findings that are local, low-risk, and can be applied in this session (single-file typo fix, deleting a clearly-dead file, renaming one symbol in a small module)
+- "Structural" findings — anything that needs human judgment, touches >3 files, or affects public APIs
+
+Now show the user a one-screen summary. Use this exact structure (it sets up the decision in Phase 4):
+
+```
+## Context Rot Audit — <repo name>
+
+**Scope:** <N files, <languages>, <subdirectory if scoped>>
+
+### Findings
+- 🔴 High: <count>   ← <one-line examples>
+- 🟡 Medium: <count> ← <one-line examples>
+- 🟢 Low: <count>    ← <one-line examples>
+
+### By category
+| Category | Count | Notable |
+|---|---|---|
+| Naming inconsistency | N | ... |
+| Dead/orphaned code | N | ... |
+| Inconsistent patterns | N | ... |
+| Misspellings | N | ... |
+| Duplicates | N | ... |
+| Stale docs | N | ... |
+
+### Quick wins (can apply now)
+1. ...
+2. ...
+
+### Structural items (need discussion)
+1. ...
+2. ...
+```
+
+If there are zero or one findings total and no high-severity items, just say so — clean bill of health, optionally apply the one-liner, done. Don't proceed to Phase 4.
+
+### Phase 4 — Ask the user how to deliver
+
+This is the hand-off point. Ask the user to choose between two paths. Phrase it roughly like:
+
+> Found X findings (Y high, Z medium). How do you want to handle this?
+>
+> **A — Inline:** I'll write up the full report here. You can apply the quick wins now if you want, and keep the structural items for later.
+>
+> **B — GitHub epic:** I'll create one parent epic issue plus a child issue per structural finding using `gh`, shaped so `alpha-loop run --epic <N>` can process the checklist. Quick wins still get applied inline (they don't deserve issues).
+>
+> **C — Both:** Inline report now, then create issues for the structural items.
+
+Wait for explicit choice. Don't assume.
+
+Heuristics to mention if it helps them decide:
+- Fewer than ~5 structural findings: A is usually right
+- Issues will be created in the current repo unless they specify otherwise
+- They need `gh` installed and authenticated for B/C
+
+### Phase 5 — Execute the chosen path
+
+#### Path A (inline only)
+
+Write the full report as a markdown document. Use the summary from Phase 3 as the header, then expand each finding with full evidence. Group by severity, not by category — high-severity items should hit the eye first.
+
+If the user wants to apply quick wins, apply them as standard edits, one at a time, with a brief diff preview before each. Don't batch.
+
+#### Path B or C (Alpha Loop GitHub issues)
+
+Read `references/github-issues.md` for the Alpha Loop issue templates and the exact `gh` commands. The flow is:
+
+1. **Pre-flight:** confirm `gh auth status` is OK, confirm the repo (default: current), confirm the user wants you to proceed creating issues.
+2. **Resolve Alpha Loop labels:** use `context-rot` plus `epic` on the parent, and only apply the configured ready label to children when the user confirms they are queue-ready.
+3. **Create the epic** first. Capture its issue number.
+4. **Create one child issue per structural finding**, each linking back to the epic with an Alpha Loop-friendly body and testable acceptance criteria.
+5. **Update the epic** with a parseable checklist linking to all child issues: `- [ ] #123 - Short title`.
+6. **Report back:** print the URL of the epic and a count of children created.
+
+Apply quick wins inline (don't make issues for them) only after issue creation is complete, unless the user says otherwise.
+
+## Tone and output rules
+
+- The audience is a technical user who wants signal, not theater. Skip preambles like "Great question!" and don't pad findings with hedges.
+- Findings should be *specific* — `src/auth/login.ts:42 uses snake_case while the rest of src/auth uses camelCase` beats "naming is inconsistent in the auth module."
+- It's fine to say "no findings in this category" — clean is a real result.
+- Don't fabricate severity. If the worst thing in the repo is two stale TODO comments, the report says that. Don't manufacture "high" findings to look thorough.
+- When in doubt about whether something is rot vs intentional, surface it as a question, not a finding.
+
+## Anti-patterns to avoid
+
+- **Don't run linters and call it an audit.** Linters catch style violations; this skill catches semantic rot. If a finding is "eslint would flag this," it's probably not interesting enough to include.
+- **Don't recommend mass-renames as quick wins.** Renaming a widely-used symbol is structural by definition. Even if it's "obviously right," it goes in the issue pile.
+- **Don't open issues for typos in comments.** Either fix them inline or skip them. Issue-noise is its own form of rot.
+- **Don't audit dependencies or generated code.** `node_modules`, `dist`, `build`, `__generated__`, `vendor`, `.next`, `target` — skip these by default. Mention if you scope-limit.
+
+## Reference files
+
+- `references/detection-patterns.md` — per-category detection commands, heuristics, and language-agnostic ripgrep patterns. Read the sections for the categories you're working on.
+- `references/per-language.md` — language-specific tools and idioms (Python, TypeScript/JS, Go, Rust, Java, Ruby). Skim only the sections matching the repo's languages.
+- `references/github-issues.md` — `gh` commands, epic template, child issue template, and labeling conventions. Read in full before Path B or C.

--- a/templates/skills/context-rot/references/detection-patterns.md
+++ b/templates/skills/context-rot/references/detection-patterns.md
@@ -1,0 +1,370 @@
+# Detection Patterns
+
+Per-category detection guidance. Each section gives language-agnostic commands first (ripgrep, git), then notes where language-specific tools add real value. Run the commands from the repo root.
+
+All examples assume `rg` (ripgrep) is available. Pipe through `head -50` liberally — you want signal, not a wall of output.
+
+## Universal exclusions
+
+Apply these as a baseline. Most rot detection should ignore:
+
+```
+--glob '!node_modules/**' \
+--glob '!.git/**' \
+--glob '!dist/**' \
+--glob '!build/**' \
+--glob '!target/**' \
+--glob '!.next/**' \
+--glob '!__generated__/**' \
+--glob '!vendor/**' \
+--glob '!*.min.js' \
+--glob '!*.map' \
+--glob '!*.lock' \
+--glob '!coverage/**'
+```
+
+Set this once as a shell variable or `.ignore` file. The patterns below assume it.
+
+---
+
+## 1. Naming inconsistency
+
+The high-value finding: same concept spelled multiple ways. An agent looking at `userId` in one file and `user_id` in another will pick whichever it saw last.
+
+### Detect mixed casing for the same root concept
+
+For each suspected identifier root, check all common casings:
+
+```bash
+# Example: is "userId" stable across the repo?
+rg -i --type-add 'code:*.{ts,tsx,js,jsx,py,go,rs,java,rb,php}' -tcode \
+   '\b(userId|user_id|userid|UserID|user-id)\b' \
+   --count-matches | sort -t: -k2 -rn | head -20
+```
+
+If multiple casings appear with non-trivial counts in the same module/package, that's a finding. Heuristic: 80/20 split across a module = inconsistency worth flagging; 99/1 is usually just a typo to fix.
+
+Concepts that commonly fragment — check each:
+
+- `userId / user_id / uid`
+- `clientId / client_id`
+- `apiKey / api_key / API_KEY` (constant casing is OK)
+- `firstName / first_name / fname`
+- `createdAt / created_at / createTime / creation_date`
+- `isActive / active / is_active / enabled`
+- `email / emailAddress / email_address`
+
+### Detect violations of stated conventions
+
+If the repo has a `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, a `STYLE.md`, or a section in `CONTRIBUTING.md` that states naming rules, grep for violations of those rules. Stated convention + observed violation = high-severity finding (these are explicitly meant to guide agents).
+
+### Detect inconsistent file naming
+
+```bash
+# Mixed file naming conventions in the same directory
+git ls-files | awk -F/ '{print $1}' | sort -u | while read dir; do
+  test -d "$dir" || continue
+  ls "$dir" 2>/dev/null | grep -E '\.(ts|js|tsx|jsx|py|go)$' | \
+    awk -F. '{print $1}' | awk '
+      /[a-z][A-Z]/ {camel++}
+      /_/ {snake++}
+      /-/ {kebab++}
+      END {if ((camel>0)+(snake>0)+(kebab>0) > 1) print "'$dir': camel="camel" snake="snake" kebab="kebab}'
+done
+```
+
+Pattern: one directory using a mix of `userProfile.ts`, `user_settings.ts`, `user-preferences.ts` is rot. One convention per directory is the floor.
+
+---
+
+## 2. Dead/orphaned code & old implementations
+
+Highest-leverage category for agent confusion. An unmarked `auth.old.ts` next to `auth.ts` will get pattern-matched.
+
+### Detect by filename markers
+
+```bash
+rg --files | rg -i '(\.old\.|\.bak\.|\.backup\.|_old\.|_bak\.|_v[0-9]+\.|_legacy\.|_deprecated\.|\.orig\.|\.copy\.|-copy\.| copy\.|\.draft\.)'
+```
+
+Any hit here is a finding. Severity depends on:
+- Is it referenced anywhere? `rg "from.*<filename>"` / `rg "import.*<filename>"` — if zero refs, high severity (just delete it)
+- Is the sibling file present? `auth.old.ts` with no `auth.ts` is even more confusing
+
+### Detect "v2" / numbered duplicates
+
+```bash
+# Files with version suffixes that aren't in a versioning system
+rg --files | grep -E '(V2|V3|_v2|_v3|2\.|New|Updated)\.(ts|tsx|js|py|go)$'
+```
+
+Cross-reference with the non-suffixed version. If both exist and both are imported, that's a structural finding.
+
+### Detect orphaned files (no imports)
+
+Language-agnostic-ish — won't catch dynamic imports but catches most:
+
+```bash
+# For each source file, check if anything imports its basename
+for f in $(rg --files -tts -tjs -tpy); do
+  base=$(basename "$f" | sed 's/\.[^.]*$//')
+  # Skip entry-pointy names
+  case "$base" in index|main|__init__|app|server|cli) continue ;; esac
+  count=$(rg -l "['\"\`/].*${base}['\"\`/.]" --glob "!${f}" 2>/dev/null | wc -l)
+  if [ "$count" -eq 0 ]; then
+    echo "ORPHAN: $f"
+  fi
+done | head -50
+```
+
+Note: false positives on tests, scripts, and migration files. Cross-check before flagging. Look at git log on the file — if it hasn't been touched in 12+ months and has no importers, it's almost certainly dead.
+
+### Detect commented-out code blocks
+
+```bash
+# Large commented-out blocks (5+ consecutive comment lines that look like code)
+rg -tts -tjs -tpy -U '(//[^\n]*\n){5,}|(#[^\n]*\n){5,}' --multiline-dotall -l
+```
+
+Then sample a few to verify they look like commented code (not docs). Files with multiple such blocks are findings.
+
+### Detect TODO/FIXME aging
+
+```bash
+# TODOs older than 1 year — agents treat these as live signal
+rg -n 'TODO|FIXME|XXX|HACK' | while IFS=: read file line rest; do
+  blame=$(git blame -L "$line,$line" --date=short "$file" 2>/dev/null | head -1)
+  echo "$blame  ::  $file:$line"
+done | sort | head -20
+```
+
+Old TODOs that reference removed code or completed work are stale-doc findings too.
+
+---
+
+## 3. Inconsistent patterns
+
+Look for *two valid ways of doing the same thing* coexisting in the same codebase. The pattern itself is fine; the inconsistency is the rot.
+
+### Async patterns (JS/TS)
+
+```bash
+# Promise.then vs async/await — count each
+rg -tts -tjs '\.then\s*\(' --count-matches | awk -F: '{s+=$2} END {print "then() calls:", s}'
+rg -tts -tjs '\bawait\s+' --count-matches | awk -F: '{s+=$2} END {print "await calls:", s}'
+```
+
+If both are non-trivial *and* they appear in the same modules, finding. If `.then` is concentrated in 2 legacy files, those files are dead-code candidates.
+
+### Error handling
+
+```bash
+# JS/TS: try/catch vs Result-types vs .catch
+rg -tts -tjs '\btry\s*\{' --count-matches
+rg -tts -tjs '\.catch\s*\(' --count-matches
+rg -tts -tjs '\b(Result|Either|Ok|Err)\b' --count-matches
+
+# Python: try/except vs result objects vs explicit error returns
+rg -tpy 'except\s+\w' --count-matches
+rg -tpy 'return\s+(None|False|-1)\s*(#.*error|#.*fail)' --count-matches
+
+# Go: if err != nil vs panic vs errors.Wrap variants
+rg -tgo 'if\s+err\s*!=\s*nil' --count-matches
+rg -tgo 'errors\.(Wrap|WithMessage|Errorf)' --count-matches
+rg -tgo 'fmt\.Errorf' --count-matches
+```
+
+Flag when two distinct error-handling philosophies coexist with no documented boundary between them.
+
+### Logging
+
+```bash
+# Multiple loggers in one codebase
+rg -tts -tjs 'console\.(log|error|warn|info)' --count-matches | awk -F: '{s+=$2} END {print "console:", s}'
+rg -tts -tjs '(winston|pino|bunyan|log4js|loglevel)' -l | head -5
+rg -tpy 'print\(' --count-matches | awk -F: '{s+=$2} END {print "print:", s}'
+rg -tpy '(logging|loguru|structlog)\.' -l | head -5
+```
+
+`console.log` + a real logger coexisting = finding (agents will copy whichever they saw first).
+
+### Config access
+
+```bash
+# process.env scattered vs centralized config module
+rg -tts -tjs 'process\.env\.' -l | wc -l
+rg -tts -tjs '(getConfig|config\.|loadConfig)' -l | wc -l
+
+rg -tpy 'os\.environ' -l | wc -l
+rg -tpy '(settings\.|get_config|Config\()' -l | wc -l
+```
+
+If env vars are read directly in 20 files *and* there's a config module, that's a finding (decide which is canonical).
+
+### Imports / module style
+
+```bash
+# CommonJS require() and ESM import in the same package
+rg -tjs '^\s*const\s+\w+\s*=\s*require\(' --count-matches | head -5
+rg -tjs '^\s*import\s+' --count-matches | head -5
+```
+
+---
+
+## 4. Misspellings & typos
+
+Identifier typos are the dangerous kind — they propagate. Comment typos are usually low-severity.
+
+### Run codespell (if available, install if not)
+
+```bash
+codespell --skip='./node_modules,./.git,./dist,./build,./*.lock' \
+          --ignore-words-list='nd,te,fo,wee,parsable' \
+          --count
+```
+
+If `codespell` isn't installed, suggest installing it (`pip install codespell`) — it's the right tool. If the user doesn't want to install, fall back to:
+
+```bash
+# Common typo patterns in identifiers
+rg -i '\b(recieve|recieved|seperat|seperate|occurence|occured|untill|begining|definately|enviroment|sucess|sucessful|paramater|paremeter|wierd|adress|accomodate|alot|alreddy|allways|arguement|calender|cancelation|catagory|comming|commited|completly|concious|congradul|consious|cooly|defenately|definatly|dependant|desireable|develope|developement|dilemna|dissapear|embarass|enviornment|excede|excellance|existance|familar|fourty|freind|grammer|guage|happend|heigth|independant|inteligence|judgement|knowlege|labratory|lenght|liason|libary|liscense|maintainance|managment|millenium|mispell|nieghbor|noticable|occassion|occured|paralel|parliment|particularily|peice|perminent|perseverence|pertinant|posession|preceeding|publically|pursuasive|recieved|reciept|recomend|refered|relevent|reminisent|rythym|scary|seperated|similiar|sincerly|speach|succesful|supercede|tendancy|thier|threshhold|tommorow|truely|tyranny|underate|untill|usefull|wether)\b' \
+   --type-add 'code:*.{ts,tsx,js,jsx,py,go,rs,java,rb,php,md}' -tcode \
+   | head -30
+```
+
+### Detect typo-in-identifier (high severity)
+
+Whatever the typo, if it appears in an exported symbol, it's high-severity — every caller has now inherited it:
+
+```bash
+# Take any typo hits from above, check if they appear in declarations
+rg '(export\s+(function|const|class|interface|type)|def |func |class )\s+\w*<typo>\w*' -tcode
+```
+
+---
+
+## 5. Duplicate concepts/utilities
+
+Two functions doing the same thing under different names. Agents will create a third.
+
+### Detect by canonical utility names
+
+```bash
+# Common utility function names that often duplicate
+for name in formatDate parseDate toDate dateToString \
+            slugify toSlug stringToSlug \
+            debounce throttle \
+            deepClone clone copyObject \
+            isEmail validateEmail checkEmail \
+            isEmpty isBlank empty \
+            httpGet fetchJson apiCall request \
+            sleep delay wait \
+            uuid generateId makeId randomId; do
+  count=$(rg -tcode -c "(function|const|def|func)\s+${name}\b" 2>/dev/null | wc -l)
+  [ "$count" -gt 1 ] && echo "DUPLICATE CANDIDATE: $name ($count files define it)"
+done
+```
+
+For each hit, manually verify: are these actually doing the same thing, or are they domain-specific (`formatDate` for invoices vs `formatDate` for logs is fine if names disambiguate by module)?
+
+### Detect by signature similarity
+
+This is harder to do mechanically. Useful heuristics:
+
+```bash
+# Multiple files with very similar function signatures
+rg -tcode --no-line-number -o '(function|def|func)\s+\w+\s*\([^)]*\)' | \
+  sort | uniq -c | sort -rn | head -20
+```
+
+If two files define `function formatCurrency(amount, currency)` with the same signature, look at both bodies. If they're 80%+ equivalent, finding.
+
+### Detect parallel directory structures
+
+```bash
+# Suspicious: utils/ and helpers/ and lib/ all in same project
+ls -d */ 2>/dev/null | grep -iE '^(utils?|helpers?|lib|common|shared|misc|tools)/'
+find . -type d -name 'utils' -o -name 'helpers' -o -name 'lib' 2>/dev/null | \
+  grep -v node_modules | head
+```
+
+Multiple "junk drawer" directories = high chance of duplicated utilities across them.
+
+---
+
+## 6. Stale documentation
+
+README and inline docs that describe code that no longer exists or behaves differently. Agents trust docs.
+
+### Detect README references to removed code
+
+```bash
+# Pull code-fenced snippets and identifier references from README
+rg -o '`[a-zA-Z_][a-zA-Z0-9_.]+`' README.md docs/ 2>/dev/null | \
+  awk -F: '{print $NF}' | tr -d '`' | sort -u > /tmp/readme_refs.txt
+
+# For each, check if it exists in code
+while read ref; do
+  # Strip method calls / property accesses for the search
+  name=$(echo "$ref" | sed 's/[().].*//')
+  [ -z "$name" ] && continue
+  rg -tcode -q "\b${name}\b" || echo "STALE REF: $ref"
+done < /tmp/readme_refs.txt | head -20
+```
+
+False positives on common words — filter for things that look like identifiers (camelCase, snake_case, PascalCase). High-value when the README's "Quick Start" snippet imports a function that doesn't exist anymore.
+
+### Detect docs older than the code they describe
+
+```bash
+# For each docs file, find code it references and compare mtimes
+for doc in README.md $(find docs -name '*.md' 2>/dev/null); do
+  doc_age=$(git log -1 --format=%ct -- "$doc" 2>/dev/null)
+  [ -z "$doc_age" ] && continue
+  newest_code=$(find src lib app -type f \( -name '*.ts' -o -name '*.py' -o -name '*.go' \) -printf '%T@\n' 2>/dev/null | sort -rn | head -1 | cut -d. -f1)
+  [ -z "$newest_code" ] && continue
+  if [ "$newest_code" -gt "$doc_age" ]; then
+    diff_days=$(( (newest_code - doc_age) / 86400 ))
+    if [ "$diff_days" -gt 180 ]; then
+      echo "STALE: $doc ($diff_days days behind newest code)"
+    fi
+  fi
+done
+```
+
+This is a heuristic — old docs can still be accurate. Use it as a signal to read the doc, not as a finding on its own.
+
+### Detect inline comments that contradict the code
+
+This needs reading. Sample comments near function definitions and check the function still does what the comment claims:
+
+```bash
+# Pull docstring/jsdoc blocks
+rg -tts -tjs -U '/\*\*[\s\S]*?\*/' --multiline -A 1
+rg -tpy -U '"""[\s\S]*?"""' --multiline -A 1
+```
+
+Sample 10-20 and verify against the function body. Look for:
+- Parameter names that don't match the signature
+- Return types that contradict the actual return
+- "Returns null if X" claims where the code returns undefined / raises
+- References to removed parameters
+
+### Detect broken internal links
+
+```bash
+rg -o '\]\(\.?/?[^)]+\.(md|py|ts|js)[^)]*\)' --no-line-number docs/ README.md 2>/dev/null | \
+  while IFS=: read file ref; do
+    path=$(echo "$ref" | sed -E 's/.*\(([^)]+)\).*/\1/' | sed 's/#.*//')
+    test -f "$path" || test -f "$(dirname "$file")/$path" || echo "BROKEN: $file -> $path"
+  done | head -20
+```
+
+---
+
+## Cross-cutting tips
+
+- **Always look at git blame** on a suspicious file before flagging. A file last touched 3 years ago is different from one touched last week.
+- **Imports tell the truth.** If a file claims to be "the new way" but only 2 places import it and 50 import the "old way," the names lie.
+- **Run quick checks first.** Skim a `find . -name "*.old.*"` and a typo scan before doing the deep analysis — it sets the tone for what kind of repo you're in.
+- **Check `git log --diff-filter=D --summary | head -50`** for recently deleted files whose names might still appear in docs or comments.

--- a/templates/skills/context-rot/references/github-issues.md
+++ b/templates/skills/context-rot/references/github-issues.md
@@ -1,0 +1,237 @@
+# GitHub Issues (Path B / C)
+
+Used when the user chooses GitHub issue delivery. Create one Alpha Loop-ready
+parent epic plus one child issue per structural finding. Quick wins are not
+turned into issues; apply them inline or leave them in the report.
+
+## Pre-flight
+
+Before creating anything, verify:
+
+```bash
+gh auth status
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+Resolve the Alpha Loop ready label if the repo has config:
+
+```bash
+READY_LABEL=$(awk -F: '/^label:/ {gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2; exit}' .alpha-loop.yaml 2>/dev/null)
+: "${READY_LABEL:=ready}"
+```
+
+Then confirm explicitly:
+
+> I'll create the context-rot epic and N child issues in `<owner>/<repo>`.
+> Children will use label `context-rot`. I will only add `<READY_LABEL>` if you
+> confirm these should be queue-ready for `alpha-loop run --epic <N>`.
+> Different repo or label posture? Tell me before I create anything.
+
+Wait for confirmation. If `gh` is unavailable or unauthenticated, stop and tell
+the user what failed. Do not use the GitHub API directly with curl.
+
+## Labels
+
+Use:
+
+- `context-rot` on the parent epic and every child issue.
+- `epic` on the parent issue.
+- The configured ready label, usually `ready`, only on child issues when the
+  user explicitly confirms the findings are ready for the loop.
+
+Create missing labels when the user approves:
+
+```bash
+gh label create context-rot --color FFA500 --description "Audit finding: codebase artifacts that confuse AI agents" 2>/dev/null || true
+gh label create epic --color 5319E7 --description "Tracks multiple related child issues" 2>/dev/null || true
+```
+
+If the ready label is missing, ask whether to create it, omit it, or use a
+repo-specific equivalent.
+
+## Epic Template
+
+Create the epic first. The body intentionally follows the richer Alpha Loop epic
+format so the ordered checklist is parseable by `alpha-loop run --epic <N>`.
+
+```bash
+EPIC_BODY=$(cat <<'EOF'
+## Goal
+
+Reduce context rot in <SHORT_SCOPE> so future AI coding agents can reliably
+identify current files, conventions, and APIs.
+
+## Non-Technical Summary
+
+This audit found codebase artifacts that can mislead agents: stale docs,
+parallel implementations, inconsistent names, dead files, or conflicting
+patterns. This epic tracks structural cleanup that needs human judgment or
+touches multiple files.
+
+## Why This Matters
+
+- Agents copy local patterns aggressively; inconsistent or stale examples create bad follow-up changes.
+- Removing misleading artifacts improves unattended Alpha Loop runs and code review quality.
+- The child issues are scoped so each cleanup can be implemented and verified independently.
+
+## Architecture Observations
+
+- Scope: <SCOPE_DESCRIPTION>
+- Primary languages/frameworks: <LANGUAGES>
+- Audit date: <DATE>
+- Quick wins handled outside this epic: <QUICK_WIN_COUNT>
+
+## Ordered Sub-Issues
+
+- [ ] #PLACEHOLDER
+
+## Acceptance Criteria
+
+- [ ] High-severity context rot findings in this audit are resolved or explicitly deferred.
+- [ ] Each child issue's acceptance criteria are satisfied.
+- [ ] No new unmarked legacy/dead/duplicate patterns are introduced while resolving the epic.
+- [ ] Final verification confirms the repo's agent-facing conventions are clear.
+
+## Dependencies and Sequencing
+
+- Start with high-severity children because they are most likely to mislead agents.
+- Run children sequentially when they touch the same files or public APIs.
+- Low-risk typo/comment fixes can be batched only when they do not overlap structural cleanup.
+
+## Verification Expectations
+
+- Re-run the relevant context-rot detection commands from each child issue.
+- Run the repo's normal test command after code changes.
+- If using Alpha Loop, run `alpha-loop run --verify-only <this epic number>` after children are complete.
+EOF
+)
+
+EPIC_NUMBER=$(gh issue create \
+  --title "Context Rot Audit - <SHORT_SCOPE>" \
+  --body "$EPIC_BODY" \
+  --label context-rot,epic \
+  | grep -oE '[0-9]+$')
+
+echo "Created epic #$EPIC_NUMBER"
+```
+
+Substitute `<DATE>`, `<SCOPE_DESCRIPTION>`, `<SHORT_SCOPE>`, `<LANGUAGES>`,
+`<QUICK_WIN_COUNT>`, and summary counts before running.
+
+## Child Issue Template
+
+For each structural finding, create one child issue. Use the standard Alpha Loop
+feature/change issue shape: summary, value, proposed approach, acceptance
+criteria, out of scope, and related links.
+
+```bash
+CHILD_BODY=$(cat <<EOF
+## Summary
+
+<One paragraph describing the context-rot finding and the desired cleanup.>
+
+## Why this matters
+
+<Explain what an AI coding agent would get wrong because this artifact exists. Be specific: wrong file, wrong naming convention, stale API, duplicate helper, or outdated docs.>
+
+## Proposed approach
+
+- <Concrete fix step one.>
+- <Concrete fix step two if needed.>
+- Verification: \`<grep/test command>\`
+
+## Acceptance criteria
+
+- [ ] <The misleading artifact is removed, renamed, documented, or consolidated.>
+- [ ] <All referenced call sites/docs/tests are updated consistently.>
+- [ ] No new occurrences of this rot pattern remain (verify with: \`<command>\`).
+
+## Out of scope
+
+- <Related cleanup that should not be attempted in this issue.>
+
+## Related
+
+- Part of #${EPIC_NUMBER}
+- Severity: <High | Medium | Low>
+- Category: <Naming inconsistency | Dead/orphaned code | Inconsistent pattern | Typo | Duplicate | Stale doc>
+
+### Evidence
+
+- \`<path>:<line>\` - <what's there>
+- \`<path>:<line>\` - <conflicting or related evidence>
+EOF
+)
+
+LABELS="context-rot"
+# Only append the ready label after explicit user confirmation.
+# LABELS="${LABELS},${READY_LABEL}"
+
+CHILD_NUMBER=$(gh issue create \
+  --title "<TITLE>" \
+  --body "$CHILD_BODY" \
+  --label "$LABELS" \
+  | grep -oE '[0-9]+$')
+
+echo "Created child #$CHILD_NUMBER"
+```
+
+Title conventions for child issues:
+
+- Use imperative voice: "Unify userId casing across auth module."
+- Include the category prefix: `[naming]`, `[dead-code]`, `[pattern]`,
+  `[typo]`, `[duplicate]`, or `[stale-doc]`.
+- Keep under 80 characters.
+
+Examples:
+
+- `[naming] Unify userId vs user_id across src/auth/`
+- `[dead-code] Remove auth.old.ts and its orphan helpers`
+- `[pattern] Standardize async handling in src/api/`
+- `[duplicate] Consolidate formatDate implementations`
+- `[stale-doc] Update README quick-start for renamed initClient API`
+
+## Updating The Epic Checklist
+
+After all child issues are created, replace the placeholder with parseable Alpha
+Loop task-list lines. Use `- [ ] #123 - Short title`; do not use markdown links
+for the issue number in this checklist.
+
+```bash
+CHECKLIST=$(printf -- '- [ ] %s\n' "${CHILD_ITEMS[@]}")
+CURRENT_BODY=$(mktemp)
+UPDATED_BODY=$(mktemp)
+
+gh issue view "$EPIC_NUMBER" --json body -q .body > "$CURRENT_BODY"
+awk -v checklist="$CHECKLIST" '
+  $0 == "- [ ] #PLACEHOLDER" { printf "%s", checklist; next }
+  { print }
+' "$CURRENT_BODY" > "$UPDATED_BODY"
+
+gh issue edit "$EPIC_NUMBER" --body "$(cat "$UPDATED_BODY")"
+```
+
+Build `CHILD_ITEMS` as strings like `#123 - [naming] Unify userId casing`.
+
+## After Creation
+
+Report:
+
+- Epic URL and number.
+- Number of child issues created by severity and category.
+- Whether the ready label was applied.
+- Quick wins applied inline, if any.
+
+If any `gh` command fails mid-flow, stop and tell the user which step failed.
+Do not retry silently.
+
+## Edge Cases
+
+- **Dry-run requested:** print the epic title, child titles, labels, and one-line
+  summaries instead of running `gh issue create`.
+- **Repo has issue templates:** mention it, but use these templates unless the
+  user asks you to adapt to the repo's issue-template fields.
+- **GitHub Projects:** if the user mentions a Project board, add
+  `--project <name>` to the create commands. Otherwise do not touch projects.
+- **Too many findings:** if more than about 25 child issues would be created,
+  pause and ask whether to consolidate related findings or split by category.

--- a/templates/skills/context-rot/references/per-language.md
+++ b/templates/skills/context-rot/references/per-language.md
@@ -1,0 +1,181 @@
+# Per-Language Tools
+
+Read only the section(s) matching the repo's primary languages. The universal ripgrep-based detection in `detection-patterns.md` already covers most ground; this file is for cases where a language-specific tool is materially better.
+
+Install tools opportunistically — if a tool isn't available, fall back to the universal patterns rather than blocking on installation. Mention to the user which tools would sharpen findings if they want to install them.
+
+---
+
+## TypeScript / JavaScript
+
+### Dead code & unused exports
+
+`knip` is the best tool here. It finds unused files, exports, and dependencies.
+
+```bash
+# One-shot, no config
+npx -y knip --no-config-hints --reporter json 2>/dev/null | head -100
+```
+
+If `knip` complains about missing config, fall back to:
+
+```bash
+# ts-prune for unused exports (older but still useful)
+npx -y ts-prune 2>/dev/null | head -30
+```
+
+### Unused dependencies
+
+```bash
+npx -y depcheck --json 2>/dev/null
+```
+
+### Type-level inconsistency
+
+```bash
+# Find interfaces/types defined more than once with the same name
+rg -tts -o '(interface|type)\s+(\w+)' --no-line-number | \
+  awk '{print $2}' | sort | uniq -c | sort -rn | awk '$1 > 1'
+```
+
+### Style inconsistency
+
+```bash
+# Mixed quote styles in same file
+rg -tts -c "from\s+'" | head -5
+rg -tts -c 'from\s+"' | head -5
+
+# Mixed semicolons (if project doesn't enforce)
+rg -tts -c ';\s*$' | head -5
+```
+
+---
+
+## Python
+
+### Dead code
+
+```bash
+# vulture finds unreachable code, unused imports, unused functions
+pip install --quiet vulture 2>/dev/null
+vulture . --min-confidence 80 --exclude '*/migrations/*,*/tests/*' 2>/dev/null | head -30
+```
+
+### Import inconsistency
+
+```bash
+# Mixed import styles for the same module
+rg -tpy '^import\s+os' --count-matches | head -3
+rg -tpy '^from\s+os\s+import' --count-matches | head -3
+
+# Relative vs absolute imports for the same package
+rg -tpy '^from\s+\.\.' -l | head -5
+rg -tpy '^from\s+<package_name>' -l | head -5
+```
+
+### Typing inconsistency
+
+```bash
+# Functions with type hints vs without — in the same module
+rg -tpy '^\s*def\s+\w+\([^)]*\)\s*->' -l | sort > /tmp/typed.txt
+rg -tpy '^\s*def\s+\w+\([^)]*\)\s*:' -l | sort > /tmp/all_funcs.txt
+comm -23 /tmp/all_funcs.txt /tmp/typed.txt | head
+```
+
+Files in both lists have mixed typing — partial typing is more confusing to agents than no typing at all.
+
+### Pydantic / dataclass / TypedDict competing
+
+```bash
+rg -tpy 'BaseModel\b' -l | wc -l
+rg -tpy '@dataclass' -l | wc -l
+rg -tpy 'TypedDict' -l | wc -l
+rg -tpy 'NamedTuple' -l | wc -l
+```
+
+Three or more in non-trivial counts → finding.
+
+### Codespell with Python-tuned ignore list
+
+```bash
+codespell --skip='./venv,./.venv,./__pycache__,./build,./*.egg-info' \
+          --ignore-words-list='nd,arange,iterm,assertin' \
+          .
+```
+
+---
+
+## Go
+
+### Dead code
+
+```bash
+# staticcheck catches unused code
+go install honnef.co/go/tools/cmd/staticcheck@latest 2>/dev/null
+staticcheck ./... 2>&1 | grep -E 'U1000|U1001' | head -30
+```
+
+### Inconsistent error wrapping
+
+```bash
+rg -tgo 'fmt\.Errorf' --count-matches | awk -F: '{s+=$2} END {print "fmt.Errorf:", s}'
+rg -tgo 'errors\.Wrap' --count-matches | awk -F: '{s+=$2} END {print "errors.Wrap:", s}'
+rg -tgo 'errors\.New' --count-matches | awk -F: '{s+=$2} END {print "errors.New:", s}'
+```
+
+Three error-construction styles in one repo is rot.
+
+### Inconsistent context handling
+
+```bash
+# Functions that take context.Context and ones that should but don't
+rg -tgo 'func\s+\w+\([^)]*\)' --no-line-number | grep -v 'ctx\s\+context' | head
+```
+
+---
+
+## Rust
+
+```bash
+# Dead code (compiler-driven, very reliable)
+cargo check --message-format=json 2>/dev/null | \
+  rg -o '"message":"[^"]*dead_code[^"]*"' | head
+
+# Clippy for stylistic inconsistency
+cargo clippy --message-format=short 2>&1 | head -30
+```
+
+---
+
+## Java
+
+```bash
+# pmd / spotbugs are the right tools but heavy. Lightweight checks:
+rg -tjava 'TODO|FIXME' -c | head
+rg -tjava 'System\.out\.println' -l | head  # often left-behind debug
+rg -tjava '@Deprecated' -l | head  # check if still used
+```
+
+---
+
+## Ruby
+
+```bash
+# rubocop is overkill for rot detection. Quick scans:
+rg -trb 'def\s+\w+' --count-matches | head
+rg -trb 'TODO|FIXME|HACK' -c | head
+
+# Mixed style: respond_to? vs duck typing checks
+rg -trb 'respond_to\?' -l | wc -l
+rg -trb 'is_a\?\|kind_of\?' -l | wc -l
+```
+
+---
+
+## When a tool isn't installed
+
+If a recommended tool isn't available, don't block. Options in order of preference:
+
+1. Use the universal ripgrep patterns from `detection-patterns.md`
+2. Note in the final report: "Tool X would sharpen findings in category Y. Install with `<cmd>` if interested."
+3. Don't auto-install without asking. Tools like `vulture`, `knip`, `codespell` are usually fine to suggest; anything that touches the project's lockfile (`npm install`, `pip install` into project venv) should always be confirmed first.

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -377,6 +377,35 @@ describe('init command', () => {
     expect(installedSkill).toBe(skillContent);
   });
 
+  it('seeds context-rot with bundled reference files from distribution templates', async () => {
+    const distTemplatesDir = join(tempDir, 'dist-templates');
+    const distSkillDir = join(distTemplatesDir, 'skills', 'context-rot');
+    const referencesDir = join(distSkillDir, 'references');
+    const skillContent = [
+      '---',
+      'name: context-rot',
+      'description: Audit a codebase for context rot and create Alpha Loop-ready issues.',
+      'auto_load: false',
+      'priority: medium',
+      '---',
+      '# Context Rot Audit',
+      '',
+    ].join('\n');
+    mkdirSync(referencesDir, { recursive: true });
+    writeFileSync(join(distSkillDir, 'SKILL.md'), skillContent);
+    writeFileSync(join(referencesDir, 'github-issues.md'), '# GitHub Issues\n\n## Epic Template\n');
+    mockedFindDistributionTemplatesDir.mockReturnValue(distTemplatesDir);
+    mockRecursiveCopyExec();
+
+    await initCommand({ yes: true });
+
+    const installedSkillDir = join(tempDir, '.alpha-loop', 'templates', 'skills', 'context-rot');
+    const installedSkill = readFileSync(join(installedSkillDir, 'SKILL.md'), 'utf-8');
+    const installedReference = readFileSync(join(installedSkillDir, 'references', 'github-issues.md'), 'utf-8');
+    expect(installedSkill).toBe(skillContent);
+    expect(installedReference).toContain('## Epic Template');
+  });
+
   it('does not overwrite a customized alpha-loop-learning-review skill during init', async () => {
     const distTemplatesDir = join(tempDir, 'dist-templates');
     const distSkillDir = join(distTemplatesDir, 'skills', 'alpha-loop-learning-review');

--- a/tests/lib/seeded-skills.test.ts
+++ b/tests/lib/seeded-skills.test.ts
@@ -168,4 +168,36 @@ describe('seeded alpha-loop skills', () => {
     expect(distSkill).toContain('Harness-only additions applied');
     expect(distSkill).toContain('proposal hallucinated citations');
   });
+
+  it('includes context-rot in distribution templates with Alpha Loop issue guidance', () => {
+    const distSkillPath = join(repoRoot, 'templates', 'skills', 'context-rot', 'SKILL.md');
+    const githubIssuesPath = join(repoRoot, 'templates', 'skills', 'context-rot', 'references', 'github-issues.md');
+    const detectionPatternsPath = join(repoRoot, 'templates', 'skills', 'context-rot', 'references', 'detection-patterns.md');
+    const perLanguagePath = join(repoRoot, 'templates', 'skills', 'context-rot', 'references', 'per-language.md');
+
+    expect(existsSync(distSkillPath)).toBe(true);
+    expect(existsSync(githubIssuesPath)).toBe(true);
+    expect(existsSync(detectionPatternsPath)).toBe(true);
+    expect(existsSync(perLanguagePath)).toBe(true);
+
+    const distSkill = readFileSync(distSkillPath, 'utf-8');
+    const githubIssues = readFileSync(githubIssuesPath, 'utf-8');
+
+    expect(distSkill).toMatch(/^name: context-rot$/m);
+    expect(distSkill).toMatch(/^description: .*Alpha Loop-ready GitHub epic and child issues/m);
+    expect(distSkill).toMatch(/^auto_load: false$/m);
+    expect(distSkill).toMatch(/^priority: medium$/m);
+    expect(distSkill).toContain('## Workflow');
+    expect(distSkill).toContain('### Phase 4');
+    expect(distSkill).toContain('Path B or C (Alpha Loop GitHub issues)');
+    expect(distSkill).toContain('references/github-issues.md');
+
+    expect(githubIssues).toContain('## Epic Template');
+    expect(githubIssues).toContain('## Child Issue Template');
+    expect(githubIssues).toContain('alpha-loop run --epic <N>');
+    expect(githubIssues).toContain('READY_LABEL');
+    expect(githubIssues).toContain('Part of #${EPIC_NUMBER}');
+    expect(githubIssues).toContain('context-rot');
+    expect(githubIssues).toContain('epic');
+  });
 });


### PR DESCRIPTION
## Summary

- Add the `context-rot` seeded skill to distribution templates with bundled detection, language, and GitHub issue references.
- Adapt the GitHub issue flow for Alpha Loop-ready epics and child issues, including parseable epic checklists and ready-label gating.
- Add regression coverage that `alpha-loop init` recursively seeds the skill and that the shipped skill includes Alpha Loop issue guidance.

## Validation

- `pnpm test` (73 suites, 1294 tests passing)