### PR TITLE
feat: batch implementation (#286)

### DIFF
--- a/.alpha-loop/learnings/issue-286-20260530-221342.md
+++ b/.alpha-loop/learnings/issue-286-20260530-221342.md
@@ -1,0 +1,28 @@
+---
+issue: 286
+status: success
+test_fix_retries: 0
+duration: 1574
+date: 2026-05-31
+retries: 0
+traces:
+  plan: .alpha-loop/sessions/session/epic-293-epic-hosted-alpha-loop-for-24-7-repo-stewardship-with-human-feedback-loops/traces/prompts/plan-issue-286.md
+  implement: .alpha-loop/sessions/session/epic-293-epic-hosted-alpha-loop-for-24-7-repo-stewardship-with-human-feedback-loops/logs/issue-286-implement.log
+  review: .alpha-loop/sessions/session/epic-293-epic-hosted-alpha-loop-for-24-7-repo-stewardship-with-human-feedback-loops/traces/outputs/review-issue-286.log
+  diff: .alpha-loop/sessions/session/epic-293-epic-hosted-alpha-loop-for-24-7-repo-stewardship-with-human-feedback-loops/diffs/issue-286.diff
+---
+
+## What Worked
+- `resume --issue <N>` now resumes requested paused or QA-feedback sessions using durable session manifests.
+
+## What Failed
+- Review found a critical transition bug where status-only paused manifests were discovered but rejected when `feedback.currentStatus` still said `running`.
+
+## Patterns
+- Treat durable session manifests as the resume source of truth, including branch, worktree, PR, prompt, transcript, and log references.
+
+## Anti-Patterns
+- Do not rely only on `feedback.currentStatus` when `manifest.status` already records a resumable paused state.
+
+## Suggested Skill Updates
+- `testing-patterns`: add regression coverage guidance for status-only paused manifests, missing worktree recreation, and duplicate-resume protection.

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -19,15 +19,38 @@ import {
   repairSessionLearningArtifacts,
   repairSessionSummaryArtifact,
 } from '../lib/learning.js';
-import { clearCrashMarker, findCrashMarkers, formatAutoCommittedResultsSection, type CrashMarkerRef } from '../lib/session.js';
+import {
+  clearCrashMarker,
+  findCrashMarkers,
+  findLatestResumableSessionForIssue,
+  formatAutoCommittedResultsSection,
+  finalizeSession,
+  rehydrateSessionContextFromManifest,
+  transitionHumanFeedbackSessionStatus,
+  transitionSessionStatus,
+  type CrashMarkerRef,
+  type DurableSessionManifest,
+  type ResumableSessionRef,
+  type SessionStage,
+  type SessionStatus,
+} from '../lib/session.js';
 import {
   labelIssue,
   commentIssue,
   createPR,
+  getIssueWithComments,
   updateProjectStatus,
+  type Comment,
+  type Issue,
 } from '../lib/github.js';
-import { isRecoveredResult } from '../lib/pipeline.js';
-import type { PipelineResult } from '../lib/pipeline.js';
+import { isRecoveredResult, processIssue } from '../lib/pipeline.js';
+import type { PipelineResult, PipelineResumeStage } from '../lib/pipeline.js';
+import {
+  classifyFeedback,
+  githubLabelChangesForStatus,
+  normalizeHumanFeedbackStatus,
+  type FeedbackClassification,
+} from '../lib/session-state.js';
 
 export type ResumeOptions = {
   issue?: string;
@@ -41,6 +64,28 @@ type StrandedBranch = {
   filesChanged: string[];
   crashMarker?: CrashMarkerRef;
 };
+
+type ResumeFeedbackContext = {
+  issue: Pick<Issue, 'number' | 'title' | 'body' | 'comments'>;
+  newComments: Comment[];
+  commentsUsedForClassification: Comment[];
+  classification: FeedbackClassification;
+  resumeStage: PipelineResumeStage;
+  contextText: string;
+  existingPrUrl: string | null;
+};
+
+const FEEDBACK_RESUME_STATUSES: SessionStatus[] = [
+  'human_input_requested',
+  'qa_requested',
+  'feedback_received',
+  'resume_requested',
+  'resuming',
+  'paused',
+  'waiting-for-feedback',
+  'qa-requested',
+  'resumed',
+];
 
 function normalizeGitBranchLine(line: string): string {
   return line.trim().replace(/^[*+]\s*/, '');
@@ -628,6 +673,387 @@ This PR collects all changes from this session for final review before merging t
   log.success(`Session PR updated: ${prUrl}`);
 }
 
+function currentManifestFeedbackStatus(manifest: DurableSessionManifest): string {
+  const status = normalizeHumanFeedbackStatus(manifest.status);
+  const feedback = normalizeHumanFeedbackStatus(manifest.feedback?.currentStatus ?? '');
+  if (status && status !== 'running' && feedback === 'running') return status;
+  return feedback ?? status ?? manifest.status;
+}
+
+function isDuplicateResume(manifest: DurableSessionManifest): boolean {
+  return currentManifestFeedbackStatus(manifest) === 'resuming' || manifest.status === 'resuming';
+}
+
+function acquireResumeLock(ref: ResumableSessionRef): string | null {
+  const lockPath = join(ref.sessionDir, 'resume.lock');
+  try {
+    writeFileSync(lockPath, JSON.stringify({
+      issueNumber: ref.manifest.issueNumber,
+      session: ref.manifest.name,
+      startedAt: new Date().toISOString(),
+    }, null, 2) + '\n', { flag: 'wx' });
+    return lockPath;
+  } catch {
+    return null;
+  }
+}
+
+function releaseResumeLock(lockPath: string | null): void {
+  if (!lockPath) return;
+  try { unlinkSync(lockPath); } catch { /* cleanup best-effort */ }
+}
+
+function latestFeedbackCutoff(manifest: DurableSessionManifest): string {
+  return manifest.feedback?.updatedAt
+    ?? manifest.timestamps.updatedAt
+    ?? manifest.timestamps.startedAt;
+}
+
+function commentsAfterCutoff(comments: Comment[], cutoff: string): Comment[] {
+  return comments.filter((comment) => comment.createdAt && comment.createdAt > cutoff);
+}
+
+function fallbackIssueFromManifest(issueNum: number, manifest: DurableSessionManifest): Issue {
+  return {
+    number: issueNum,
+    title: manifest.currentIssue?.title
+      ?? manifest.issues.find((issue) => issue.issueNum === issueNum)?.title
+      ?? `Issue #${issueNum}`,
+    body: '',
+    labels: manifest.labels,
+    comments: [],
+  };
+}
+
+function commentsForClassification(newComments: Comment[], comments: Comment[]): Comment[] {
+  if (newComments.length > 0) return newComments;
+  return comments.slice(-3);
+}
+
+function classifyResumeStage(classification: FeedbackClassification): PipelineResumeStage {
+  if (classification === 'approval') return 'verification';
+  if (classification === 'change_request') return 'implementation';
+  return 'clarification';
+}
+
+function formatCommentBullet(comment: Comment): string {
+  const body = comment.body.trim();
+  const trimmed = body.length > 1500 ? `${body.slice(0, 1500)}\n... (comment truncated)` : body;
+  return `- **@${comment.author}** (${comment.createdAt}): ${trimmed}`;
+}
+
+function formatPromptRefs(manifest: DurableSessionManifest): string[] {
+  if (manifest.prompts.length === 0) return ['- (no prompt references recorded)'];
+  return manifest.prompts.map((prompt) => {
+    const issue = prompt.issueNum !== undefined ? `#${prompt.issueNum} ` : '';
+    return `- ${issue}${prompt.stage}: \`${prompt.path}\` (${prompt.hash.slice(0, 12)})`;
+  });
+}
+
+function formatTranscriptRefs(manifest: DurableSessionManifest): string[] {
+  const lines: string[] = [];
+  if (manifest.transcripts.length > 0) {
+    for (const transcript of manifest.transcripts) {
+      const issue = transcript.issueNum !== undefined ? `#${transcript.issueNum} ` : '';
+      lines.push(`- ${issue}${transcript.stage}: \`${transcript.path}\``);
+    }
+  }
+  for (const file of manifest.logs.files) {
+    lines.push(`- log: \`${file}\``);
+  }
+  return lines.length > 0 ? lines : ['- (no transcript or log references recorded)'];
+}
+
+function buildResumeFeedbackContext(
+  ref: ResumableSessionRef,
+  issue: Pick<Issue, 'number' | 'title' | 'body' | 'comments'>,
+): ResumeFeedbackContext {
+  const comments = issue.comments ?? [];
+  const newComments = commentsAfterCutoff(comments, latestFeedbackCutoff(ref.manifest));
+  const commentsUsedForClassification = commentsForClassification(newComments, comments);
+  const feedbackText = commentsUsedForClassification.map((comment) => comment.body).join('\n\n')
+    || ref.manifest.feedback.resumeInstructions
+    || ref.manifest.feedback.question
+    || 'Resume requested without new comment text.';
+  const classification = classifyFeedback(feedbackText);
+  const resumeStage = classifyResumeStage(classification);
+  const existingPrUrl = ref.manifest.feedback.prUrl
+    ?? ref.manifest.prUrl
+    ?? ref.manifest.sessionPrUrl
+    ?? ref.manifest.issues.find((entry) => entry.issueNum === issue.number)?.prUrl
+    ?? null;
+  const savedBranch = ref.recoveryBranch ?? ref.manifest.worktree?.branch ?? ref.manifest.lastKnownBranch;
+  const savedWorktree = ref.worktreePath ?? ref.manifest.worktree?.path ?? null;
+
+  const lines: string[] = [
+    `### Session`,
+    `- Session: \`${ref.manifest.name}\``,
+    `- Prior status: \`${ref.manifest.status}\` / feedback \`${ref.manifest.feedback.currentStatus}\``,
+    `- Resume classification: \`${classification}\``,
+    `- Resume stage: \`${resumeStage}\``,
+    `- Saved branch: ${savedBranch ? `\`${savedBranch}\`` : '(not recorded)'}`,
+    `- Saved worktree: ${savedWorktree ? `\`${savedWorktree}\`${ref.worktreeExists ? ' (exists)' : ' (missing, recreate from branch)'}` : '(not recorded)'}`,
+    `- Existing PR: ${existingPrUrl ?? '(none recorded)'}`,
+  ];
+
+  if (ref.manifest.parentEpicNumber) {
+    lines.push(`- Parent epic: #${ref.manifest.parentEpicNumber}${ref.manifest.parentEpicTitle ? ` ${ref.manifest.parentEpicTitle}` : ''}`);
+  }
+
+  lines.push('', '### Prior Human Feedback State');
+  if (ref.manifest.feedback.question) lines.push(`- Question: ${ref.manifest.feedback.question}`);
+  if (ref.manifest.feedback.resumeInstructions) lines.push(`- Prior resume instructions: ${ref.manifest.feedback.resumeInstructions}`);
+  if (ref.manifest.feedback.qaChecklist.length > 0) {
+    lines.push('- QA checklist:');
+    for (const item of ref.manifest.feedback.qaChecklist) lines.push(`  - ${item}`);
+  }
+  if (!ref.manifest.feedback.question && !ref.manifest.feedback.resumeInstructions && ref.manifest.feedback.qaChecklist.length === 0) {
+    lines.push('- (no prior question or QA checklist recorded)');
+  }
+
+  lines.push('', '### New Human Feedback');
+  if (newComments.length > 0) {
+    lines.push(...newComments.map(formatCommentBullet));
+  } else if (commentsUsedForClassification.length > 0) {
+    lines.push('- No comments newer than the saved pause timestamp; using the latest issue comments for context:');
+    lines.push(...commentsUsedForClassification.map(formatCommentBullet));
+  } else {
+    lines.push('- No GitHub issue comments were available. Use the prior feedback state and issue body.');
+  }
+
+  lines.push('', '### Prior Prompt References', ...formatPromptRefs(ref.manifest));
+  lines.push('', '### Transcript And Log References', ...formatTranscriptRefs(ref.manifest));
+
+  lines.push('', '### Resume Instructions');
+  if (resumeStage === 'verification') {
+    lines.push('- Human feedback appears to approve the current work. Do not make arbitrary implementation changes; run the normal tests, review, and verification path and update the existing PR.');
+  } else if (resumeStage === 'implementation') {
+    lines.push('- Human feedback requests a change. Address only that feedback, preserve prior work, run tests/review/verification, and update the existing PR.');
+  } else {
+    lines.push('- Treat the feedback as clarification or scope guidance. Use it to continue safely; if it is still ambiguous or expands scope, pause again with a concrete request.');
+  }
+
+  return {
+    issue,
+    newComments,
+    commentsUsedForClassification,
+    classification,
+    resumeStage,
+    contextText: lines.join('\n'),
+    existingPrUrl,
+  };
+}
+
+function markResumeLabels(config: ReturnType<typeof loadConfig>, issueNum: number): void {
+  for (const change of githubLabelChangesForStatus('resuming', config.labelReady)) {
+    labelIssue(config.repo, issueNum, change.add, change.remove);
+  }
+}
+
+function transitionManifestToResuming(ref: ResumableSessionRef, context: ResumeFeedbackContext): void {
+  let current = currentManifestFeedbackStatus(ref.manifest);
+  if (current === 'human_input_requested' || current === 'qa_requested') {
+    transitionHumanFeedbackSessionStatus(ref.manifestPath, {
+      to: 'feedback_received',
+      reason: `Feedback loaded from GitHub issue comments (${context.classification})`,
+      issueNum: context.issue.number,
+      classification: context.classification,
+      prUrl: context.existingPrUrl,
+      eventPayload: {
+        source: 'github_issue_comments',
+        newCommentCount: context.newComments.length,
+        commentsUsedForClassification: context.commentsUsedForClassification.length,
+      },
+    });
+    current = 'feedback_received';
+  }
+
+  if (current === 'feedback_received') {
+    transitionHumanFeedbackSessionStatus(ref.manifestPath, {
+      to: 'resume_requested',
+      reason: `Resume requested for ${context.resumeStage} after ${context.classification} feedback`,
+      issueNum: context.issue.number,
+      classification: context.classification,
+      prUrl: context.existingPrUrl,
+      eventPayload: {
+        resumeStage: context.resumeStage,
+      },
+    });
+    current = 'resume_requested';
+  }
+
+  if (current !== 'resume_requested') {
+    transitionSessionStatus(ref.manifestPath, 'resume_requested', 'resume_requested');
+  }
+  transitionHumanFeedbackSessionStatus(ref.manifestPath, {
+    to: 'resuming',
+    reason: `alpha-loop resume --issue ${context.issue.number} started`,
+    issueNum: context.issue.number,
+    classification: context.classification,
+    prUrl: context.existingPrUrl,
+    eventPayload: {
+      resumeStage: context.resumeStage,
+    },
+  });
+}
+
+function formatResumeSummaryComment(context: ResumeFeedbackContext, result: PipelineResult): string {
+  const status = result.status === 'success'
+    ? 'completed'
+    : result.status === 'waiting'
+      ? `waiting (${result.waitingStatus ?? 'feedback required'})`
+      : 'failed';
+  const lines = [
+    '## Alpha Loop Resume Summary',
+    '',
+    `Feedback classification: \`${context.classification}\``,
+    `Resume stage: \`${context.resumeStage}\``,
+    `Result: \`${status}\``,
+    '',
+    '### Feedback Addressed',
+  ];
+
+  const comments = context.newComments.length > 0 ? context.newComments : context.commentsUsedForClassification;
+  if (comments.length > 0) lines.push(...comments.map(formatCommentBullet));
+  else lines.push('- No new GitHub comments were available; resumed from saved session feedback state.');
+
+  lines.push('', '### Verification');
+  lines.push(`- Tests: ${result.testsPassing ? 'PASS' : 'FAIL'}`);
+  lines.push(`- Verification: ${result.verifySkipped ? 'SKIPPED' : result.verifyPassing ? 'PASS' : 'FAIL'}`);
+  if (result.prUrl) lines.push(`- PR: ${result.prUrl}`);
+  else if (context.existingPrUrl) lines.push(`- PR: ${context.existingPrUrl}`);
+
+  lines.push('', '### Remaining');
+  if (result.status === 'waiting') {
+    if (result.humanInputQuestion) lines.push(`- Waiting for clarification: ${result.humanInputQuestion}`);
+    else if (result.qaChecklist && result.qaChecklist.length > 0) lines.push(`- Waiting for QA: ${result.qaChecklist.join('; ')}`);
+    else lines.push(`- Waiting reason: ${result.waitingReason ?? 'human feedback required'}`);
+  } else if (result.status === 'failure') {
+    lines.push(`- Resume failed during the automated pipeline. Check session logs for issue #${result.issueNum}.`);
+  } else {
+    lines.push('- No remaining feedback items were recorded by the resumed run.');
+  }
+
+  lines.push('', '---', '*Resumed by alpha-loop from the saved session manifest.*');
+  return lines.join('\n');
+}
+
+function finalStatusForResult(result: PipelineResult): SessionStatus {
+  if (result.status === 'success') return 'completed';
+  if (result.status === 'waiting') {
+    if (result.waitingStatus === 'human_input_requested') return 'human_input_requested';
+    if (result.waitingStatus === 'qa_requested') return 'qa_requested';
+    return 'waiting-for-feedback';
+  }
+  return 'failed';
+}
+
+function finalStageForStatus(status: SessionStatus): SessionStage {
+  if (status === 'active') return 'status';
+  if (status === 'cleaned-up') return 'cleanup';
+  return status as SessionStage;
+}
+
+async function resumePausedIssueFromManifest(
+  issueNum: number,
+  config: ReturnType<typeof loadConfig>,
+): Promise<boolean> {
+  const ref = findLatestResumableSessionForIssue(issueNum, join(process.cwd(), '.alpha-loop', 'sessions'), {
+    statuses: FEEDBACK_RESUME_STATUSES,
+  });
+  if (!ref) return false;
+
+  if (isDuplicateResume(ref.manifest)) {
+    log.warn(`Issue #${issueNum} is already resuming in ${ref.manifest.name}; duplicate resume skipped.`);
+    return true;
+  }
+
+  const lockPath = acquireResumeLock(ref);
+  if (!lockPath) {
+    log.warn(`Issue #${issueNum} already has an active resume lock in ${ref.manifest.name}; duplicate resume skipped.`);
+    return true;
+  }
+
+  try {
+    const issue = getIssueWithComments(config.repo, issueNum) ?? fallbackIssueFromManifest(issueNum, ref.manifest);
+    const context = buildResumeFeedbackContext(ref, issue);
+    const session = rehydrateSessionContextFromManifest(ref);
+    const savedBranch = ref.recoveryBranch ?? ref.manifest.worktree?.branch ?? ref.manifest.lastKnownBranch;
+    const savedPath = ref.worktreePath ?? ref.manifest.worktree?.path ?? undefined;
+
+    log.step(`Resuming paused issue #${issueNum}: ${issue.title}`);
+    log.info(`Session: ${ref.manifest.name}`);
+    log.info(`Feedback classification: ${context.classification}; stage: ${context.resumeStage}`);
+
+    transitionManifestToResuming(ref, context);
+    if (!config.dryRun) {
+      markResumeLabels(config, issueNum);
+    }
+
+    const result = await processIssue(
+      issueNum,
+      issue.title,
+      issue.body,
+      config,
+      session,
+      {
+        resumeContext: context.contextText,
+        resumeStage: context.resumeStage,
+        existingPrUrl: context.existingPrUrl,
+        savedWorktree: {
+          branch: savedBranch,
+          path: savedPath,
+        },
+      },
+    );
+    session.results = session.results.filter((entry) => entry.issueNum !== result.issueNum);
+    session.results.push(result);
+
+    const finalStatus = finalStatusForResult(result);
+    if (finalStatus === 'completed' || finalStatus === 'failed') {
+      transitionHumanFeedbackSessionStatus(ref.manifestPath, {
+        to: finalStatus,
+        reason: `Resume finished with pipeline status ${result.status}`,
+        issueNum,
+        classification: context.classification,
+        prUrl: result.prUrl ?? context.existingPrUrl,
+        eventPayload: {
+          testsPassing: result.testsPassing,
+          verifyPassing: result.verifyPassing,
+          verifySkipped: result.verifySkipped,
+        },
+      });
+    } else {
+      transitionSessionStatus(ref.manifestPath, finalStatus, finalStageForStatus(finalStatus), {
+        prUrl: result.prUrl ?? context.existingPrUrl,
+      });
+    }
+
+    if (config.autoMerge) {
+      await finalizeSession(session, config);
+    }
+
+    if (!config.dryRun) {
+      commentIssue(config.repo, issueNum, formatResumeSummaryComment(context, result));
+    }
+
+    return true;
+  } catch (err) {
+    try {
+      transitionHumanFeedbackSessionStatus(ref.manifestPath, {
+        to: 'failed',
+        reason: `Resume failed: ${err instanceof Error ? err.message : String(err)}`,
+        issueNum,
+      });
+    } catch {
+      transitionSessionStatus(ref.manifestPath, 'failed', 'failed');
+    }
+    throw err;
+  } finally {
+    releaseResumeLock(lockPath);
+  }
+}
+
 /**
  * Main entry point for `alpha-loop resume`.
  */
@@ -644,6 +1070,11 @@ export async function resumeCommand(options: ResumeOptions): Promise<void> {
   if (options.issue && isNaN(filterIssue!)) {
     log.error(`Invalid issue number: ${options.issue}`);
     process.exit(1);
+  }
+
+  if (filterIssue !== undefined && !options.session) {
+    const handledPausedSession = await resumePausedIssueFromManifest(filterIssue, config);
+    if (handledPausedSession) return;
   }
 
   log.step('Scanning for stranded branches...');

--- a/src/lib/pipeline.ts
+++ b/src/lib/pipeline.ts
@@ -431,8 +431,17 @@ export function isRecoveredResult<T extends { recoveryMode?: PipelineRecoveryMod
   return result.recoveryMode !== undefined;
 }
 
+export type PipelineResumeStage = 'implementation' | 'verification' | 'clarification';
+
 export type PipelineOptions = {
   epicContext?: EpicPromptContext;
+  resumeContext?: string;
+  resumeStage?: PipelineResumeStage;
+  existingPrUrl?: string | null;
+  savedWorktree?: {
+    path?: string | null;
+    branch?: string | null;
+  };
 };
 
 const PAUSE_REQUEST_FILE = 'alpha-loop-pause-request.json';
@@ -648,6 +657,7 @@ async function pauseSessionForRequest(input: PauseSessionInput): Promise<Pipelin
     projectDir,
     autoCleanup: config.autoCleanup,
     preserveIfCommits: true,
+    worktreePath,
     sessionStatus: waitingStatus,
     dryRun: config.dryRun,
   });
@@ -1001,6 +1011,9 @@ export async function processIssue(
     statePath: defaultEscalationStatePath(projectDir),
   });
   const epicOption = epicPromptOption(pipelineOptions);
+  const resumeStage = pipelineOptions.resumeStage;
+  const resumeContext = pipelineOptions.resumeContext?.trim();
+  const resumeVerificationOnly = resumeStage === 'verification';
   let turnCounter = 0;
   const stageCtx = (stage: RoutingStageName): StageContext => ({
     stage,
@@ -1059,6 +1072,8 @@ export async function processIssue(
       autoMerge: config.autoMerge,
       skipInstall: config.skipInstall,
       setupCommand: config.setupCommand,
+      savedBranch: pipelineOptions.savedWorktree?.branch,
+      savedPath: pipelineOptions.savedWorktree?.path,
       dryRun: config.dryRun,
     });
     worktreePath = wt.path;
@@ -1135,11 +1150,29 @@ export async function processIssue(
   currentStep = 'plan';
   recordSessionStage(session, 'plan');
   log.step('Step 3: Planning');
-  let plan: IssuePlan = DEFAULT_PLAN;
+  let plan: IssuePlan = resumeVerificationOnly
+    ? {
+        ...DEFAULT_PLAN,
+        summary: 'Resume verification after human feedback',
+        implementation: 'No implementation requested by the resume classification; verify the saved branch and update the existing PR.',
+        testing: { needed: true, reason: 'Resumed QA approval still requires test confirmation.' },
+        verification: {
+          needed: true,
+          instructions: resumeContext
+            ? `Use the resume context and prior QA checklist while verifying the existing implementation.\n\n${resumeContext}`
+            : 'Verify the existing implementation after human QA approval.',
+          reason: 'Human feedback approved QA or requested verification without implementation changes.',
+        },
+        qa: { needed: false, checklist: [], reason: 'Resume path is consuming QA feedback, not requesting new QA yet.' },
+      }
+    : DEFAULT_PLAN;
   // Write plan inside the worktree (agents sandbox to their CWD), then move to sessions dir
   const planFileInWorktree = join(worktreePath, `plan-issue-${issueNum}.json`);
   const planFileInSession = join(session.logsDir, `plan-issue-${issueNum}.json`);
-  if (!config.dryRun) {
+  if (resumeVerificationOnly) {
+    log.info('Planning skipped: resume classified this feedback as verification-only');
+    stepsCompleted.push('plan-skipped');
+  } else if (!config.dryRun) {
     try {
       const planPrompt = buildIssuePlanPrompt({
         issueNum,
@@ -1170,7 +1203,7 @@ export async function processIssue(
       if (planResult.exitCode !== 0 && isTransientError(planResult.output)) {
         log.warn(`Agent hit a transient error during planning for #${issueNum} — re-queuing`);
         requeueIssue(config, issueNum);
-        const cleanup = await cleanupWorktree({ issueNum, projectDir, autoCleanup: config.autoCleanup });
+        const cleanup = await cleanupWorktree({ issueNum, projectDir, autoCleanup: config.autoCleanup, worktreePath });
         recordSessionCleanup(session, {
           status: cleanup.status,
           worktreePath: cleanup.path,
@@ -1215,21 +1248,28 @@ export async function processIssue(
   currentStep = 'implement';
   recordSessionStage(session, 'implement');
   log.step('Step 4: Implementing');
-  // Build resume context if worktree was recovered from a previous session
-  const resumeNote = worktreeResumed
-    ? `**IMPORTANT: This worktree contains work from a previous session that was interrupted.**
-Run \`git log --oneline -10\` to see what has already been done.
-Do NOT redo work that is already committed. Build on top of existing progress.\n\n`
-    : '';
+  const implementResumeContext = [
+    worktreeResumed
+      ? [
+          '**Recovered worktree:** this branch contains work from a previous session.',
+          'Run `git log --oneline -10` to see what has already been done.',
+          'Do not redo committed work; build on top of existing progress.',
+        ].join('\n')
+      : '',
+    resumeContext ?? '',
+  ].filter(Boolean).join('\n\n');
 
-  if (!config.dryRun) {
+  if (resumeVerificationOnly) {
+    log.info('Implementation skipped: human feedback was classified as approval/verification-only');
+    stepsCompleted.push('implement-skipped');
+  } else if (!config.dryRun) {
     // Load vision and project context
     const visionContext = loadFileIfExists(join(projectDir, '.alpha-loop', 'vision.md'));
     const projectContext = loadFileIfExists(join(projectDir, '.alpha-loop', 'context.md'));
     const previousResult = getPreviousResult(session);
     const learningContext = getLearningContext(join(projectDir, '.alpha-loop', 'learnings'));
 
-    const implementPrompt = resumeNote + buildImplementPrompt({
+    const implementPrompt = buildImplementPrompt({
       issueNum,
       title,
       body,
@@ -1240,6 +1280,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
       projectContext: projectContext ?? undefined,
       previousResult: previousResult ?? undefined,
       learningContext: learningContext || undefined,
+      resumeContext: implementResumeContext || undefined,
     });
 
     // Trace the implement prompt
@@ -1275,7 +1316,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
       if (isTransientError(implResult.output)) {
         log.warn(`Agent hit a transient error during implementation for #${issueNum} — re-queuing`);
         requeueIssue(config, issueNum);
-        const cleanup = await cleanupWorktree({ issueNum, projectDir, autoCleanup: config.autoCleanup, preserveIfCommits: true });
+        const cleanup = await cleanupWorktree({ issueNum, projectDir, autoCleanup: config.autoCleanup, preserveIfCommits: true, worktreePath });
         recordSessionCleanup(session, {
           status: cleanup.status,
           worktreePath: cleanup.path,
@@ -1289,7 +1330,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
       labelIssue(config.repo, issueNum, 'failed', 'in-progress');
       commentIssue(config.repo, issueNum, 'Agent loop failed during implementation. See logs for details.');
       writeRecoverableCrashMarker(new Error('Implementation failed after writing commits'), 'implement');
-      const cleanup = await cleanupWorktree({ issueNum, projectDir, autoCleanup: config.autoCleanup, preserveIfCommits: true });
+      const cleanup = await cleanupWorktree({ issueNum, projectDir, autoCleanup: config.autoCleanup, preserveIfCommits: true, worktreePath });
       recordSessionCleanup(session, {
         status: cleanup.status,
         worktreePath: cleanup.path,
@@ -1561,6 +1602,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
         verifyInstructions: plan.verification.instructions,
         verifyMethod: plan.verification.method,
         verifyCommand: plan.verification.command,
+        resumeContext: resumeContext || undefined,
         ...epicOption,
       });
       verifyOutput = verifyResult.output;
@@ -1724,7 +1766,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
   currentStep = 'pr';
   recordSessionStage(session, 'pr');
   log.step('Step 9: Creating PR');
-  let prUrl: string | undefined;
+  let prUrl: string | undefined = pipelineOptions.existingPrUrl ?? undefined;
 
   if (!config.dryRun) {
     const prBase = config.autoMerge ? session.branch : config.baseBranch;
@@ -1939,6 +1981,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
       projectDir,
       autoCleanup: config.autoCleanup,
       preserveIfCommits: true,
+      worktreePath,
       dryRun: config.dryRun,
     });
     recordSessionCleanup(session, {
@@ -1952,6 +1995,7 @@ Do NOT redo work that is already committed. Build on top of existing progress.\n
       issueNum,
       projectDir,
       autoCleanup: config.autoCleanup,
+      worktreePath,
       dryRun: config.dryRun,
     });
     recordSessionCleanup(session, {

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -16,6 +16,7 @@ export type ImplementPromptOptions = {
   projectContext?: string;
   previousResult?: string;
   learningContext?: string;
+  resumeContext?: string;
 };
 
 export type ReviewPromptOptions = {
@@ -208,7 +209,7 @@ export function buildIssuePlanPrompt(options: IssuePlanPromptOptions): string {
  * Build the implementation prompt for an AI agent.
  */
 export function buildImplementPrompt(options: ImplementPromptOptions): string {
-  const { issueNum, title, body, comments, planContent, epicContext, visionContext, projectContext, previousResult, learningContext } = options;
+  const { issueNum, title, body, comments, planContent, epicContext, visionContext, projectContext, previousResult, learningContext, resumeContext } = options;
 
   const sections: string[] = [
     `Implement GitHub issue #${issueNum}: ${title}`,
@@ -246,6 +247,10 @@ export function buildImplementPrompt(options: ImplementPromptOptions): string {
 
   if (learningContext) {
     sections.push('', '', learningContext);
+  }
+
+  if (resumeContext) {
+    sections.push('', '', '## Resume Context', resumeContext);
   }
 
   sections.push(

--- a/src/lib/session-state.ts
+++ b/src/lib/session-state.ts
@@ -368,7 +368,8 @@ export function classifyFeedback(text: string): FeedbackClassification {
   if (/\b(new scope|follow[- ]?up|separate issue|another issue|also add|also include|while you're there)\b/.test(lower)) {
     return 'new_scope';
   }
-  if (/\b(change|fix|update|remove|revise|adjust)\b/.test(lower)) return 'change_request';
+  if (/\b(change|fix|update|remove|revise|adjust|fail|failed|failing|broken)\b/.test(lower)) return 'change_request';
+  if (/\b(does not work|doesn't work|not working)\b/.test(lower)) return 'change_request';
   if (text.includes('?') || /\b(clarify|clarification|what i meant|answer)\b/.test(lower)) return 'clarification';
   return 'clarification';
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -197,6 +197,10 @@ export type ResumableSessionRef = {
   recoveryBranch: string | null;
 };
 
+export type FindResumableSessionOptions = {
+  statuses?: Iterable<SessionStatus>;
+};
+
 function isRecoveredSessionResult(
   result: PipelineResult,
 ): result is PipelineResult & { recoveryMode: NonNullable<PipelineResult['recoveryMode']> } {
@@ -573,9 +577,11 @@ function issueMatchesManifest(manifest: DurableSessionManifest, issueNum: number
 export function findLatestResumableSessionForIssue(
   issueNum: number,
   sessionsRoot = join(process.cwd(), '.alpha-loop', 'sessions'),
+  options: FindResumableSessionOptions = {},
 ): ResumableSessionRef | null {
   if (!existsSync(sessionsRoot)) return null;
   const refs: ResumableSessionRef[] = [];
+  const statuses = options.statuses ? new Set(options.statuses) : RESUMABLE_STATUSES;
 
   try {
     for (const group of readdirSync(sessionsRoot, { withFileTypes: true })) {
@@ -587,7 +593,8 @@ export function findLatestResumableSessionForIssue(
         const manifestPath = sessionManifestPath(sessionDir);
         const manifest = loadSessionManifest(manifestPath);
         if (!manifest) continue;
-        if (!RESUMABLE_STATUSES.has(manifest.status)) continue;
+        const feedbackStatus = manifest.feedback?.currentStatus;
+        if (!statuses.has(manifest.status) && (!feedbackStatus || !statuses.has(feedbackStatus))) continue;
         if (!issueMatchesManifest(manifest, issueNum)) continue;
         const worktreePath = manifest.worktree?.path ?? null;
         refs.push({
@@ -610,6 +617,43 @@ export function findLatestResumableSessionForIssue(
     return bTime.localeCompare(aTime);
   });
   return refs[0] ?? null;
+}
+
+function readSessionResults(sessionDir: string): PipelineResult[] {
+  try {
+    return readdirSync(sessionDir)
+      .filter((file) => file.startsWith('result-') && file.endsWith('.json'))
+      .sort()
+      .map((file) => {
+        try {
+          return JSON.parse(readFileSync(join(sessionDir, file), 'utf-8')) as PipelineResult;
+        } catch {
+          return null;
+        }
+      })
+      .filter((result): result is PipelineResult => result !== null);
+  } catch {
+    return [];
+  }
+}
+
+export function rehydrateSessionContextFromManifest(ref: ResumableSessionRef): SessionContext {
+  const { manifest, manifestPath, sessionDir } = ref;
+  return {
+    id: manifest.sessionId,
+    name: manifest.name,
+    branch: manifest.branch,
+    startedAt: manifest.timestamps.startedAt,
+    resultsDir: sessionDir,
+    logsDir: join(sessionDir, 'logs'),
+    manifestPath,
+    results: readSessionResults(sessionDir),
+    sessionPrUrl: manifest.sessionPrUrl ?? manifest.prUrl ?? undefined,
+    currentIssueNum: manifest.currentIssue?.issueNum ?? manifest.issueNumber ?? undefined,
+    parentEpicNum: manifest.parentEpicNumber ?? undefined,
+    epic: manifest.epic,
+    queue: manifest.queue,
+  };
 }
 
 function slugify(text: string): string {

--- a/src/lib/verify.ts
+++ b/src/lib/verify.ts
@@ -109,8 +109,10 @@ export async function runVerify(options: {
   verifyCommand?: string;
   /** Parent epic context for sub-issue verification. */
   epicContext?: EpicPromptContext;
+  /** Resume-specific human feedback and prior-session references. */
+  resumeContext?: string;
 }): Promise<VerifyResult> {
-  const { worktree, logFile, issueNum, title, body, config, sessionDir, verifyInstructions, verifyMethod, verifyCommand, epicContext } = options;
+  const { worktree, logFile, issueNum, title, body, config, sessionDir, verifyInstructions, verifyMethod, verifyCommand, epicContext, resumeContext } = options;
 
   if (config.skipVerify) {
     log.info('Verification skipped (skipVerify=true)');
@@ -206,6 +208,7 @@ export async function runVerify(options: {
 ${body}
 
 ${epicContext ? `${formatEpicPromptContext(epicContext)}\n\nUse the parent epic context to verify integration-sensitive behavior while keeping judgment focused on issue #${issueNum}.\n` : ''}
+${resumeContext ? `## Resume Context\n${resumeContext}\n` : ''}
 
 ## What Changed
 ${diffStat.stdout || 'No diff available'}

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -23,6 +23,8 @@ export type SetupWorktreeOptions = {
   autoMerge?: boolean;
   skipInstall?: boolean;
   setupCommand?: string;
+  savedBranch?: string | null;
+  savedPath?: string | null;
   dryRun?: boolean;
 };
 
@@ -31,6 +33,7 @@ export type CleanupWorktreeOptions = {
   projectDir: string;
   autoCleanup?: boolean;
   preserveIfCommits?: boolean;
+  worktreePath?: string;
   /** Preserve paused/waiting/QA worktrees unless retention explicitly expires them. */
   sessionStatus?: SessionStatus;
   /** Set by retention cleanup when it is intentionally expiring preserved work. */
@@ -57,10 +60,14 @@ const ENV_FILES = ['.env', '.env.local', '.env.development', '.env.development.l
  * 3. Neither exists → create fresh worktree and branch
  */
 export async function setupWorktree(options: SetupWorktreeOptions): Promise<WorktreeResult> {
-  const { issueNum, projectDir, baseBranch, sessionBranch, autoMerge, skipInstall, setupCommand, dryRun } = options;
-  const branch = `agent/issue-${issueNum}`;
+  const { issueNum, projectDir, baseBranch, sessionBranch, autoMerge, skipInstall, setupCommand, savedBranch, savedPath, dryRun } = options;
+  const defaultBranch = `agent/issue-${issueNum}`;
+  const branch = savedBranch?.trim() || defaultBranch;
   const worktreesDir = resolve(projectDir, '.worktrees');
-  const worktreePath = resolve(worktreesDir, `issue-${issueNum}`);
+  const worktreePath = savedPath?.trim()
+    ? resolve(projectDir, savedPath)
+    : resolve(worktreesDir, `issue-${issueNum}`);
+  const requiresSavedBranch = Boolean(savedBranch?.trim());
 
   log.info(`Creating worktree at ${worktreePath} (branch: ${branch})`);
 
@@ -102,16 +109,37 @@ export async function setupWorktree(options: SetupWorktreeOptions): Promise<Work
         log.info(`Resumed worktree with ${commitCount} commit(s)`);
         resumed = true;
       } else {
-        // Can't reuse — force-delete branch and fall through to fresh creation
         log.warn(`Could not reuse branch ${branch}: ${reuseResult.stderr}`);
+        if (requiresSavedBranch) {
+          throw new Error(`Failed to recreate saved worktree from ${branch}: ${reuseResult.stderr}`);
+        }
+        // Can't reuse a disposable issue branch — force-delete and fall through to fresh creation.
         exec(`git branch -D "${branch}"`, { cwd: projectDir });
         exec('git worktree prune', { cwd: projectDir });
+      }
+    } else if (requiresSavedBranch) {
+      exec('git fetch origin', { cwd: projectDir });
+      const remoteBranchCheck = exec(`git rev-parse --verify "origin/${branch}"`, { cwd: projectDir });
+      if (remoteBranchCheck.exitCode === 0) {
+        log.info(`Found remote branch origin/${branch}, recreating worktree from it (resuming previous work)`);
+        const remoteReuseResult = exec(`git worktree add "${worktreePath}" -b "${branch}" "origin/${branch}"`, { cwd: projectDir });
+        if (remoteReuseResult.exitCode === 0) {
+          const commitCount = worktreeHasCommits(worktreePath);
+          log.info(`Resumed worktree with ${commitCount} commit(s)`);
+          resumed = true;
+        } else {
+          throw new Error(`Failed to recreate saved worktree from origin/${branch}: ${remoteReuseResult.stderr}`);
+        }
       }
     }
   }
 
   // --- Case 3: Fresh creation (no existing worktree or branch) ---
   if (!resumed) {
+    if (requiresSavedBranch) {
+      throw new Error(`Saved resume branch ${branch} was not found; cannot recreate paused worktree without losing context`);
+    }
+
     // Delete remote branch from previous failed runs
     exec(`git push origin --delete "${branch}"`, { cwd: projectDir });
 
@@ -226,7 +254,9 @@ export async function cleanupWorktree(options: CleanupWorktreeOptions): Promise<
     retentionExpired = false,
     dryRun,
   } = options;
-  const worktreePath = resolve(projectDir, '.worktrees', `issue-${issueNum}`);
+  const worktreePath = options.worktreePath
+    ? resolve(projectDir, options.worktreePath)
+    : resolve(projectDir, '.worktrees', `issue-${issueNum}`);
 
   if (!autoCleanup) {
     log.info('Skipping worktree cleanup (autoCleanup=false)');

--- a/tests/commands/resume.test.ts
+++ b/tests/commands/resume.test.ts
@@ -20,10 +20,16 @@ jest.mock('../../src/lib/prompts', () => ({
   buildReviewPrompt: jest.fn(() => 'review prompt'),
 }));
 
+jest.mock('../../src/lib/pipeline', () => ({
+  isRecoveredResult: jest.fn((result: { recoveryMode?: string }) => result.recoveryMode !== undefined),
+  processIssue: jest.fn(),
+}));
+
 jest.mock('../../src/lib/github', () => ({
   labelIssue: jest.fn(),
   commentIssue: jest.fn(),
   createPR: jest.fn(),
+  getIssueWithComments: jest.fn(),
   updateProjectStatus: jest.fn(),
 }));
 
@@ -38,15 +44,17 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { findStrandedBranches, resumeCommand } from '../../src/commands/resume';
 import { loadConfig, resolveStepConfig, type Config } from '../../src/lib/config';
-import { createPR, labelIssue, commentIssue, updateProjectStatus } from '../../src/lib/github';
+import { createPR, labelIssue, commentIssue, getIssueWithComments, updateProjectStatus } from '../../src/lib/github';
 import { ghExec } from '../../src/lib/rate-limit';
 import { spawnAgent } from '../../src/lib/agent';
 import { exec } from '../../src/lib/shell';
+import { processIssue } from '../../src/lib/pipeline';
 import {
   generateSessionSummary,
   repairSessionLearningArtifacts,
   repairSessionSummaryArtifact,
 } from '../../src/lib/learning';
+import type { DurableSessionManifest } from '../../src/lib/session';
 
 const mockExec = exec as jest.MockedFunction<typeof exec>;
 const mockLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
@@ -55,8 +63,10 @@ const mockGhExec = ghExec as jest.MockedFunction<typeof ghExec>;
 const mockCreatePR = createPR as jest.MockedFunction<typeof createPR>;
 const mockLabelIssue = labelIssue as jest.MockedFunction<typeof labelIssue>;
 const mockCommentIssue = commentIssue as jest.MockedFunction<typeof commentIssue>;
+const mockGetIssueWithComments = getIssueWithComments as jest.MockedFunction<typeof getIssueWithComments>;
 const mockUpdateProjectStatus = updateProjectStatus as jest.MockedFunction<typeof updateProjectStatus>;
 const mockSpawnAgent = spawnAgent as jest.MockedFunction<typeof spawnAgent>;
+const mockProcessIssue = processIssue as jest.MockedFunction<typeof processIssue>;
 const mockGenerateSessionSummary = generateSessionSummary as jest.MockedFunction<typeof generateSessionSummary>;
 const mockRepairSessionLearningArtifacts = repairSessionLearningArtifacts as jest.MockedFunction<typeof repairSessionLearningArtifacts>;
 const mockRepairSessionSummaryArtifact = repairSessionSummaryArtifact as jest.MockedFunction<typeof repairSessionSummaryArtifact>;
@@ -71,6 +81,18 @@ beforeEach(() => {
   tempDir = undefined;
   mockResolveStepConfig.mockReturnValue({ agent: 'codex', model: 'gpt-5' });
   mockCreatePR.mockReturnValue('https://github.com/owner/repo/pull/269');
+  mockGetIssueWithComments.mockReturnValue(null);
+  mockProcessIssue.mockResolvedValue({
+    issueNum: 286,
+    title: 'Resume paused work',
+    status: 'success',
+    prUrl: 'https://github.com/owner/repo/pull/286',
+    testsPassing: true,
+    verifyPassing: true,
+    verifySkipped: false,
+    duration: 12,
+    filesChanged: 1,
+  });
   mockRepairSessionLearningArtifacts.mockReturnValue({ repaired: 0, created: 1, skipped: 0, failed: 0 });
 });
 
@@ -128,6 +150,100 @@ function baseConfig(overrides: Partial<Config> = {}): Config {
     evalIncludeAgentPrompts: true,
     evalIncludeSkills: true,
     preferEpics: false,
+    ...overrides,
+  };
+}
+
+function makeManifest(overrides: Partial<DurableSessionManifest> = {}): DurableSessionManifest {
+  const now = '2026-05-30T12:00:00.000Z';
+  return {
+    version: 1,
+    sessionId: 'session-20260530-120000',
+    name: 'session/20260530-120000',
+    issueNumber: 286,
+    issueNumbers: [286],
+    parentEpicNumber: 293,
+    parentEpicTitle: 'Hosted Alpha Loop',
+    branch: 'session/20260530-120000',
+    baseBranch: 'master',
+    prUrl: null,
+    sessionPrUrl: null,
+    status: 'human_input_requested',
+    stage: 'human_input_requested',
+    labels: ['needs-human-input'],
+    feedback: {
+      currentStatus: 'human_input_requested',
+      question: 'Which CTA copy should be used?',
+      resumeInstructions: 'Use the selected CTA copy and continue.',
+      qaChecklist: [],
+      prUrl: null,
+      previewUrl: null,
+      classification: null,
+      followUpIssueNumber: null,
+      followUpIssueUrl: null,
+      transitionHistory: [],
+      events: [],
+      updatedAt: now,
+    },
+    harness: {
+      agent: 'codex',
+      model: 'gpt-5',
+      reviewModel: 'gpt-5',
+      command: 'codex',
+      testCommand: 'pnpm test',
+    },
+    command: 'codex',
+    worktree: {
+      path: join(tmpdir(), 'alpha-loop-resume-worktree-286'),
+      branch: 'agent/issue-286',
+      resumed: false,
+      missing: false,
+      lastKnownBranch: 'agent/issue-286',
+      updatedAt: now,
+    },
+    lastKnownBranch: 'agent/issue-286',
+    currentIssue: { issueNum: 286, title: 'Resume paused work' },
+    issues: [{
+      issueNum: 286,
+      title: 'Resume paused work',
+      status: 'human_input_requested',
+      stage: 'human_input_requested',
+      branch: 'agent/issue-286',
+      worktreePath: join(tmpdir(), 'alpha-loop-resume-worktree-286'),
+      worktreeMissing: false,
+      updatedAt: now,
+    }],
+    prompts: [{
+      issueNum: 286,
+      stage: 'implement',
+      path: '.alpha-loop/traces/session-20260530-120000/prompts/issue-286-implement.md',
+      hash: '1234567890abcdef',
+      recordedAt: now,
+    }],
+    promptPath: '.alpha-loop/traces/session-20260530-120000/prompts/issue-286-implement.md',
+    promptHash: '1234567890abcdef',
+    transcripts: [{
+      issueNum: 286,
+      stage: 'implement',
+      path: '.alpha-loop/traces/session-20260530-120000/outputs/issue-286-implement.log',
+      recordedAt: now,
+    }],
+    transcriptPath: '.alpha-loop/traces/session-20260530-120000/outputs/issue-286-implement.log',
+    logs: {
+      sessionDir: '.alpha-loop/sessions/session/20260530-120000',
+      logsDir: '.alpha-loop/sessions/session/20260530-120000/logs',
+      traceDir: '.alpha-loop/traces/session-20260530-120000',
+      files: ['.alpha-loop/sessions/session/20260530-120000/logs/issue-286.log'],
+    },
+    screenshots: [],
+    previewUrl: null,
+    timestamps: {
+      createdAt: now,
+      startedAt: now,
+      updatedAt: now,
+    },
+    lastEventId: null,
+    errors: [],
     ...overrides,
   };
 }
@@ -195,6 +311,181 @@ describe('findStrandedBranches', () => {
 });
 
 describe('resumeCommand', () => {
+  test('resumes a paused clarification session with feedback and prior transcript context', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-resume-paused-'));
+    process.chdir(tempDir);
+
+    const sessionDir = join(tempDir, '.alpha-loop', 'sessions', 'session', '20260530-120000');
+    const worktreePath = join(tempDir, '.worktrees', 'issue-286');
+    mkdirSync(worktreePath, { recursive: true });
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, 'session.json'), JSON.stringify(makeManifest({
+      worktree: {
+        path: worktreePath,
+        branch: 'agent/issue-286',
+        resumed: false,
+        missing: false,
+        lastKnownBranch: 'agent/issue-286',
+        updatedAt: '2026-05-30T12:00:00.000Z',
+      },
+      issues: [{
+        issueNum: 286,
+        title: 'Resume paused work',
+        status: 'human_input_requested',
+        stage: 'human_input_requested',
+        branch: 'agent/issue-286',
+        worktreePath,
+        worktreeMissing: false,
+        updatedAt: '2026-05-30T12:00:00.000Z',
+      }],
+    }), null, 2));
+
+    mockLoadConfig.mockReturnValue(baseConfig());
+    mockGetIssueWithComments.mockReturnValue({
+      number: 286,
+      title: 'Resume paused work',
+      body: 'Issue body',
+      labels: ['needs-human-input'],
+      comments: [{
+        author: 'bradtaylorsf',
+        body: 'Use the shorter CTA copy.',
+        createdAt: '2026-05-30T12:05:00.000Z',
+      }],
+    });
+
+    await resumeCommand({ issue: '286' });
+
+    expect(mockProcessIssue).toHaveBeenCalledWith(
+      286,
+      'Resume paused work',
+      'Issue body',
+      expect.objectContaining({ repo: 'owner/repo' }),
+      expect.objectContaining({
+        name: 'session/20260530-120000',
+        resultsDir: expect.stringContaining('.alpha-loop/sessions/session/20260530-120000'),
+        logsDir: expect.stringContaining('.alpha-loop/sessions/session/20260530-120000/logs'),
+      }),
+      expect.objectContaining({
+        resumeStage: 'clarification',
+        existingPrUrl: null,
+        savedWorktree: {
+          branch: 'agent/issue-286',
+          path: expect.stringContaining('.worktrees/issue-286'),
+        },
+        resumeContext: expect.stringContaining('Use the shorter CTA copy.'),
+      }),
+    );
+    const options = mockProcessIssue.mock.calls[0][5] as any;
+    expect(options.resumeContext).toContain('issue-286-implement.md');
+    expect(options.resumeContext).toContain('issue-286-implement.log');
+    expect(mockLabelIssue).toHaveBeenCalledWith('owner/repo', 286, 'in-progress', 'ready');
+    expect(mockLabelIssue).toHaveBeenCalledWith('owner/repo', 286, 'in-progress', 'needs-human-input');
+    expect(mockCommentIssue).toHaveBeenCalledWith(
+      'owner/repo',
+      286,
+      expect.stringContaining('Feedback classification: `clarification`'),
+    );
+
+    const manifest = JSON.parse(readFileSync(join(sessionDir, 'session.json'), 'utf-8'));
+    expect(manifest.status).toBe('completed');
+    expect(manifest.feedback.transitionHistory.map((entry: any) => entry.to)).toEqual([
+      'feedback_received',
+      'resume_requested',
+      'resuming',
+      'completed',
+    ]);
+  });
+
+  test('resumes QA change requests at implementation stage and keeps the existing PR URL', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-resume-qa-'));
+    process.chdir(tempDir);
+
+    const sessionDir = join(tempDir, '.alpha-loop', 'sessions', 'session', '20260530-130000');
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, 'session.json'), JSON.stringify(makeManifest({
+      sessionId: 'session-20260530-130000',
+      name: 'session/20260530-130000',
+      status: 'qa_requested',
+      stage: 'qa_requested',
+      prUrl: 'https://github.com/owner/repo/pull/286',
+      feedback: {
+        ...makeManifest().feedback,
+        currentStatus: 'qa_requested',
+        question: null,
+        resumeInstructions: 'Complete QA, then reply with approval or requested changes.',
+        qaChecklist: ['Open preview', 'Confirm CTA copy'],
+        prUrl: 'https://github.com/owner/repo/pull/286',
+        updatedAt: '2026-05-30T12:00:00.000Z',
+      },
+      timestamps: {
+        createdAt: '2026-05-30T12:00:00.000Z',
+        startedAt: '2026-05-30T12:00:00.000Z',
+        updatedAt: '2026-05-30T12:00:00.000Z',
+      },
+    }), null, 2));
+
+    mockLoadConfig.mockReturnValue(baseConfig());
+    mockGetIssueWithComments.mockReturnValue({
+      number: 286,
+      title: 'Resume paused work',
+      body: 'Issue body',
+      labels: ['in-review', 'needs-human-input'],
+      comments: [{
+        author: 'bradtaylorsf',
+        body: 'QA failed: please change the button copy.',
+        createdAt: '2026-05-30T12:10:00.000Z',
+      }],
+    });
+
+    await resumeCommand({ issue: '286' });
+
+    expect(mockProcessIssue).toHaveBeenCalledWith(
+      286,
+      'Resume paused work',
+      'Issue body',
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({
+        resumeStage: 'implementation',
+        existingPrUrl: 'https://github.com/owner/repo/pull/286',
+        resumeContext: expect.stringContaining('QA failed: please change the button copy.'),
+      }),
+    );
+    const options = mockProcessIssue.mock.calls[0][5] as any;
+    expect(options.resumeContext).toContain('QA checklist');
+  });
+
+  test('skips duplicate resume when the latest manifest is already resuming', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-resume-duplicate-'));
+    process.chdir(tempDir);
+
+    const sessionDir = join(tempDir, '.alpha-loop', 'sessions', 'session', '20260530-140000');
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, 'session.json'), JSON.stringify(makeManifest({
+      sessionId: 'session-20260530-140000',
+      name: 'session/20260530-140000',
+      status: 'resuming',
+      stage: 'resuming',
+      feedback: {
+        ...makeManifest().feedback,
+        currentStatus: 'resuming',
+      },
+      timestamps: {
+        createdAt: '2026-05-30T12:00:00.000Z',
+        startedAt: '2026-05-30T12:00:00.000Z',
+        updatedAt: '2026-05-30T14:00:00.000Z',
+      },
+    }), null, 2));
+
+    mockLoadConfig.mockReturnValue(baseConfig());
+
+    await resumeCommand({ issue: '286' });
+
+    expect(mockProcessIssue).not.toHaveBeenCalled();
+    expect(mockGetIssueWithComments).not.toHaveBeenCalled();
+    expect(mockCreatePR).not.toHaveBeenCalled();
+  });
+
   test('prefers crash markers over branch walking and clears marker after saving recovered result', async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'alpha-loop-resume-marker-'));
     process.chdir(tempDir);

--- a/tests/lib/pipeline.test.ts
+++ b/tests/lib/pipeline.test.ts
@@ -620,6 +620,60 @@ describe('processIssue', () => {
     expect(mockExtractLearnings).toHaveBeenCalledWith(expect.objectContaining({ epicContext }));
   });
 
+  test('passes resume context and saved worktree hints into resumed implementation', async () => {
+    await processIssue(42, 'Test issue', 'Issue body', makeConfig(), makeSession(), {
+      resumeStage: 'implementation',
+      resumeContext: '## New feedback\nPlease change the button copy.',
+      existingPrUrl: 'https://github.com/owner/repo/pull/42',
+      savedWorktree: {
+        branch: 'agent/custom-42',
+        path: '/tmp/worktrees/custom-42',
+      },
+    });
+
+    expect(mockSetupWorktree).toHaveBeenCalledWith(expect.objectContaining({
+      savedBranch: 'agent/custom-42',
+      savedPath: '/tmp/worktrees/custom-42',
+    }));
+    expect(mockBuildImplementPrompt).toHaveBeenCalledWith(expect.objectContaining({
+      resumeContext: '## New feedback\nPlease change the button copy.',
+    }));
+    expect(mockCreatePR).toHaveBeenCalledWith(expect.objectContaining({
+      head: 'agent/issue-42',
+      body: expect.stringContaining('Test Results'),
+    }));
+  });
+
+  test('skips implementation and runs verification when resumed feedback is approval', async () => {
+    const { existsSync, readFileSync } = require('node:fs');
+    const mockExistsSync = existsSync as jest.MockedFunction<typeof import('node:fs').existsSync>;
+    const mockReadFileSync = readFileSync as jest.MockedFunction<typeof import('node:fs').readFileSync>;
+
+    mockExistsSync.mockImplementation((path: any) => String(path).includes('verify-issue-42.json'));
+    mockReadFileSync.mockImplementation((path: any) => {
+      if (String(path).includes('verify-issue-42.json')) {
+        return JSON.stringify({ passed: true, summary: 'QA approval verified', findings: [] });
+      }
+      return '';
+    });
+    mockRunVerify.mockResolvedValue({ passed: true, skipped: false, output: 'Status: PASS' });
+
+    const result = await processIssue(42, 'Test issue', 'Issue body', makeConfig({ skipVerify: false }), makeSession(), {
+      resumeStage: 'verification',
+      resumeContext: 'Human approved QA.',
+    });
+
+    expect(result.status).toBe('success');
+    expect(mockBuildImplementPrompt).not.toHaveBeenCalled();
+    expect(mockRunVerify).toHaveBeenCalledWith(expect.objectContaining({
+      resumeContext: 'Human approved QA.',
+    }));
+    const implementCalls = mockSpawnAgent.mock.calls.filter(
+      (call: any[]) => call[0].prompt === 'implement prompt',
+    );
+    expect(implementCalls).toHaveLength(0);
+  });
+
   test('does not pass epic context when pipeline options are omitted', async () => {
     await processIssue(42, 'Test issue', 'Issue body', makeConfig(), makeSession());
 

--- a/tests/lib/prompts.test.ts
+++ b/tests/lib/prompts.test.ts
@@ -133,6 +133,19 @@ describe('buildImplementPrompt', () => {
     expect(prompt).toContain('Keep the implementation narrowly scoped to issue #189');
     expect(prompt).toContain('Preserve contracts that sibling sub-issues depend on');
   });
+
+  test('includes resume context before scope rules', () => {
+    const prompt = buildImplementPrompt({
+      issueNum: 286,
+      title: 'Resume paused work',
+      body: 'Resume after human feedback',
+      resumeContext: 'Human asked for the CTA copy to change.\nPrior prompt: `.alpha-loop/traces/session/prompts/issue-286-implement.md`',
+    });
+
+    expect(prompt).toContain('## Resume Context');
+    expect(prompt).toContain('Human asked for the CTA copy to change.');
+    expect(prompt.indexOf('## Resume Context')).toBeLessThan(prompt.indexOf('## Scope Rules'));
+  });
 });
 
 describe('buildReviewPrompt', () => {

--- a/tests/lib/session-state.test.ts
+++ b/tests/lib/session-state.test.ts
@@ -114,6 +114,7 @@ describe('human feedback session state machine', () => {
   it('classifies common feedback intents', () => {
     expect(classifyFeedback('LGTM, approved')).toBe('approval');
     expect(classifyFeedback('Please change the button copy')).toBe('change_request');
+    expect(classifyFeedback('QA failed: the checkout flow is broken')).toBe('change_request');
     expect(classifyFeedback('Also add a settings page as a follow-up')).toBe('new_scope');
     expect(classifyFeedback('Do not proceed with this')).toBe('rejection');
     expect(classifyFeedback('Which branch is this using?')).toBe('clarification');

--- a/tests/lib/worktree.test.ts
+++ b/tests/lib/worktree.test.ts
@@ -204,6 +204,35 @@ describe('setupWorktree', () => {
     expect(addCall).toBeDefined();
   });
 
+  test('recreates a missing saved worktree from the saved branch', async () => {
+    mockExists.mockReturnValue(false);
+    mockExec.mockImplementation((cmd: string) => {
+      if (cmd.includes('rev-parse --verify "agent/custom-286"')) {
+        return { stdout: 'abc123', stderr: '', exitCode: 0 };
+      }
+      if (cmd.includes('merge-base')) {
+        return { stdout: '', stderr: '', exitCode: 1 };
+      }
+      return { stdout: '', stderr: '', exitCode: 0 };
+    });
+
+    const result = await setupWorktree({
+      ...baseOptions,
+      savedBranch: 'agent/custom-286',
+      savedPath: '/home/user/project/.worktrees/custom-286',
+    });
+
+    expect(result).toEqual({
+      path: '/home/user/project/.worktrees/custom-286',
+      branch: 'agent/custom-286',
+      resumed: true,
+    });
+    expect(mockExec).toHaveBeenCalledWith(
+      'git worktree add "/home/user/project/.worktrees/custom-286" "agent/custom-286"',
+      { cwd: '/home/user/project' },
+    );
+  });
+
   test('deletes remote branch on fresh creation', async () => {
     // No existing branch
     mockExec.mockImplementation((cmd: string) => {


### PR DESCRIPTION
Closes #286
Part of #293

## Summary

Batch implementation of 1 issues:
- **#286**: feat: resume paused issues after human feedback

## Test Results

| Check | Status |
|-------|--------|
| Unit tests | PASS |
| Code review | PASS |

## Code Review

Fixed a resume transition bug for status-only paused manifests; tests and build pass.

- **CRITICAL** [FIXED] `src/lib/session-state.ts`: Status-only paused manifests with feedback.currentStatus still set to running were discovered by resume lookup but rejected by the feedback transition helper before resume could proceed.

---
*Automated by [alpha-loop](https://github.com/bradtaylorsf/alpha-loop) · Batch mode · Full logs in `.alpha-loop/sessions/`*